### PR TITLE
feat(ops): one tool grammar — chat and MCP collapse onto a shared operation layer

### DIFF
--- a/src/ai/chat_ops.py
+++ b/src/ai/chat_ops.py
@@ -1,548 +1,128 @@
-"""Tool grammar for the streaming AI chat.
+"""Compatibility surface for the chat-op grammar (issue #1764).
 
-The chat lets a model emit one or more ``fiestaboard`` fenced JSON blocks
-inline with its prose. Each block is a structured *operation* that the
-editor applies to the page in flight.
-
-We deliberately do **not** use a provider's native tool/function-calling
-API: many OpenAI-compatible servers (Ollama, LM Studio, older OpenRouter
-routes) silently ignore the ``tools`` field, and the Anthropic adapter
-in :mod:`src.ai.protocols` doesn't yet plumb ``tool_use`` content blocks
-through streaming. A fenced JSON convention works identically across
-every provider we support.
-
-The server validates each block against the schemas below as the fence
-closes, and re-emits the validated payload as an ``event: tool_call``
-SSE frame to the frontend.
+The grammar itself — the pydantic arg models, the op-name registry, and
+``parse_tool_call`` — moved verbatim to :mod:`src.ops.grammar`, next to
+the operation registry (:mod:`src.ops.registry`) that maps every chat op
+onto its canonical executor. This module re-exports the whole surface so
+existing importers (``src.ai.chat``, the contract tests, and anything
+external) keep working unchanged; what the model emits and what the web
+client validates against is byte-identical.
 """
 
 from __future__ import annotations
 
-from typing import Any, Literal, Union
-
-from pydantic import BaseModel, ConfigDict, Field
-
-Alignment = Literal["left", "center", "right"]
-
-
-# ---------------------------------------------------------------------------
-# Line-metadata block, shared by replace_page and the line-level patch ops.
-# ---------------------------------------------------------------------------
-
-
-class LineMetadata(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    alignment: Alignment = "left"
-    wrap: bool = False
-
-
-# ---------------------------------------------------------------------------
-# replace_page — wholesale page replacement (same shape as the legacy
-# ``/pages/ai/generate`` response). Used when the user asks for a brand-new
-# page or a full rewrite.
-# ---------------------------------------------------------------------------
-
-
-class ReplacePageArgs(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    name: str = Field(..., min_length=1, max_length=100)
-    template: list[str] = Field(..., min_length=1)
-    line_metadata: list[LineMetadata] = Field(default_factory=list)
-    duration_seconds: int = Field(300, ge=10, le=3600)
-
-
-class ReplacePageOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    op: Literal["replace_page"]
-    args: ReplacePageArgs
-
-
-# ---------------------------------------------------------------------------
-# apply_patch — line-level edits to the current page.
-# ---------------------------------------------------------------------------
-
-
-class ReplaceLineOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    type: Literal["replace_line"]
-    index: int = Field(..., ge=0)
-    text: str
-    alignment: Alignment | None = None
-    wrap: bool | None = None
-
-
-class InsertLineOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    type: Literal["insert_line"]
-    index: int = Field(..., ge=0)
-    text: str
-    alignment: Alignment | None = None
-    wrap: bool | None = None
-
-
-class DeleteLineOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    type: Literal["delete_line"]
-    index: int = Field(..., ge=0)
-
-
-class UpdateLineMetadataOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    type: Literal["update_line_metadata"]
-    index: int = Field(..., ge=0)
-    alignment: Alignment | None = None
-    wrap: bool | None = None
-
-
-LineOp = ReplaceLineOp | InsertLineOp | DeleteLineOp | UpdateLineMetadataOp
-
-
-class ApplyPatchArgs(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    changes: list[LineOp] = Field(default_factory=list)
-    rename: str | None = Field(default=None, max_length=100)
-
-
-class ApplyPatchOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    op: Literal["apply_patch"]
-    args: ApplyPatchArgs
-
-
-# ---------------------------------------------------------------------------
-# suggest_variables — read-only, surfaces plugin variables to the user.
-# ---------------------------------------------------------------------------
-
-
-class VariableSuggestion(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    ref: str = Field(..., description="Variable reference like 'plugin.field'.")
-    description: str | None = None
-    example: str | None = None
-
-
-class SuggestVariablesArgs(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    suggestions: list[VariableSuggestion] = Field(default_factory=list)
-
-
-class SuggestVariablesOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    op: Literal["suggest_variables"]
-    args: SuggestVariablesArgs
-
-
-# ---------------------------------------------------------------------------
-# navigate_to_page — send the user to a page editor without editing content.
-# ---------------------------------------------------------------------------
-
-
-class NavigateToPageArgs(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    page_id: str = Field(..., description="Existing page ID, or 'new' to create.")
-    device_type: str | None = Field(default=None)
-
-
-class NavigateToPageOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    op: Literal["navigate_to_page"]
-    args: NavigateToPageArgs
-
-
-# ---------------------------------------------------------------------------
-# install_plugin — install a plugin from the official registry.
-# ---------------------------------------------------------------------------
-
-
-class InstallPluginArgs(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    plugin_id: str = Field(..., min_length=1, max_length=100)
-    source: Literal["registry"] = "registry"
-    auto_enable: bool = True
-    initial_config: dict[str, Any] | None = None
-
-
-class InstallPluginOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    op: Literal["install_plugin"]
-    args: InstallPluginArgs
-
-
-# ---------------------------------------------------------------------------
-# update_plugin_config — change settings for an already-installed plugin.
-# ---------------------------------------------------------------------------
-
-
-class UpdatePluginConfigArgs(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    plugin_id: str = Field(..., min_length=1, max_length=100)
-    config: dict[str, Any] = Field(default_factory=dict)
-
-
-class UpdatePluginConfigOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    op: Literal["update_plugin_config"]
-    args: UpdatePluginConfigArgs
-
-
-# ---------------------------------------------------------------------------
-# enable_plugin — enable an already-installed but currently-disabled plugin.
-# ---------------------------------------------------------------------------
-
-
-class EnablePluginArgs(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    plugin_id: str = Field(..., min_length=1, max_length=100)
-
-
-class EnablePluginOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    op: Literal["enable_plugin"]
-    args: EnablePluginArgs
-
-
-# ---------------------------------------------------------------------------
-# disable_plugin — disable an installed plugin without uninstalling it.
-# ---------------------------------------------------------------------------
-
-
-class DisablePluginArgs(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    plugin_id: str = Field(..., min_length=1, max_length=100)
-
-
-class DisablePluginOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    op: Literal["disable_plugin"]
-    args: DisablePluginArgs
-
-
-# ---------------------------------------------------------------------------
-# uninstall_plugin — permanently remove an installed plugin.
-# ---------------------------------------------------------------------------
-
-
-class UninstallPluginArgs(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    plugin_id: str = Field(..., min_length=1, max_length=100)
-
-
-class UninstallPluginOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    op: Literal["uninstall_plugin"]
-    args: UninstallPluginArgs
-
-
-# ---------------------------------------------------------------------------
-# update_setting — change a non-credential system setting.
-# Credential-bearing settings (AI providers, MQTT) are excluded.
-# ---------------------------------------------------------------------------
-
-SettingCategory = Literal[
-    "display",
-    "transitions",
-    "output",
-    "polling",
-    "location",
-    "silence_schedule",
-    "active_page",
-]
-
-
-class UpdateSettingArgs(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    category: SettingCategory
-    values: dict[str, Any] = Field(default_factory=dict)
-
-
-class UpdateSettingOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    op: Literal["update_setting"]
-    args: UpdateSettingArgs
-
-
-# ---------------------------------------------------------------------------
-# create_collection / update_collection — manage page collections.
-# ---------------------------------------------------------------------------
-
-
-class CreateCollectionArgs(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    name: str = Field(..., min_length=1, max_length=100)
-    page_ids: list[str] = Field(default_factory=list)
-    # Time-mode interval; ignored when selection_mode == "variable".
-    interval_seconds: int = Field(30, ge=5, le=86400)
-
-
-class CreateCollectionOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    op: Literal["create_collection"]
-    args: CreateCollectionArgs
-
-
-class UpdateCollectionArgs(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    collection_id: str = Field(..., description="ID of the collection to update.")
-    name: str | None = Field(default=None, min_length=1, max_length=100)
-    page_ids: list[str] | None = None
-    interval_seconds: int | None = Field(default=None, ge=5, le=86400)
-
-
-class UpdateCollectionOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    op: Literal["update_collection"]
-    args: UpdateCollectionArgs
-
-
-# ---------------------------------------------------------------------------
-# create_schedule / update_schedule / delete_schedule — manage the
-# display schedule (which page shows at what time).
-# ---------------------------------------------------------------------------
-
-DayPattern = Literal["all", "weekdays", "weekends", "custom"]
-_VALID_CUSTOM_DAYS = {"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"}
-
-
-class CreateScheduleArgs(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    page_id: str = Field(..., description="Page or collection ID to show.")
-    start_time: str = Field(..., description="24h HH:MM start time.")
-    end_time: str | None = Field(default=None, description="24h HH:MM end time, or null for open-ended.")
-    day_pattern: DayPattern = "all"
-    custom_days: list[str] | None = Field(default=None, description="Required when day_pattern='custom'.")
-    enabled: bool = True
-
-
-class CreateScheduleOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    op: Literal["create_schedule"]
-    args: CreateScheduleArgs
-
-
-class UpdateScheduleArgs(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    schedule_id: str = Field(..., description="ID of the schedule entry to update.")
-    page_id: str | None = None
-    start_time: str | None = None
-    end_time: str | None = None
-    day_pattern: DayPattern | None = None
-    custom_days: list[str] | None = None
-    enabled: bool | None = None
-
-
-class UpdateScheduleOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    op: Literal["update_schedule"]
-    args: UpdateScheduleArgs
-
-
-class DeleteScheduleArgs(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    schedule_id: str = Field(..., description="ID of the schedule entry to delete.")
-
-
-class DeleteScheduleOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    op: Literal["delete_schedule"]
-    args: DeleteScheduleArgs
-
-
-# ---------------------------------------------------------------------------
-# update_plugin — trigger a registry update for an installed plugin.
-# ---------------------------------------------------------------------------
-
-
-class UpdatePluginArgs(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    plugin_id: str = Field(..., min_length=1, max_length=100)
-
-
-class UpdatePluginOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    op: Literal["update_plugin"]
-    args: UpdatePluginArgs
-
-
-# ---------------------------------------------------------------------------
-# navigate_to_schedule — open the schedule editor, optionally pre-filling a
-# new entry form.
-# ---------------------------------------------------------------------------
-
-
-class NavigateToScheduleArgs(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    prefill: dict[str, Any] | None = Field(default=None)
-
-
-class NavigateToScheduleOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    op: Literal["navigate_to_schedule"]
-    args: NavigateToScheduleArgs
-
-
-# ---------------------------------------------------------------------------
-# trigger_system_update — trigger a FiestaBoard system update.
-# ---------------------------------------------------------------------------
-
-
-class TriggerSystemUpdateArgs(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-
-class TriggerSystemUpdateOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    op: Literal["trigger_system_update"]
-    args: TriggerSystemUpdateArgs
-
-
-# ---------------------------------------------------------------------------
-# update_task_list — frontend-only task tracker (no API call).
-# The model emits this to announce and update a running todo list so the
-# user can see progress across multi-step autonomous sessions.
-# ---------------------------------------------------------------------------
-
-TaskStatus = Literal["pending", "in_progress", "done", "failed"]
-
-
-class TaskItem(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    id: str = Field(..., min_length=1, max_length=50)
-    label: str = Field(..., min_length=1, max_length=200)
-    status: TaskStatus = "pending"
-
-
-class UpdateTaskListArgs(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    tasks: list[TaskItem] = Field(default_factory=list)
-
-
-class UpdateTaskListOp(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    op: Literal["update_task_list"]
-    args: UpdateTaskListArgs
-
-
-# ---------------------------------------------------------------------------
-# Discriminated union + helper.
-# ---------------------------------------------------------------------------
-
-
-ToolCall = Union[  # noqa: UP007 — pydantic discriminated-union requires typing.Union
-    ReplacePageOp,
+from src.ops.grammar import (
+    _OP_REGISTRY,
+    Alignment,
+    ApplyPatchArgs,
     ApplyPatchOp,
-    SuggestVariablesOp,
-    NavigateToPageOp,
-    NavigateToScheduleOp,
-    InstallPluginOp,
-    UpdatePluginConfigOp,
-    EnablePluginOp,
-    DisablePluginOp,
-    UninstallPluginOp,
-    UpdateSettingOp,
+    CreateCollectionArgs,
     CreateCollectionOp,
-    UpdateCollectionOp,
+    CreateScheduleArgs,
     CreateScheduleOp,
-    UpdateScheduleOp,
+    DayPattern,
+    DeleteLineOp,
+    DeleteScheduleArgs,
     DeleteScheduleOp,
-    UpdatePluginOp,
+    DisablePluginArgs,
+    DisablePluginOp,
+    EnablePluginArgs,
+    EnablePluginOp,
+    InsertLineOp,
+    InstallPluginArgs,
+    InstallPluginOp,
+    LineMetadata,
+    LineOp,
+    NavigateToPageArgs,
+    NavigateToPageOp,
+    NavigateToScheduleArgs,
+    NavigateToScheduleOp,
+    ReplaceLineOp,
+    ReplacePageArgs,
+    ReplacePageOp,
+    SettingCategory,
+    SuggestVariablesArgs,
+    SuggestVariablesOp,
+    TaskItem,
+    TaskStatus,
+    ToolCall,
+    ToolCallValidationError,
+    TriggerSystemUpdateArgs,
     TriggerSystemUpdateOp,
+    UninstallPluginArgs,
+    UninstallPluginOp,
+    UpdateCollectionArgs,
+    UpdateCollectionOp,
+    UpdateLineMetadataOp,
+    UpdatePluginArgs,
+    UpdatePluginConfigArgs,
+    UpdatePluginConfigOp,
+    UpdatePluginOp,
+    UpdateScheduleArgs,
+    UpdateScheduleOp,
+    UpdateSettingArgs,
+    UpdateSettingOp,
+    UpdateTaskListArgs,
     UpdateTaskListOp,
+    VariableSuggestion,
+    parse_tool_call,
+    supported_ops,
+)
+
+__all__ = [
+    "_OP_REGISTRY",
+    "Alignment",
+    "ApplyPatchArgs",
+    "ApplyPatchOp",
+    "CreateCollectionArgs",
+    "CreateCollectionOp",
+    "CreateScheduleArgs",
+    "CreateScheduleOp",
+    "DayPattern",
+    "DeleteLineOp",
+    "DeleteScheduleArgs",
+    "DeleteScheduleOp",
+    "DisablePluginArgs",
+    "DisablePluginOp",
+    "EnablePluginArgs",
+    "EnablePluginOp",
+    "InsertLineOp",
+    "InstallPluginArgs",
+    "InstallPluginOp",
+    "LineMetadata",
+    "LineOp",
+    "NavigateToPageArgs",
+    "NavigateToPageOp",
+    "NavigateToScheduleArgs",
+    "NavigateToScheduleOp",
+    "ReplaceLineOp",
+    "ReplacePageArgs",
+    "ReplacePageOp",
+    "SettingCategory",
+    "SuggestVariablesArgs",
+    "SuggestVariablesOp",
+    "TaskItem",
+    "TaskStatus",
+    "ToolCall",
+    "ToolCallValidationError",
+    "TriggerSystemUpdateArgs",
+    "TriggerSystemUpdateOp",
+    "UninstallPluginArgs",
+    "UninstallPluginOp",
+    "UpdateCollectionArgs",
+    "UpdateCollectionOp",
+    "UpdateLineMetadataOp",
+    "UpdatePluginArgs",
+    "UpdatePluginConfigArgs",
+    "UpdatePluginConfigOp",
+    "UpdatePluginOp",
+    "UpdateScheduleArgs",
+    "UpdateScheduleOp",
+    "UpdateSettingArgs",
+    "UpdateSettingOp",
+    "UpdateTaskListArgs",
+    "UpdateTaskListOp",
+    "VariableSuggestion",
+    "parse_tool_call",
+    "supported_ops",
 ]
-
-
-_OP_REGISTRY = {
-    "replace_page": ReplacePageOp,
-    "apply_patch": ApplyPatchOp,
-    "suggest_variables": SuggestVariablesOp,
-    "navigate_to_page": NavigateToPageOp,
-    "navigate_to_schedule": NavigateToScheduleOp,
-    "install_plugin": InstallPluginOp,
-    "update_plugin_config": UpdatePluginConfigOp,
-    "enable_plugin": EnablePluginOp,
-    "disable_plugin": DisablePluginOp,
-    "uninstall_plugin": UninstallPluginOp,
-    "update_setting": UpdateSettingOp,
-    "create_collection": CreateCollectionOp,
-    "update_collection": UpdateCollectionOp,
-    "create_schedule": CreateScheduleOp,
-    "update_schedule": UpdateScheduleOp,
-    "delete_schedule": DeleteScheduleOp,
-    "update_plugin": UpdatePluginOp,
-    "trigger_system_update": TriggerSystemUpdateOp,
-    "update_task_list": UpdateTaskListOp,
-}
-
-
-class ToolCallValidationError(ValueError):
-    """Raised when a fenced block fails schema validation."""
-
-
-def parse_tool_call(payload: object) -> ToolCall:
-    """Validate a parsed JSON object against the operation grammar.
-
-    The model is asked to emit ``{"op": "...", "args": {...}}``. We
-    dispatch on ``op`` and validate against the corresponding model so
-    Pydantic gives us per-field errors (better UX than a giant union
-    failure).
-    """
-    if not isinstance(payload, dict):
-        raise ToolCallValidationError("Tool call must be a JSON object.")
-    op = payload.get("op")
-    if not isinstance(op, str):
-        raise ToolCallValidationError("Tool call is missing the required 'op' string.")
-    model_cls = _OP_REGISTRY.get(op)
-    if model_cls is None:
-        raise ToolCallValidationError(f"Unknown tool op: {op!r}")
-    try:
-        return model_cls.model_validate(payload)
-    except Exception as exc:  # pydantic.ValidationError, etc.
-        raise ToolCallValidationError(str(exc)) from exc
-
-
-def supported_ops() -> list[str]:
-    """Stable list of supported op names — used in the system prompt."""
-    return list(_OP_REGISTRY.keys())

--- a/src/ai/prompt_builder.py
+++ b/src/ai/prompt_builder.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal
 
 from src.devices import DeviceType, get_dimensions
+from src.ops.teaching import dimensions_phrase
 from src.templates.expressions import function_signatures
 
 # Which caller is building the prompt. The shared core (device limits,
@@ -434,7 +435,7 @@ def build_prompt(
     )
 
     layout_rules = (
-        f"DEVICE: {device_type} ({cols} columns x {rows} rows).\n"
+        f"DEVICE: {device_type} ({dimensions_phrase(device_type)}).\n"
         f"- Output exactly {rows} entries in `template` (use empty\n"
         f"  strings to leave a row blank).\n"
         f"- Each line's rendered width must be <= {cols} columns. If a\n"

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -52,54 +52,18 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+# Mutating tools dispatch into the shared operation layer (#1764); the
+# result envelopes live there too, so executors and the read-only tools
+# that remain here return identical shapes. Every tool returns structured
+# data (dict/list) rather than a json.dumps()'d string — FastMCP
+# serializes the return value into tool output automatically, so clients
+# get real JSON instead of a JSON string that has to be parsed again.
+from .ops import executors as ops_executors
+from .ops import teaching as ops_teaching
+from .ops.results import err as _err
+from .ops.results import serialize as _serialize
+
 logger = logging.getLogger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# Response helpers — every tool returns structured data (dict/list) rather
-# than a json.dumps()'d string. FastMCP serializes the return value into
-# tool output automatically, so clients get real JSON instead of a JSON
-# string that has to be parsed again.
-# ---------------------------------------------------------------------------
-
-
-def _ok(message: str, **fields: Any) -> dict[str, Any]:
-    """Standard success envelope for mutation tools."""
-    return {"status": "success", "message": message, **fields}
-
-
-def _err(error: str) -> dict[str, Any]:
-    """Standard error envelope. Tools never raise — they return this instead."""
-    return {"status": "error", "error": error}
-
-
-def _serialize(obj: Any) -> Any:
-    """Convert Pydantic models / dataclasses / datetimes to JSON-compatible primitives.
-
-    Used when a tool returns Pydantic models (pages, schedules, carousels)
-    or dataclasses (settings objects). Plain dicts/lists pass through.
-    Falls back to ``__dict__`` for other ad-hoc objects (e.g. SimpleNamespace).
-    """
-    import dataclasses
-    from datetime import date, datetime, time
-
-    if obj is None or isinstance(obj, str | int | float | bool):
-        return obj
-    if hasattr(obj, "model_dump"):
-        return obj.model_dump(mode="json")
-    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
-        return {k: _serialize(v) for k, v in dataclasses.asdict(obj).items()}
-    if isinstance(obj, list):
-        return [_serialize(x) for x in obj]
-    if isinstance(obj, tuple):
-        return [_serialize(x) for x in obj]
-    if isinstance(obj, dict):
-        return {k: _serialize(v) for k, v in obj.items()}
-    if isinstance(obj, datetime | date | time):
-        return obj.isoformat()
-    if hasattr(obj, "__dict__"):
-        return {k: _serialize(v) for k, v in vars(obj).items() if not k.startswith("_")}
-    return str(obj)
 
 
 # ---------------------------------------------------------------------------
@@ -153,28 +117,14 @@ def _build_mcp_server() -> Any:
             "  • get_plugin_data(plugin_id) — see the LIVE values a plugin is\n"
             "    currently exposing. Use this when a page renders '???' or wrong\n"
             "    values; it tells you whether the plugin or the template is at fault.\n\n"
-            "DEVICE DIMENSIONS (template_lines length must match exactly)\n"
-            "  • flagship: 22 columns × 6 rows\n"
-            "  • note:     15 columns × 3 rows\n"
-            "  Content longer than the board width is TRUNCATED at render time —\n"
-            "  prefer concise variable names, the |wrap filter, or {{= LEFT(...)}}\n"
-            "  over letting the engine silently cut text off.\n\n"
-            "TEMPLATE SYNTAX\n"
-            "  • Variables:  {{plugin_id.variable_name}}  e.g. {{weather.temperature}}\n"
-            "  • Colors:     {{red}} {{orange}} {{yellow}} {{green}} {{blue}}\n"
-            "                {{violet}} {{purple}} {{white}} {{black}}\n"
-            "                Numeric equivalents 63–71 also work ({{63}} = red).\n"
-            "                Each color token renders as ONE solid tile (not a\n"
-            "                style for following text). Place the token where you\n"
-            "                want the dot/indicator to appear.\n"
-            "  • Filters:    {{var|upper}} {{var|lower}} {{var|pad:5}} {{var|wrap}}\n"
-            "                |wrap lets a long value flow into the empty lines\n"
-            "                immediately below it — leave blank lines beneath a\n"
-            "                wrapped line for overflow.\n"
-            "  • Formulas:   {{= EXPRESSION }} for Excel-like logic.\n"
-            "                Functions include: IF, AND, OR, NOT, UPPER, LOWER,\n"
-            "                LEFT, RIGHT, LEN, ROUND, FLOOR, CEIL, MIN, MAX, COLOR.\n"
-            '                Example: {{= IF(weather.temp_f > 80, "HOT", "OK")}}\n\n'
+            # Board-dimensions and template-syntax teaching is GENERATED from
+            # the defining modules (#1764) — the previous hardcoded copy had
+            # rotted (nonexistent |upper/|lower filters, a 63–71 color range,
+            # a frozen 15-function formula roster).
+            + ops_teaching.device_dimensions_block()
+            + "\n\n"
+            + ops_teaching.template_syntax_block()
+            + "\n\n"
             "SAFETY RULES (please follow strictly)\n"
             "  • NEVER guess API keys, tokens, or credentials. If a plugin needs\n"
             "    one, ask the user to provide it before calling configure_plugin().\n"
@@ -198,8 +148,9 @@ def _build_mcp_server() -> Any:
     # -----------------------------------------------------------------------
     # Plugin tools
     #
-    # The mutating ones delegate to ``PluginService`` (#1757) — the same
-    # orchestration the REST handlers use — rather than driving
+    # The mutating ones dispatch into the operation layer (#1764) —
+    # ``src.ops.executors`` — which delegates to ``PluginService`` (#1757),
+    # the same orchestration the REST handlers use, rather than driving
     # ``PluginRegistry`` directly. Enabling or configuring a plugin is two
     # writes, not one: the registry holds the live state, ConfigManager holds
     # ``config.json``. #1588 is what going straight to the registry costs —
@@ -208,31 +159,6 @@ def _build_mcp_server() -> Any:
     # to disk. Going through the service (not ``api_server``'s handlers) is
     # what keeps mcp_server importable without api_server.
     # -----------------------------------------------------------------------
-
-    def _plugin_service() -> Any:
-        """The shared plugin-orchestration service (never api_server).
-
-        Mirrors the REST layer's 503 guard: when the plugin subsystem cannot
-        import, tools report the clean "Plugin system is not available."
-        domain error instead of a raw ImportError (#1865 review).
-        """
-        try:
-            from .plugins.service import PluginService
-        except ImportError as exc:
-            raise RuntimeError("Plugin system is not available.") from exc
-
-        return PluginService()
-
-    def _rest_detail(exc: Any) -> str:
-        """Flatten an HTTPException detail into a single message.
-
-        The plugin-config endpoint raises ``detail={"errors": [...]}``; the
-        rest raise a plain string.
-        """
-        detail = getattr(exc, "detail", exc)
-        if isinstance(detail, dict) and detail.get("errors"):
-            return "; ".join(str(e) for e in detail["errors"])
-        return str(detail)
 
     @mcp.tool()
     def list_installed_plugins() -> list[dict[str, Any]] | dict[str, Any]:
@@ -290,22 +216,7 @@ def _build_mcp_server() -> Any:
         After installing, use configure_plugin() to set API keys and other settings.
         Use get_template_variables() to discover the variables the plugin exposes.
         """
-        from fastapi import HTTPException
-
-        try:
-            await _plugin_service().install_from_registry(plugin_id)
-        except HTTPException as exc:
-            return _err(f"Error installing plugin '{plugin_id}': {_rest_detail(exc)}")
-        except Exception as exc:
-            return _err(f"Error installing plugin '{plugin_id}': {exc}")
-
-        if auto_enable:
-            enabled = await enable_plugin(plugin_id)
-            if enabled.get("status") == "error":
-                return _err(f"Plugin '{plugin_id}' was installed but could not be enabled: {enabled['error']}")
-
-        state = "installed and enabled" if auto_enable else "installed (disabled)"
-        return _ok(f"Plugin '{plugin_id}' {state} successfully.", plugin_id=plugin_id, enabled=auto_enable)
+        return await ops_executors.install_plugin(plugin_id, auto_enable=auto_enable)
 
     @mcp.tool()
     async def enable_plugin(plugin_id: str) -> dict[str, Any]:
@@ -317,16 +228,7 @@ def _build_mcp_server() -> Any:
         Args:
             plugin_id: The plugin identifier (from list_installed_plugins()).
         """
-        from fastapi import HTTPException
-
-        try:
-            _plugin_service().enable_plugin(plugin_id)
-        except HTTPException as exc:
-            return _err(f"Error enabling plugin '{plugin_id}': {_rest_detail(exc)}")
-        except Exception as exc:
-            return _err(f"Error enabling plugin '{plugin_id}': {exc}")
-
-        return _ok(f"Plugin '{plugin_id}' enabled successfully.", plugin_id=plugin_id)
+        return ops_executors.enable_plugin(plugin_id)
 
     @mcp.tool()
     async def disable_plugin(plugin_id: str) -> dict[str, Any]:
@@ -337,16 +239,7 @@ def _build_mcp_server() -> Any:
         Args:
             plugin_id: The plugin identifier (from list_installed_plugins()).
         """
-        from fastapi import HTTPException
-
-        try:
-            _plugin_service().disable_plugin(plugin_id)
-        except HTTPException as exc:
-            return _err(f"Error disabling plugin '{plugin_id}': {_rest_detail(exc)}")
-        except Exception as exc:
-            return _err(f"Error disabling plugin '{plugin_id}': {exc}")
-
-        return _ok(f"Plugin '{plugin_id}' disabled successfully.", plugin_id=plugin_id)
+        return ops_executors.disable_plugin(plugin_id)
 
     @mcp.tool()
     async def uninstall_plugin(plugin_id: str) -> dict[str, Any]:
@@ -359,16 +252,7 @@ def _build_mcp_server() -> Any:
         Args:
             plugin_id: The plugin identifier (from list_installed_plugins()).
         """
-        from fastapi import HTTPException
-
-        try:
-            _plugin_service().uninstall(plugin_id)
-        except HTTPException as exc:
-            return _err(f"Error uninstalling plugin '{plugin_id}': {_rest_detail(exc)}")
-        except Exception as exc:
-            return _err(f"Error uninstalling plugin '{plugin_id}': {exc}")
-
-        return _ok(f"Plugin '{plugin_id}' uninstalled successfully.", plugin_id=plugin_id)
+        return ops_executors.uninstall_plugin(plugin_id)
 
     @mcp.tool()
     async def configure_plugin(plugin_id: str, config: dict[str, Any]) -> dict[str, Any]:
@@ -389,27 +273,7 @@ def _build_mcp_server() -> Any:
             config: Dictionary of configuration key-value pairs to update.
                     Only include keys you want to change.
         """
-        from fastapi import HTTPException
-
-        from .config_manager import get_config_manager
-
-        try:
-            # Raw stored config, WITHOUT the env-var overlay — this merge is
-            # persisted, and merging the overlay in would write env secrets
-            # into config.json (issue #1761).
-            existing = get_config_manager().get_plugin_config(plugin_id, include_env_overrides=False) or {}
-            merged = {**existing, **config}
-            masked = _plugin_service().update_plugin_config(plugin_id, merged)
-        except HTTPException as exc:
-            return _err(f"Error configuring plugin '{plugin_id}': {_rest_detail(exc)}")
-        except Exception as exc:
-            return _err(f"Error configuring plugin '{plugin_id}': {exc}")
-
-        return _ok(
-            f"Configuration updated for '{plugin_id}'.",
-            plugin_id=plugin_id,
-            config=_serialize(masked),
-        )
+        return ops_executors.configure_plugin(plugin_id, config)
 
     @mcp.tool()
     async def update_plugin(plugin_id: str) -> dict[str, Any]:
@@ -420,25 +284,9 @@ def _build_mcp_server() -> Any:
         Args:
             plugin_id: The plugin identifier (from list_installed_plugins()).
         """
-        from fastapi import HTTPException
-
-        # #1741: this used to call ``registry.reload_plugin()`` and nothing
-        # else — re-importing the code already on disk and reporting
-        # "updated successfully" without ever fetching anything, for any
-        # id at all. It also skipped every guard the update path applies
-        # (built-in rejection, realpath containment of the plugin's
-        # local_path inside the external plugins directory, and the .git
-        # check) before it lets a path near ``git``. Same lesson as #1588:
-        # go through PluginService.apply_update — the shared, guarded
-        # path — do not re-derive its checks here.
-        try:
-            await _plugin_service().apply_update(plugin_id)
-        except HTTPException as exc:
-            return _err(f"Error updating plugin '{plugin_id}': {_rest_detail(exc)}")
-        except Exception as exc:
-            return _err(f"Error updating plugin '{plugin_id}': {exc}")
-
-        return _ok(f"Plugin '{plugin_id}' updated successfully.", plugin_id=plugin_id)
+        # #1741 lives on in the executor: updates go through
+        # PluginService.apply_update — the shared, guarded path.
+        return await ops_executors.update_plugin(plugin_id)
 
     @mcp.tool()
     def get_template_variables() -> dict[str, Any]:
@@ -561,26 +409,12 @@ def _build_mcp_server() -> Any:
             ["{{white}}{{= UPPER(weather.city)}}", "{{yellow}}{{weather.temperature}}°F",
              "{{weather.condition}}", "", "{{date_time.time_12h}}", "{{date_time.date_short}}"]
         """
-        try:
-            from .pages.models import PageCreate
-            from .pages.service import get_page_service
-
-            svc = get_page_service()
-            data = PageCreate(
-                name=name,
-                type="template",
-                device_type=device_type,  # type: ignore[arg-type]
-                template=template_lines,
-                duration_seconds=duration_seconds,
-            )
-            page = svc.create_page(data)
-            return _ok(
-                f"Page '{name}' created with id '{page.id}'.",
-                page_id=page.id,
-                name=page.name,
-            )
-        except Exception as exc:
-            return _err(f"Error creating page: {exc}")
+        return ops_executors.create_page(
+            name=name,
+            template_lines=template_lines,
+            device_type=device_type,
+            duration_seconds=duration_seconds,
+        )
 
     @mcp.tool()
     def update_page(
@@ -597,34 +431,12 @@ def _build_mcp_server() -> Any:
             template_lines: New template content (optional). Replaces all lines.
             duration_seconds: New time-mode duration in seconds (optional).
         """
-        try:
-            from .pages.models import PageUpdate
-            from .pages.service import get_page_service
-
-            svc = get_page_service()
-            # Only pass fields the caller actually supplied. PageService.update_page
-            # merges with model_dump(exclude_unset=True), and "unset" means *not
-            # passed to the constructor* — an explicit None counts as set. Passing
-            # name/template/duration unconditionally therefore sent template=None on
-            # every partial update, wiping the template and failing validation with
-            # "Template page requires template content". Renaming a page or changing
-            # its duration over MCP was impossible.
-            fields: dict[str, Any] = {}
-            if name is not None:
-                fields["name"] = name
-            if template_lines is not None:
-                fields["template"] = template_lines
-            if duration_seconds is not None:
-                fields["duration_seconds"] = duration_seconds
-            if not fields:
-                return _err("Nothing to update: pass at least one of name, template_lines, duration_seconds.")
-
-            page = svc.update_page(page_id, PageUpdate(**fields))
-            if page is None:
-                return _err(f"Page '{page_id}' not found.")
-            return _ok(f"Page '{page_id}' updated.", page_id=page.id, name=page.name)
-        except Exception as exc:
-            return _err(f"Error updating page '{page_id}': {exc}")
+        return ops_executors.update_page(
+            page_id,
+            name=name,
+            template_lines=template_lines,
+            duration_seconds=duration_seconds,
+        )
 
     @mcp.tool()
     def delete_page(page_id: str) -> dict[str, Any]:
@@ -636,28 +448,7 @@ def _build_mcp_server() -> Any:
         Args:
             page_id: The page identifier (from list_pages()).
         """
-        try:
-            from .pages.service import get_page_service
-
-            svc = get_page_service()
-            result = svc.delete_page(page_id)
-            # DeleteResult exposes `deleted`, not `success`, and has no
-            # `message`. Reading `result.success` raised AttributeError, which
-            # this tool caught and returned as an error string — so delete_page
-            # never deleted anything over MCP. Same drift as #1559/#1561: the
-            # REST handler was updated (api_server.py uses result.deleted) and
-            # this call site was left behind.
-            if not result.deleted:
-                return _err(f"Page '{page_id}' was not deleted (it may not exist).")
-            return _ok(
-                f"Page '{page_id}' deleted successfully.",
-                page_id=page_id,
-                default_page_created=result.default_page_created,
-                new_page_id=result.new_page_id,
-                active_page_updated=result.active_page_updated,
-            )
-        except Exception as exc:
-            return _err(f"Error deleting page '{page_id}': {exc}")
+        return ops_executors.delete_page(page_id)
 
     @mcp.tool()
     def render_page_preview(
@@ -747,25 +538,13 @@ def _build_mcp_server() -> Any:
                       (runs until the next schedule or end of day). Default: None.
             enabled: Whether this schedule is active. Default: True.
         """
-        try:
-            from .schedules.models import ScheduleCreate
-            from .schedules.service import get_schedule_service
-
-            svc = get_schedule_service()
-            data = ScheduleCreate(
-                page_id=page_id,
-                start_time=start_time,
-                end_time=end_time,
-                day_pattern=day_pattern,  # type: ignore[arg-type]
-                enabled=enabled,
-            )
-            entry = svc.create_schedule(data)
-            return _ok(
-                f"Schedule created: page '{page_id}' from {start_time} on {day_pattern} days.",
-                schedule_id=entry.id,
-            )
-        except Exception as exc:
-            return _err(f"Error creating schedule: {exc}")
+        return ops_executors.create_schedule(
+            page_id=page_id,
+            start_time=start_time,
+            day_pattern=day_pattern,
+            end_time=end_time,
+            enabled=enabled,
+        )
 
     @mcp.tool()
     def update_schedule(
@@ -784,28 +563,18 @@ def _build_mcp_server() -> Any:
             schedule_id: The schedule identifier (from list_schedules()).
             page_id: New page to display (optional).
             start_time: New start time in HH:MM format (optional).
-            end_time: New end time in HH:MM format, or None to make open-ended (optional).
+            end_time: New end time in HH:MM format (optional; omitted = unchanged).
             day_pattern: New day pattern: 'all', 'weekdays', 'weekends', 'custom' (optional).
             enabled: Enable or disable this schedule entry (optional).
         """
-        try:
-            from .schedules.models import ScheduleUpdate
-            from .schedules.service import get_schedule_service
-
-            svc = get_schedule_service()
-            data = ScheduleUpdate(
-                page_id=page_id,
-                start_time=start_time,
-                end_time=end_time,
-                day_pattern=day_pattern,  # type: ignore[arg-type]
-                enabled=enabled,
-            )
-            entry = svc.update_schedule(schedule_id, data)
-            if entry is None:
-                return _err(f"Schedule '{schedule_id}' not found.")
-            return _ok(f"Schedule '{schedule_id}' updated.", schedule_id=entry.id)
-        except Exception as exc:
-            return _err(f"Error updating schedule '{schedule_id}': {exc}")
+        return ops_executors.update_schedule(
+            schedule_id,
+            page_id=page_id,
+            start_time=start_time,
+            end_time=end_time,
+            day_pattern=day_pattern,
+            enabled=enabled,
+        )
 
     @mcp.tool()
     def delete_schedule(schedule_id: str) -> dict[str, Any]:
@@ -814,19 +583,7 @@ def _build_mcp_server() -> Any:
         Args:
             schedule_id: The schedule identifier (from list_schedules()).
         """
-        try:
-            from .schedules.service import get_schedule_service
-
-            svc = get_schedule_service()
-            # #1742: delete_schedule() returns False when the id does not
-            # exist. Discarding it made every delete look successful, so a
-            # typo'd id read back as "deleted" — DELETE /schedules/{id} 404s
-            # in the same case. Same drift delete_page was fixed for.
-            if not svc.delete_schedule(schedule_id):
-                return _err(f"Schedule '{schedule_id}' not found.")
-            return _ok(f"Schedule '{schedule_id}' deleted successfully.", schedule_id=schedule_id)
-        except Exception as exc:
-            return _err(f"Error deleting schedule '{schedule_id}': {exc}")
+        return ops_executors.delete_schedule(schedule_id)
 
     # -----------------------------------------------------------------------
     # Collection tools
@@ -881,43 +638,15 @@ def _build_mcp_server() -> Any:
             poll_seconds: For variable mode — how often to re-evaluate rules
                 (default 10). Range: 2–600.
         """
-        try:
-            from .collections.models import (
-                CollectionCreate,
-                TimeModeConfig,
-                VariableModeConfig,
-                VariableRule,
-            )
-            from .collections.service import get_collection_service
-
-            svc = get_collection_service()
-
-            time_cfg = TimeModeConfig(interval_seconds=interval_seconds)
-            variable_cfg: VariableModeConfig | None = None
-            if selection_mode == "variable":
-                if not default_page_id:
-                    return _err("variable mode requires default_page_id")
-                variable_cfg = VariableModeConfig(
-                    rules=[VariableRule(**r) for r in (rules or [])],
-                    default_page_id=default_page_id,
-                    poll_seconds=poll_seconds,
-                )
-
-            data = CollectionCreate(
-                name=name,
-                page_ids=page_ids,
-                selection_mode=selection_mode,  # type: ignore[arg-type]
-                time=time_cfg,
-                variable=variable_cfg,
-            )
-            collection = svc.create_collection(data)
-            return _ok(
-                f"Collection '{name}' created with {len(page_ids)} pages in {selection_mode} mode.",
-                collection_id=collection.id,
-                name=collection.name,
-            )
-        except Exception as exc:
-            return _err(f"Error creating collection: {exc}")
+        return ops_executors.create_collection(
+            name=name,
+            page_ids=page_ids,
+            selection_mode=selection_mode,
+            interval_seconds=interval_seconds,
+            rules=rules,
+            default_page_id=default_page_id,
+            poll_seconds=poll_seconds,
+        )
 
     @mcp.tool()
     def update_collection(
@@ -946,43 +675,16 @@ def _build_mcp_server() -> Any:
             default_page_id: New fallback page (variable mode).
             poll_seconds: New re-evaluation cadence (variable mode).
         """
-        try:
-            from .collections.models import (
-                CollectionUpdate,
-                TimeModeConfig,
-                VariableModeConfig,
-                VariableRule,
-            )
-            from .collections.service import get_collection_service
-
-            svc = get_collection_service()
-
-            time_cfg: TimeModeConfig | None = (
-                TimeModeConfig(interval_seconds=interval_seconds) if interval_seconds is not None else None
-            )
-            variable_cfg: VariableModeConfig | None = None
-            if rules is not None or default_page_id is not None or poll_seconds is not None:
-                if not default_page_id:
-                    return _err("variable mode update requires default_page_id")
-                variable_cfg = VariableModeConfig(
-                    rules=[VariableRule(**r) for r in (rules or [])],
-                    default_page_id=default_page_id,
-                    poll_seconds=poll_seconds if poll_seconds is not None else 10,
-                )
-
-            data = CollectionUpdate(
-                name=name,
-                page_ids=page_ids,
-                selection_mode=selection_mode,  # type: ignore[arg-type]
-                time=time_cfg,
-                variable=variable_cfg,
-            )
-            collection = svc.update_collection(collection_id, data)
-            if collection is None:
-                return _err(f"Collection '{collection_id}' not found.")
-            return _ok(f"Collection '{collection_id}' updated.", collection_id=collection.id)
-        except Exception as exc:
-            return _err(f"Error updating collection '{collection_id}': {exc}")
+        return ops_executors.update_collection(
+            collection_id,
+            name=name,
+            page_ids=page_ids,
+            selection_mode=selection_mode,
+            interval_seconds=interval_seconds,
+            rules=rules,
+            default_page_id=default_page_id,
+            poll_seconds=poll_seconds,
+        )
 
     @mcp.tool()
     def delete_collection(collection_id: str) -> dict[str, Any]:
@@ -991,19 +693,7 @@ def _build_mcp_server() -> Any:
         Args:
             collection_id: The collection identifier (from list_collections()).
         """
-        try:
-            from .collections.service import get_collection_service
-
-            svc = get_collection_service()
-            # #1742: same as delete_schedule above — the boolean was dropped.
-            if not svc.delete_collection(collection_id):
-                return _err(f"Collection '{collection_id}' not found.")
-            return _ok(
-                f"Collection '{collection_id}' deleted successfully.",
-                collection_id=collection_id,
-            )
-        except Exception as exc:
-            return _err(f"Error deleting collection '{collection_id}': {exc}")
+        return ops_executors.delete_collection(collection_id)
 
     # -----------------------------------------------------------------------
     # System tools
@@ -1071,34 +761,11 @@ def _build_mcp_server() -> Any:
         Args:
             page_id: The page or collection ID to display (from list_pages() or list_collections()).
         """
-        # Delegate to the REST handler rather than reimplementing it. Selecting
-        # a page is more than a settings write: it validates the ref, enforces
-        # page<->board size compatibility, dismisses active plugin triggers so
-        # the choice sticks (#856), and renders to the board. Issue #1559 was
-        # this tool going its own way and calling a method that never existed.
-        from fastapi import HTTPException
-
-        from .api_server import set_active_page as _rest_set_active_page
-
-        try:
-            response = await _rest_set_active_page({"page_id": page_id})
-        except HTTPException as exc:
-            return _err(f"Error setting active page: {exc.detail}")
-        except Exception as exc:
-            return _err(f"Error setting active page: {exc}")
-
-        message = f"Active page set to '{page_id}'."
-        if response.get("paused"):
-            message += " The board is paused, so it will appear when you resume it."
-        elif not response.get("sent_to_board"):
-            message += " It will appear on the board on the next display refresh."
-        return _ok(
-            message,
-            page_id=page_id,
-            sent_to_board=bool(response.get("sent_to_board")),
-            paused=bool(response.get("paused")),
-            warnings=response.get("warnings", []),
-        )
+        # The executor delegates to the REST handler rather than
+        # reimplementing it (#1559): selecting a page validates the ref,
+        # enforces page<->board size compatibility, dismisses active plugin
+        # triggers (#856), and renders to the board.
+        return await ops_executors.set_active_page(page_id)
 
     @mcp.tool()
     def set_schedule_mode(enabled: bool) -> dict[str, Any]:
@@ -1110,17 +777,7 @@ def _build_mcp_server() -> Any:
         Args:
             enabled: True to enable schedule-based display, False to disable.
         """
-        try:
-            # Schedule mode is a settings flag (per-board since #1244), not
-            # something ScheduleService owns — same mixup as issue #1559.
-            from .settings.service import get_settings_service
-
-            svc = get_settings_service()
-            svc.set_schedule_enabled(enabled)
-            state = "enabled" if enabled else "disabled"
-            return _ok(f"Schedule mode {state}.", enabled=enabled)
-        except Exception as exc:
-            return _err(f"Error setting schedule mode: {exc}")
+        return ops_executors.set_schedule_mode(enabled)
 
     # -----------------------------------------------------------------------
     # MCP Resources
@@ -1283,8 +940,8 @@ def _build_mcp_server() -> Any:
             "3. Call get_template_variables() to find the right variable references\n"
             "4. Create a well-designed page with create_page() using those variables\n"
             "5. Offer to schedule the page if appropriate\n\n"
-            "Flagship display is 22×6 characters. Use colour tokens like {{yellow}}, "
-            "{{white}}, {{green}} to make it visually clear."
+            f"{ops_teaching.dimensions_summary_sentence()} Use colour tokens like "
+            "{{yellow}}, {{white}}, {{green}} to make it visually clear."
         )
 
     @mcp.prompt()

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -554,6 +554,8 @@ def _build_mcp_server() -> Any:
         end_time: str | None = None,
         day_pattern: str | None = None,
         enabled: bool | None = None,
+        clear_end_time: bool = False,
+        clear_custom_days: bool = False,
     ) -> dict[str, Any]:
         """Update an existing schedule entry.
 
@@ -566,6 +568,11 @@ def _build_mcp_server() -> Any:
             end_time: New end time in HH:MM format (optional; omitted = unchanged).
             day_pattern: New day pattern: 'all', 'weekdays', 'weekends', 'custom' (optional).
             enabled: Enable or disable this schedule entry (optional).
+            clear_end_time: Set True to remove the end time, making the entry
+                open-ended. Needed because omitting end_time means
+                "unchanged" — an explicit null cannot express the clear.
+            clear_custom_days: Set True to drop a stored custom day list
+                (e.g. when changing day_pattern away from 'custom').
         """
         return ops_executors.update_schedule(
             schedule_id,
@@ -574,6 +581,8 @@ def _build_mcp_server() -> Any:
             end_time=end_time,
             day_pattern=day_pattern,
             enabled=enabled,
+            clear_end_time=clear_end_time,
+            clear_custom_days=clear_custom_days,
         )
 
     @mcp.tool()

--- a/src/ops/__init__.py
+++ b/src/ops/__init__.py
@@ -1,0 +1,37 @@
+"""FiestaBoard's shared operation layer (issue #1764).
+
+One grammar of named operations, executed the same way whichever AI
+surface asked: the streaming chat's ``fiestaboard`` fenced blocks
+(:mod:`src.ai.chat_ops`) and the MCP tools (:mod:`src.mcp_server`) both
+resolve into the executors registered here. Teaching text about the
+board (dimensions, template syntax) is generated once in
+:mod:`src.ops.teaching` from real device/engine metadata.
+"""
+
+from . import executors, teaching
+from .registry import (
+    OPERATIONS,
+    ClientSideOperationError,
+    Operation,
+    execute,
+    execute_sync,
+    get_operation,
+    operation_names,
+)
+from .results import err, ok, rest_detail, serialize
+
+__all__ = [
+    "OPERATIONS",
+    "ClientSideOperationError",
+    "Operation",
+    "err",
+    "execute",
+    "execute_sync",
+    "executors",
+    "get_operation",
+    "ok",
+    "operation_names",
+    "rest_detail",
+    "serialize",
+    "teaching",
+]

--- a/src/ops/executors.py
+++ b/src/ops/executors.py
@@ -1,0 +1,619 @@
+"""Canonical executors for FiestaBoard operations.
+
+One implementation per operation (issue #1764). Each executor carries the
+behavior that used to live inline in an MCP tool body in
+:mod:`src.mcp_server`; the MCP tools and the chat grammar
+(:mod:`src.ai.chat_ops`, resolved through :mod:`src.ops.registry`) both
+dispatch here, so the two surfaces cannot drift again.
+
+Conventions, inherited from the MCP tools so re-expressing them here is
+behavior-preserving:
+
+- Executors never raise: failures come back as ``results.err(...)``
+  envelopes, successes as ``results.ok(...)``.
+- Services are imported lazily inside each executor so tests can patch the
+  canonical module locations (``src.pages.service.get_page_service`` etc.)
+  and so importing this module never drags in ``api_server``.
+- Plugin mutations go through :class:`src.plugins.service.PluginService`
+  (#1757/#1588): the registry holds live state, ConfigManager holds
+  ``config.json``, and only the service writes both.
+
+Unified semantics decided at #1764 (see the parity suite,
+``tests/test_op_parity.py``):
+
+- ``configure_plugin`` MERGES the given keys into the stored config (the
+  MCP behavior, pinned by tests/test_mcp_state_effects.py). The chat op
+  ``update_plugin_config`` resolves here and gains merge semantics at the
+  op layer; ``PUT /plugins/{id}/config`` keeps its replace semantics — it
+  is the settings-form endpoint, not an operation surface.
+- ``update_schedule`` applies ONLY the fields the caller supplied. The MCP
+  tool used to pass every parameter (explicit ``None``s count as *set*
+  under ``model_dump(exclude_unset=True)``) and silently wiped
+  ``end_time`` on any partial update — the same defect ``update_page``
+  was already fixed for.
+- ``update_collection`` does not force ``selection_mode`` back to
+  ``"time"`` when only the interval changes (the web drawer still does,
+  client-side — a #1766 concern).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .results import err, ok, rest_detail, serialize
+
+logger = logging.getLogger(__name__)
+
+
+def _plugin_service() -> Any:
+    """The shared plugin-orchestration service (never api_server)."""
+    from src.plugins.service import PluginService
+
+    return PluginService()
+
+
+# ---------------------------------------------------------------------------
+# Plugin operations
+# ---------------------------------------------------------------------------
+
+
+async def install_plugin(
+    plugin_id: str,
+    auto_enable: bool = True,
+    initial_config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Install a plugin from the official registry, optionally enable + configure it.
+
+    ``initial_config`` exists only on the chat grammar; when given it is
+    applied through :func:`configure_plugin` after a successful enable.
+    """
+    from fastapi import HTTPException
+
+    try:
+        await _plugin_service().install_from_registry(plugin_id)
+    except HTTPException as exc:
+        return err(f"Error installing plugin '{plugin_id}': {rest_detail(exc)}")
+    except Exception as exc:
+        return err(f"Error installing plugin '{plugin_id}': {exc}")
+
+    if auto_enable:
+        enabled = enable_plugin(plugin_id)
+        if enabled.get("status") == "error":
+            return err(f"Plugin '{plugin_id}' was installed but could not be enabled: {enabled['error']}")
+
+    if initial_config:
+        configured = configure_plugin(plugin_id, initial_config)
+        if configured.get("status") == "error":
+            return err(f"Plugin '{plugin_id}' was installed but could not be configured: {configured['error']}")
+
+    state = "installed and enabled" if auto_enable else "installed (disabled)"
+    return ok(f"Plugin '{plugin_id}' {state} successfully.", plugin_id=plugin_id, enabled=auto_enable)
+
+
+def enable_plugin(plugin_id: str) -> dict[str, Any]:
+    """Enable an installed but currently-disabled plugin."""
+    from fastapi import HTTPException
+
+    try:
+        _plugin_service().enable_plugin(plugin_id)
+    except HTTPException as exc:
+        return err(f"Error enabling plugin '{plugin_id}': {rest_detail(exc)}")
+    except Exception as exc:
+        return err(f"Error enabling plugin '{plugin_id}': {exc}")
+
+    return ok(f"Plugin '{plugin_id}' enabled successfully.", plugin_id=plugin_id)
+
+
+def disable_plugin(plugin_id: str) -> dict[str, Any]:
+    """Disable an installed plugin without uninstalling it."""
+    from fastapi import HTTPException
+
+    try:
+        _plugin_service().disable_plugin(plugin_id)
+    except HTTPException as exc:
+        return err(f"Error disabling plugin '{plugin_id}': {rest_detail(exc)}")
+    except Exception as exc:
+        return err(f"Error disabling plugin '{plugin_id}': {exc}")
+
+    return ok(f"Plugin '{plugin_id}' disabled successfully.", plugin_id=plugin_id)
+
+
+def uninstall_plugin(plugin_id: str) -> dict[str, Any]:
+    """Permanently remove an installed plugin. Irreversible."""
+    from fastapi import HTTPException
+
+    try:
+        _plugin_service().uninstall(plugin_id)
+    except HTTPException as exc:
+        return err(f"Error uninstalling plugin '{plugin_id}': {rest_detail(exc)}")
+    except Exception as exc:
+        return err(f"Error uninstalling plugin '{plugin_id}': {exc}")
+
+    return ok(f"Plugin '{plugin_id}' uninstalled successfully.", plugin_id=plugin_id)
+
+
+def configure_plugin(plugin_id: str, config: dict[str, Any]) -> dict[str, Any]:
+    """Merge the given keys into the plugin's stored config and persist.
+
+    Merge — not replace — so a partial update never drops previously-set
+    fields (and never trips required-field validation on the keys it did
+    not send). Pinned by tests/test_mcp_state_effects.py.
+    """
+    from fastapi import HTTPException
+
+    from src.config_manager import get_config_manager
+
+    try:
+        existing = get_config_manager().get_plugin_config(plugin_id) or {}
+        merged = {**existing, **config}
+        masked = _plugin_service().update_plugin_config(plugin_id, merged)
+    except HTTPException as exc:
+        return err(f"Error configuring plugin '{plugin_id}': {rest_detail(exc)}")
+    except Exception as exc:
+        return err(f"Error configuring plugin '{plugin_id}': {exc}")
+
+    return ok(
+        f"Configuration updated for '{plugin_id}'.",
+        plugin_id=plugin_id,
+        config=serialize(masked),
+    )
+
+
+async def update_plugin(plugin_id: str) -> dict[str, Any]:
+    """Update an installed plugin from its git remote.
+
+    #1741: goes through ``PluginService.apply_update`` — the shared,
+    guarded path — never re-deriving its checks here.
+    """
+    from fastapi import HTTPException
+
+    try:
+        await _plugin_service().apply_update(plugin_id)
+    except HTTPException as exc:
+        return err(f"Error updating plugin '{plugin_id}': {rest_detail(exc)}")
+    except Exception as exc:
+        return err(f"Error updating plugin '{plugin_id}': {exc}")
+
+    return ok(f"Plugin '{plugin_id}' updated successfully.", plugin_id=plugin_id)
+
+
+# ---------------------------------------------------------------------------
+# Page operations
+# ---------------------------------------------------------------------------
+
+
+def create_page(
+    name: str,
+    template_lines: list[str],
+    device_type: str = "flagship",
+    duration_seconds: int = 300,
+    line_metadata: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Create a new template page.
+
+    ``line_metadata`` exists only on the chat grammar (``replace_page``);
+    the MCP tool never sends it.
+    """
+    try:
+        from src.pages.models import PageCreate
+        from src.pages.service import get_page_service
+
+        svc = get_page_service()
+        fields: dict[str, Any] = {
+            "name": name,
+            "type": "template",
+            "device_type": device_type,
+            "template": template_lines,
+            "duration_seconds": duration_seconds,
+        }
+        if line_metadata:
+            fields["line_metadata"] = line_metadata
+        page = svc.create_page(PageCreate(**fields))
+        return ok(
+            f"Page '{name}' created with id '{page.id}'.",
+            page_id=page.id,
+            name=page.name,
+        )
+    except Exception as exc:
+        return err(f"Error creating page: {exc}")
+
+
+def update_page(
+    page_id: str,
+    name: str | None = None,
+    template_lines: list[str] | None = None,
+    duration_seconds: int | None = None,
+) -> dict[str, Any]:
+    """Update an existing page's name, template content, or duration.
+
+    Only fields the caller actually supplied are passed through —
+    ``PageService.update_page`` merges with ``model_dump(exclude_unset=True)``,
+    where an explicit ``None`` counts as set and would wipe the template.
+    """
+    try:
+        from src.pages.models import PageUpdate
+        from src.pages.service import get_page_service
+
+        svc = get_page_service()
+        fields: dict[str, Any] = {}
+        if name is not None:
+            fields["name"] = name
+        if template_lines is not None:
+            fields["template"] = template_lines
+        if duration_seconds is not None:
+            fields["duration_seconds"] = duration_seconds
+        if not fields:
+            return err("Nothing to update: pass at least one of name, template_lines, duration_seconds.")
+
+        page = svc.update_page(page_id, PageUpdate(**fields))
+        if page is None:
+            return err(f"Page '{page_id}' not found.")
+        return ok(f"Page '{page_id}' updated.", page_id=page.id, name=page.name)
+    except Exception as exc:
+        return err(f"Error updating page '{page_id}': {exc}")
+
+
+def delete_page(page_id: str) -> dict[str, Any]:
+    """Delete a page permanently."""
+    try:
+        from src.pages.service import get_page_service
+
+        svc = get_page_service()
+        result = svc.delete_page(page_id)
+        if not result.deleted:
+            return err(f"Page '{page_id}' was not deleted (it may not exist).")
+        return ok(
+            f"Page '{page_id}' deleted successfully.",
+            page_id=page_id,
+            default_page_created=result.default_page_created,
+            new_page_id=result.new_page_id,
+            active_page_updated=result.active_page_updated,
+        )
+    except Exception as exc:
+        return err(f"Error deleting page '{page_id}': {exc}")
+
+
+async def set_active_page(page_id: str) -> dict[str, Any]:
+    """Set which page is currently shown on the display.
+
+    Delegates to the REST handler rather than reimplementing it: selecting
+    a page validates the ref, enforces page<->board size compatibility,
+    dismisses active plugin triggers (#856), and renders to the board.
+    Issue #1559 was a reimplementation going its own way.
+    """
+    from fastapi import HTTPException
+
+    from src.api_server import set_active_page as _rest_set_active_page
+
+    try:
+        response = await _rest_set_active_page({"page_id": page_id})
+    except HTTPException as exc:
+        return err(f"Error setting active page: {exc.detail}")
+    except Exception as exc:
+        return err(f"Error setting active page: {exc}")
+
+    message = f"Active page set to '{page_id}'."
+    if response.get("paused"):
+        message += " The board is paused, so it will appear when you resume it."
+    elif not response.get("sent_to_board"):
+        message += " It will appear on the board on the next display refresh."
+    return ok(
+        message,
+        page_id=page_id,
+        sent_to_board=bool(response.get("sent_to_board")),
+        paused=bool(response.get("paused")),
+        warnings=response.get("warnings", []),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schedule operations
+# ---------------------------------------------------------------------------
+
+
+def create_schedule(
+    page_id: str,
+    start_time: str,
+    day_pattern: str = "all",
+    end_time: str | None = None,
+    enabled: bool = True,
+    custom_days: list[str] | None = None,
+) -> dict[str, Any]:
+    """Create a schedule entry showing a page (or collection) at a time slot.
+
+    ``custom_days`` exists only on the chat grammar (required there when
+    ``day_pattern == "custom"``); the MCP tool never sends it.
+    """
+    try:
+        from src.schedules.models import ScheduleCreate
+        from src.schedules.service import get_schedule_service
+
+        svc = get_schedule_service()
+        fields: dict[str, Any] = {
+            "page_id": page_id,
+            "start_time": start_time,
+            "end_time": end_time,
+            "day_pattern": day_pattern,
+            "enabled": enabled,
+        }
+        if custom_days is not None:
+            fields["custom_days"] = custom_days
+        entry = svc.create_schedule(ScheduleCreate(**fields))
+        return ok(
+            f"Schedule created: page '{page_id}' from {start_time} on {day_pattern} days.",
+            schedule_id=entry.id,
+        )
+    except Exception as exc:
+        return err(f"Error creating schedule: {exc}")
+
+
+def update_schedule(
+    schedule_id: str,
+    page_id: str | None = None,
+    start_time: str | None = None,
+    end_time: str | None = None,
+    day_pattern: str | None = None,
+    enabled: bool | None = None,
+    custom_days: list[str] | None = None,
+) -> dict[str, Any]:
+    """Update an existing schedule entry. Only supplied fields change.
+
+    ``ScheduleService.update_schedule`` merges with
+    ``model_dump(exclude_unset=True)`` — an explicit ``None`` counts as
+    set. Passing every parameter unconditionally therefore wiped
+    ``end_time`` (making the entry open-ended) on every partial update;
+    the #1764 parity suite caught it, and it is the same defect
+    ``update_page`` was fixed for.
+    """
+    try:
+        from src.schedules.models import ScheduleUpdate
+        from src.schedules.service import get_schedule_service
+
+        svc = get_schedule_service()
+        fields: dict[str, Any] = {}
+        if page_id is not None:
+            fields["page_id"] = page_id
+        if start_time is not None:
+            fields["start_time"] = start_time
+        if end_time is not None:
+            fields["end_time"] = end_time
+        if day_pattern is not None:
+            fields["day_pattern"] = day_pattern
+        if enabled is not None:
+            fields["enabled"] = enabled
+        if custom_days is not None:
+            fields["custom_days"] = custom_days
+        if not fields:
+            return err(
+                "Nothing to update: pass at least one of page_id, start_time, "
+                "end_time, day_pattern, custom_days, enabled."
+            )
+
+        entry = svc.update_schedule(schedule_id, ScheduleUpdate(**fields))
+        if entry is None:
+            return err(f"Schedule '{schedule_id}' not found.")
+        return ok(f"Schedule '{schedule_id}' updated.", schedule_id=entry.id)
+    except Exception as exc:
+        return err(f"Error updating schedule '{schedule_id}': {exc}")
+
+
+def delete_schedule(schedule_id: str) -> dict[str, Any]:
+    """Delete a schedule entry permanently."""
+    try:
+        from src.schedules.service import get_schedule_service
+
+        svc = get_schedule_service()
+        # #1742: delete_schedule() returns False when the id does not exist.
+        if not svc.delete_schedule(schedule_id):
+            return err(f"Schedule '{schedule_id}' not found.")
+        return ok(f"Schedule '{schedule_id}' deleted successfully.", schedule_id=schedule_id)
+    except Exception as exc:
+        return err(f"Error deleting schedule '{schedule_id}': {exc}")
+
+
+def set_schedule_mode(enabled: bool) -> dict[str, Any]:
+    """Enable or disable schedule-based display.
+
+    Schedule mode is a settings flag (per-board since #1244), not
+    something ScheduleService owns — same mixup as issue #1559.
+    """
+    try:
+        from src.settings.service import get_settings_service
+
+        svc = get_settings_service()
+        svc.set_schedule_enabled(enabled)
+        state = "enabled" if enabled else "disabled"
+        return ok(f"Schedule mode {state}.", enabled=enabled)
+    except Exception as exc:
+        return err(f"Error setting schedule mode: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Collection operations
+# ---------------------------------------------------------------------------
+
+
+def create_collection(
+    name: str,
+    page_ids: list[str],
+    selection_mode: str = "time",
+    interval_seconds: int = 30,
+    rules: list[dict[str, str]] | None = None,
+    default_page_id: str | None = None,
+    poll_seconds: int = 10,
+) -> dict[str, Any]:
+    """Create a collection that decides which page to show."""
+    try:
+        from src.collections.models import (
+            CollectionCreate,
+            TimeModeConfig,
+            VariableModeConfig,
+            VariableRule,
+        )
+        from src.collections.service import get_collection_service
+
+        svc = get_collection_service()
+
+        time_cfg = TimeModeConfig(interval_seconds=interval_seconds)
+        variable_cfg: Any = None
+        if selection_mode == "variable":
+            if not default_page_id:
+                return err("variable mode requires default_page_id")
+            variable_cfg = VariableModeConfig(
+                rules=[VariableRule(**r) for r in (rules or [])],
+                default_page_id=default_page_id,
+                poll_seconds=poll_seconds,
+            )
+
+        data = CollectionCreate(
+            name=name,
+            page_ids=page_ids,
+            selection_mode=selection_mode,  # type: ignore[arg-type]
+            time=time_cfg,
+            variable=variable_cfg,
+        )
+        collection = svc.create_collection(data)
+        return ok(
+            f"Collection '{name}' created with {len(page_ids)} pages in {selection_mode} mode.",
+            collection_id=collection.id,
+            name=collection.name,
+        )
+    except Exception as exc:
+        return err(f"Error creating collection: {exc}")
+
+
+def update_collection(
+    collection_id: str,
+    name: str | None = None,
+    page_ids: list[str] | None = None,
+    selection_mode: str | None = None,
+    interval_seconds: int | None = None,
+    rules: list[dict[str, str]] | None = None,
+    default_page_id: str | None = None,
+    poll_seconds: int | None = None,
+) -> dict[str, Any]:
+    """Update a collection's name, page list, or selection config.
+
+    An interval-only update changes the time-mode config without forcing
+    ``selection_mode`` back to ``"time"`` — flipping a variable-mode
+    collection requires sending ``selection_mode`` explicitly.
+    """
+    try:
+        from src.collections.models import (
+            CollectionUpdate,
+            TimeModeConfig,
+            VariableModeConfig,
+            VariableRule,
+        )
+        from src.collections.service import get_collection_service
+
+        svc = get_collection_service()
+
+        time_cfg: Any = TimeModeConfig(interval_seconds=interval_seconds) if interval_seconds is not None else None
+        variable_cfg: Any = None
+        if rules is not None or default_page_id is not None or poll_seconds is not None:
+            if not default_page_id:
+                return err("variable mode update requires default_page_id")
+            variable_cfg = VariableModeConfig(
+                rules=[VariableRule(**r) for r in (rules or [])],
+                default_page_id=default_page_id,
+                poll_seconds=poll_seconds if poll_seconds is not None else 10,
+            )
+
+        data = CollectionUpdate(
+            name=name,
+            page_ids=page_ids,
+            selection_mode=selection_mode,  # type: ignore[arg-type]
+            time=time_cfg,
+            variable=variable_cfg,
+        )
+        collection = svc.update_collection(collection_id, data)
+        if collection is None:
+            return err(f"Collection '{collection_id}' not found.")
+        return ok(f"Collection '{collection_id}' updated.", collection_id=collection.id)
+    except Exception as exc:
+        return err(f"Error updating collection '{collection_id}': {exc}")
+
+
+def delete_collection(collection_id: str) -> dict[str, Any]:
+    """Delete a collection permanently."""
+    try:
+        from src.collections.service import get_collection_service
+
+        svc = get_collection_service()
+        # #1742: same as delete_schedule above — the boolean was dropped.
+        if not svc.delete_collection(collection_id):
+            return err(f"Collection '{collection_id}' not found.")
+        return ok(
+            f"Collection '{collection_id}' deleted successfully.",
+            collection_id=collection_id,
+        )
+    except Exception as exc:
+        return err(f"Error deleting collection '{collection_id}': {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Settings / system operations (chat-grammar surface)
+# ---------------------------------------------------------------------------
+
+
+async def update_setting(category: str, values: dict[str, Any]) -> dict[str, Any]:
+    """Change a non-credential system setting.
+
+    Chat-grammar op. Each category delegates to the REST handler that owns
+    it (the same endpoints the web drawer calls), so validation and
+    normalization live exactly once. ``active_page`` resolves to the
+    canonical :func:`set_active_page` executor shared with MCP.
+    """
+    from fastapi import HTTPException
+
+    try:
+        if category == "active_page":
+            page_id = values.get("page_id")
+            if not isinstance(page_id, str) or not page_id:
+                return err("active_page requires values.page_id")
+            return await set_active_page(page_id)
+
+        import src.api_server as api
+
+        if category == "display":
+            await api.update_display_settings(dict(values))
+        elif category == "transitions":
+            await api.update_transition_settings(dict(values))
+        elif category == "output":
+            await api.update_output_settings(dict(values))
+        elif category == "polling":
+            await api.update_polling_settings(dict(values))
+        elif category == "location":
+            await api.update_location_settings(dict(values))
+        elif category == "silence_schedule":
+            await api.update_silence_schedule(api.SilenceScheduleRequest(**values))
+        else:
+            return err(f"Unknown setting category: {category!r}")
+    except HTTPException as exc:
+        return err(f"Error updating {category} settings: {rest_detail(exc)}")
+    except Exception as exc:
+        return err(f"Error updating {category} settings: {exc}")
+
+    return ok(f"{category} settings updated.", category=category)
+
+
+async def trigger_system_update() -> dict[str, Any]:
+    """Trigger an in-place system update via the updater sidecar.
+
+    Chat-grammar op. Delegates to the system router's apply handler
+    (#1758) — the process may be recreated shortly after it succeeds.
+    """
+    from fastapi import HTTPException
+
+    try:
+        from src.system.routes import system_update_apply
+
+        response = await system_update_apply()
+    except HTTPException as exc:
+        return err(f"Error triggering system update: {rest_detail(exc)}")
+    except Exception as exc:
+        return err(f"Error triggering system update: {exc}")
+
+    return ok("System update started. The board will restart shortly.", detail=serialize(response))

--- a/src/ops/executors.py
+++ b/src/ops/executors.py
@@ -384,11 +384,9 @@ def update_schedule(
             fields["enabled"] = enabled
         if custom_days is not None:
             fields["custom_days"] = custom_days
-        if not fields:
-            return err(
-                "Nothing to update: pass at least one of page_id, start_time, "
-                "end_time, day_pattern, custom_days, enabled."
-            )
+        # No empty-fields guard: an empty ScheduleUpdate is a no-op merge, and
+        # the pre-#1764 tool always called the service — the "not found" reply
+        # for an unknown id (pinned by tests/test_mcp_server.py) depends on it.
 
         entry = svc.update_schedule(schedule_id, ScheduleUpdate(**fields))
         if entry is None:

--- a/src/ops/executors.py
+++ b/src/ops/executors.py
@@ -47,8 +47,16 @@ logger = logging.getLogger(__name__)
 
 
 def _plugin_service() -> Any:
-    """The shared plugin-orchestration service (never api_server)."""
-    from src.plugins.service import PluginService
+    """The shared plugin-orchestration service (never api_server).
+
+    Mirrors the REST layer's 503 guard: when the plugin subsystem cannot
+    import, tools report the clean "Plugin system is not available."
+    domain error instead of a raw ImportError (#1865 review).
+    """
+    try:
+        from src.plugins.service import PluginService
+    except ImportError as exc:
+        raise RuntimeError("Plugin system is not available.") from exc
 
     return PluginService()
 
@@ -145,7 +153,10 @@ def configure_plugin(plugin_id: str, config: dict[str, Any]) -> dict[str, Any]:
     from src.config_manager import get_config_manager
 
     try:
-        existing = get_config_manager().get_plugin_config(plugin_id) or {}
+        # Raw STORED config, WITHOUT the env-var overlay — this merge is
+        # persisted, and merging the overlay in would write env secrets
+        # into config.json (issue #1761 / #1864 review).
+        existing = get_config_manager().get_plugin_config(plugin_id, include_env_overrides=False) or {}
         merged = {**existing, **config}
         masked = _plugin_service().update_plugin_config(plugin_id, merged)
     except HTTPException as exc:
@@ -356,6 +367,8 @@ def update_schedule(
     day_pattern: str | None = None,
     enabled: bool | None = None,
     custom_days: list[str] | None = None,
+    clear_end_time: bool = False,
+    clear_custom_days: bool = False,
 ) -> dict[str, Any]:
     """Update an existing schedule entry. Only supplied fields change.
 
@@ -365,6 +378,14 @@ def update_schedule(
     ``end_time`` (making the entry open-ended) on every partial update;
     the #1764 parity suite caught it, and it is the same defect
     ``update_page`` was fixed for.
+
+    The wipe-protection makes ``end_time=None`` mean "unchanged", which
+    leaves no way to make a bounded entry open-ended again — the explicit
+    ``clear_end_time=True`` flag is that escape hatch (#1873/#1874 review).
+    ``clear_custom_days=True`` is the symmetric flag for dropping a stale
+    custom day list when switching ``day_pattern`` away from ``custom``.
+    REST is unaffected: its PATCH body distinguishes absent from null
+    natively.
     """
     try:
         from src.schedules.models import ScheduleUpdate
@@ -378,12 +399,16 @@ def update_schedule(
             fields["start_time"] = start_time
         if end_time is not None:
             fields["end_time"] = end_time
+        if clear_end_time:
+            fields["end_time"] = None
         if day_pattern is not None:
             fields["day_pattern"] = day_pattern
         if enabled is not None:
             fields["enabled"] = enabled
         if custom_days is not None:
             fields["custom_days"] = custom_days
+        if clear_custom_days:
+            fields["custom_days"] = None
         # No empty-fields guard: an empty ScheduleUpdate is a no-op merge, and
         # the pre-#1764 tool always called the service — the "not found" reply
         # for an unknown id (pinned by tests/test_mcp_server.py) depends on it.

--- a/src/ops/grammar.py
+++ b/src/ops/grammar.py
@@ -1,0 +1,553 @@
+"""Tool grammar for the streaming AI chat (the chat-op spellings).
+
+Moved verbatim from ``src/ai/chat_ops.py`` (issue #1764): the grammar now
+lives in the shared operation layer next to the registry that executes it,
+and ``src.ai.chat_ops`` re-exports every public and pinned symbol so the
+validation surface — names, schemas, error type — is unchanged.
+
+The chat lets a model emit one or more ``fiestaboard`` fenced JSON blocks
+inline with its prose. Each block is a structured *operation* that the
+editor applies to the page in flight.
+
+We deliberately do **not** use a provider's native tool/function-calling
+API: many OpenAI-compatible servers (Ollama, LM Studio, older OpenRouter
+routes) silently ignore the ``tools`` field, and the Anthropic adapter
+in :mod:`src.ai.protocols` doesn't yet plumb ``tool_use`` content blocks
+through streaming. A fenced JSON convention works identically across
+every provider we support.
+
+The server validates each block against the schemas below as the fence
+closes, and re-emits the validated payload as an ``event: tool_call``
+SSE frame to the frontend.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+
+Alignment = Literal["left", "center", "right"]
+
+
+# ---------------------------------------------------------------------------
+# Line-metadata block, shared by replace_page and the line-level patch ops.
+# ---------------------------------------------------------------------------
+
+
+class LineMetadata(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    alignment: Alignment = "left"
+    wrap: bool = False
+
+
+# ---------------------------------------------------------------------------
+# replace_page — wholesale page replacement (same shape as the legacy
+# ``/pages/ai/generate`` response). Used when the user asks for a brand-new
+# page or a full rewrite.
+# ---------------------------------------------------------------------------
+
+
+class ReplacePageArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    name: str = Field(..., min_length=1, max_length=100)
+    template: list[str] = Field(..., min_length=1)
+    line_metadata: list[LineMetadata] = Field(default_factory=list)
+    duration_seconds: int = Field(300, ge=10, le=3600)
+
+
+class ReplacePageOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    op: Literal["replace_page"]
+    args: ReplacePageArgs
+
+
+# ---------------------------------------------------------------------------
+# apply_patch — line-level edits to the current page.
+# ---------------------------------------------------------------------------
+
+
+class ReplaceLineOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    type: Literal["replace_line"]
+    index: int = Field(..., ge=0)
+    text: str
+    alignment: Alignment | None = None
+    wrap: bool | None = None
+
+
+class InsertLineOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    type: Literal["insert_line"]
+    index: int = Field(..., ge=0)
+    text: str
+    alignment: Alignment | None = None
+    wrap: bool | None = None
+
+
+class DeleteLineOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    type: Literal["delete_line"]
+    index: int = Field(..., ge=0)
+
+
+class UpdateLineMetadataOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    type: Literal["update_line_metadata"]
+    index: int = Field(..., ge=0)
+    alignment: Alignment | None = None
+    wrap: bool | None = None
+
+
+LineOp = ReplaceLineOp | InsertLineOp | DeleteLineOp | UpdateLineMetadataOp
+
+
+class ApplyPatchArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    changes: list[LineOp] = Field(default_factory=list)
+    rename: str | None = Field(default=None, max_length=100)
+
+
+class ApplyPatchOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    op: Literal["apply_patch"]
+    args: ApplyPatchArgs
+
+
+# ---------------------------------------------------------------------------
+# suggest_variables — read-only, surfaces plugin variables to the user.
+# ---------------------------------------------------------------------------
+
+
+class VariableSuggestion(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    ref: str = Field(..., description="Variable reference like 'plugin.field'.")
+    description: str | None = None
+    example: str | None = None
+
+
+class SuggestVariablesArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    suggestions: list[VariableSuggestion] = Field(default_factory=list)
+
+
+class SuggestVariablesOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    op: Literal["suggest_variables"]
+    args: SuggestVariablesArgs
+
+
+# ---------------------------------------------------------------------------
+# navigate_to_page — send the user to a page editor without editing content.
+# ---------------------------------------------------------------------------
+
+
+class NavigateToPageArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    page_id: str = Field(..., description="Existing page ID, or 'new' to create.")
+    device_type: str | None = Field(default=None)
+
+
+class NavigateToPageOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    op: Literal["navigate_to_page"]
+    args: NavigateToPageArgs
+
+
+# ---------------------------------------------------------------------------
+# install_plugin — install a plugin from the official registry.
+# ---------------------------------------------------------------------------
+
+
+class InstallPluginArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    plugin_id: str = Field(..., min_length=1, max_length=100)
+    source: Literal["registry"] = "registry"
+    auto_enable: bool = True
+    initial_config: dict[str, Any] | None = None
+
+
+class InstallPluginOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    op: Literal["install_plugin"]
+    args: InstallPluginArgs
+
+
+# ---------------------------------------------------------------------------
+# update_plugin_config — change settings for an already-installed plugin.
+# ---------------------------------------------------------------------------
+
+
+class UpdatePluginConfigArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    plugin_id: str = Field(..., min_length=1, max_length=100)
+    config: dict[str, Any] = Field(default_factory=dict)
+
+
+class UpdatePluginConfigOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    op: Literal["update_plugin_config"]
+    args: UpdatePluginConfigArgs
+
+
+# ---------------------------------------------------------------------------
+# enable_plugin — enable an already-installed but currently-disabled plugin.
+# ---------------------------------------------------------------------------
+
+
+class EnablePluginArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    plugin_id: str = Field(..., min_length=1, max_length=100)
+
+
+class EnablePluginOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    op: Literal["enable_plugin"]
+    args: EnablePluginArgs
+
+
+# ---------------------------------------------------------------------------
+# disable_plugin — disable an installed plugin without uninstalling it.
+# ---------------------------------------------------------------------------
+
+
+class DisablePluginArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    plugin_id: str = Field(..., min_length=1, max_length=100)
+
+
+class DisablePluginOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    op: Literal["disable_plugin"]
+    args: DisablePluginArgs
+
+
+# ---------------------------------------------------------------------------
+# uninstall_plugin — permanently remove an installed plugin.
+# ---------------------------------------------------------------------------
+
+
+class UninstallPluginArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    plugin_id: str = Field(..., min_length=1, max_length=100)
+
+
+class UninstallPluginOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    op: Literal["uninstall_plugin"]
+    args: UninstallPluginArgs
+
+
+# ---------------------------------------------------------------------------
+# update_setting — change a non-credential system setting.
+# Credential-bearing settings (AI providers, MQTT) are excluded.
+# ---------------------------------------------------------------------------
+
+SettingCategory = Literal[
+    "display",
+    "transitions",
+    "output",
+    "polling",
+    "location",
+    "silence_schedule",
+    "active_page",
+]
+
+
+class UpdateSettingArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    category: SettingCategory
+    values: dict[str, Any] = Field(default_factory=dict)
+
+
+class UpdateSettingOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    op: Literal["update_setting"]
+    args: UpdateSettingArgs
+
+
+# ---------------------------------------------------------------------------
+# create_collection / update_collection — manage page collections.
+# ---------------------------------------------------------------------------
+
+
+class CreateCollectionArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    name: str = Field(..., min_length=1, max_length=100)
+    page_ids: list[str] = Field(default_factory=list)
+    # Time-mode interval; ignored when selection_mode == "variable".
+    interval_seconds: int = Field(30, ge=5, le=86400)
+
+
+class CreateCollectionOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    op: Literal["create_collection"]
+    args: CreateCollectionArgs
+
+
+class UpdateCollectionArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    collection_id: str = Field(..., description="ID of the collection to update.")
+    name: str | None = Field(default=None, min_length=1, max_length=100)
+    page_ids: list[str] | None = None
+    interval_seconds: int | None = Field(default=None, ge=5, le=86400)
+
+
+class UpdateCollectionOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    op: Literal["update_collection"]
+    args: UpdateCollectionArgs
+
+
+# ---------------------------------------------------------------------------
+# create_schedule / update_schedule / delete_schedule — manage the
+# display schedule (which page shows at what time).
+# ---------------------------------------------------------------------------
+
+DayPattern = Literal["all", "weekdays", "weekends", "custom"]
+_VALID_CUSTOM_DAYS = {"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"}
+
+
+class CreateScheduleArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    page_id: str = Field(..., description="Page or collection ID to show.")
+    start_time: str = Field(..., description="24h HH:MM start time.")
+    end_time: str | None = Field(default=None, description="24h HH:MM end time, or null for open-ended.")
+    day_pattern: DayPattern = "all"
+    custom_days: list[str] | None = Field(default=None, description="Required when day_pattern='custom'.")
+    enabled: bool = True
+
+
+class CreateScheduleOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    op: Literal["create_schedule"]
+    args: CreateScheduleArgs
+
+
+class UpdateScheduleArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    schedule_id: str = Field(..., description="ID of the schedule entry to update.")
+    page_id: str | None = None
+    start_time: str | None = None
+    end_time: str | None = None
+    day_pattern: DayPattern | None = None
+    custom_days: list[str] | None = None
+    enabled: bool | None = None
+
+
+class UpdateScheduleOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    op: Literal["update_schedule"]
+    args: UpdateScheduleArgs
+
+
+class DeleteScheduleArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    schedule_id: str = Field(..., description="ID of the schedule entry to delete.")
+
+
+class DeleteScheduleOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    op: Literal["delete_schedule"]
+    args: DeleteScheduleArgs
+
+
+# ---------------------------------------------------------------------------
+# update_plugin — trigger a registry update for an installed plugin.
+# ---------------------------------------------------------------------------
+
+
+class UpdatePluginArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    plugin_id: str = Field(..., min_length=1, max_length=100)
+
+
+class UpdatePluginOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    op: Literal["update_plugin"]
+    args: UpdatePluginArgs
+
+
+# ---------------------------------------------------------------------------
+# navigate_to_schedule — open the schedule editor, optionally pre-filling a
+# new entry form.
+# ---------------------------------------------------------------------------
+
+
+class NavigateToScheduleArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    prefill: dict[str, Any] | None = Field(default=None)
+
+
+class NavigateToScheduleOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    op: Literal["navigate_to_schedule"]
+    args: NavigateToScheduleArgs
+
+
+# ---------------------------------------------------------------------------
+# trigger_system_update — trigger a FiestaBoard system update.
+# ---------------------------------------------------------------------------
+
+
+class TriggerSystemUpdateArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+
+class TriggerSystemUpdateOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    op: Literal["trigger_system_update"]
+    args: TriggerSystemUpdateArgs
+
+
+# ---------------------------------------------------------------------------
+# update_task_list — frontend-only task tracker (no API call).
+# The model emits this to announce and update a running todo list so the
+# user can see progress across multi-step autonomous sessions.
+# ---------------------------------------------------------------------------
+
+TaskStatus = Literal["pending", "in_progress", "done", "failed"]
+
+
+class TaskItem(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = Field(..., min_length=1, max_length=50)
+    label: str = Field(..., min_length=1, max_length=200)
+    status: TaskStatus = "pending"
+
+
+class UpdateTaskListArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    tasks: list[TaskItem] = Field(default_factory=list)
+
+
+class UpdateTaskListOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    op: Literal["update_task_list"]
+    args: UpdateTaskListArgs
+
+
+# ---------------------------------------------------------------------------
+# Discriminated union + helper.
+# ---------------------------------------------------------------------------
+
+
+ToolCall = Union[  # noqa: UP007 — pydantic discriminated-union requires typing.Union
+    ReplacePageOp,
+    ApplyPatchOp,
+    SuggestVariablesOp,
+    NavigateToPageOp,
+    NavigateToScheduleOp,
+    InstallPluginOp,
+    UpdatePluginConfigOp,
+    EnablePluginOp,
+    DisablePluginOp,
+    UninstallPluginOp,
+    UpdateSettingOp,
+    CreateCollectionOp,
+    UpdateCollectionOp,
+    CreateScheduleOp,
+    UpdateScheduleOp,
+    DeleteScheduleOp,
+    UpdatePluginOp,
+    TriggerSystemUpdateOp,
+    UpdateTaskListOp,
+]
+
+
+_OP_REGISTRY = {
+    "replace_page": ReplacePageOp,
+    "apply_patch": ApplyPatchOp,
+    "suggest_variables": SuggestVariablesOp,
+    "navigate_to_page": NavigateToPageOp,
+    "navigate_to_schedule": NavigateToScheduleOp,
+    "install_plugin": InstallPluginOp,
+    "update_plugin_config": UpdatePluginConfigOp,
+    "enable_plugin": EnablePluginOp,
+    "disable_plugin": DisablePluginOp,
+    "uninstall_plugin": UninstallPluginOp,
+    "update_setting": UpdateSettingOp,
+    "create_collection": CreateCollectionOp,
+    "update_collection": UpdateCollectionOp,
+    "create_schedule": CreateScheduleOp,
+    "update_schedule": UpdateScheduleOp,
+    "delete_schedule": DeleteScheduleOp,
+    "update_plugin": UpdatePluginOp,
+    "trigger_system_update": TriggerSystemUpdateOp,
+    "update_task_list": UpdateTaskListOp,
+}
+
+
+class ToolCallValidationError(ValueError):
+    """Raised when a fenced block fails schema validation."""
+
+
+def parse_tool_call(payload: object) -> ToolCall:
+    """Validate a parsed JSON object against the operation grammar.
+
+    The model is asked to emit ``{"op": "...", "args": {...}}``. We
+    dispatch on ``op`` and validate against the corresponding model so
+    Pydantic gives us per-field errors (better UX than a giant union
+    failure).
+    """
+    if not isinstance(payload, dict):
+        raise ToolCallValidationError("Tool call must be a JSON object.")
+    op = payload.get("op")
+    if not isinstance(op, str):
+        raise ToolCallValidationError("Tool call is missing the required 'op' string.")
+    model_cls = _OP_REGISTRY.get(op)
+    if model_cls is None:
+        raise ToolCallValidationError(f"Unknown tool op: {op!r}")
+    try:
+        return model_cls.model_validate(payload)
+    except Exception as exc:  # pydantic.ValidationError, etc.
+        raise ToolCallValidationError(str(exc)) from exc
+
+
+def supported_ops() -> list[str]:
+    """Stable list of supported op names — used in the system prompt."""
+    return list(_OP_REGISTRY.keys())

--- a/src/ops/registry.py
+++ b/src/ops/registry.py
@@ -270,7 +270,7 @@ async def execute(name: str, args: dict[str, Any]) -> dict[str, Any]:
     assert op.executor is not None
 
     if op.chat_name is not None and name == op.chat_name:
-        from src.ai.chat_ops import parse_tool_call
+        from .grammar import parse_tool_call
 
         validated = parse_tool_call({"op": name, "args": args})
         assert op.adapt_chat_args is not None, f"chat-named op {name!r} has no args adapter"

--- a/src/ops/registry.py
+++ b/src/ops/registry.py
@@ -1,0 +1,289 @@
+"""The named operation set — one grammar for chat ops and MCP tools.
+
+Issue #1764: ``src/ai/chat_ops.py`` and ``src/mcp_server.py`` grew two
+parallel grammars for the same actions (``update_plugin_config`` vs
+``configure_plugin``, ``replace_page`` vs ``create_page``), each with its
+own implementation. This registry maps *both* name sets onto one canonical
+executor per operation (:mod:`src.ops.executors`), so the surfaces cannot
+diverge in behavior. Retiring the duplicate names is #1766-style follow-up
+work; here both grammars stay valid.
+
+Three kinds of operation live here:
+
+- shared ops — a chat name and an MCP tool name resolving to one executor;
+- single-surface server ops — only one grammar names them today
+  (``delete_page`` is MCP-only, ``update_setting`` is chat-only);
+- client-side chat ops — applied inside the web UI with no server-side
+  effect (``apply_patch`` edits the editor's draft, ``navigate_to_page``
+  routes). They are registered so the registry describes the *whole*
+  grammar, but carry no executor.
+
+``execute()`` is the chat-grammar entry point: given a chat op name it
+validates the args against the op's chat schema (the same models
+``parse_tool_call`` uses) before adapting them onto the executor. MCP
+tools call the executors directly — their argument shape already is the
+canonical one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from . import executors
+
+
+class ClientSideOperationError(LookupError):
+    """Raised when execute() is asked to run an op that only the web UI applies."""
+
+
+@dataclass(frozen=True)
+class Operation:
+    """One named operation: canonical name, aliases, validator, executor."""
+
+    name: str
+    #: Canonical executor. ``None`` only for client-side chat ops.
+    executor: Callable[..., Any] | None = None
+    #: The chat-grammar spelling, when the chat surface has one.
+    chat_name: str | None = None
+    #: The MCP tool spelling, when the MCP surface has one.
+    mcp_tool: str | None = None
+    #: Maps validated chat args (a pydantic model) onto executor kwargs.
+    adapt_chat_args: Callable[[Any], dict[str, Any]] | None = None
+    #: True for ops the web UI applies client-side (no server effect).
+    client_side: bool = field(default=False)
+
+    @property
+    def aliases(self) -> set[str]:
+        return {n for n in (self.name, self.chat_name, self.mcp_tool) if n}
+
+
+def _model_fields(args: Any, *names: str) -> dict[str, Any]:
+    """Executor kwargs from the named chat-args fields, skipping ``None``s."""
+    out: dict[str, Any] = {}
+    for name in names:
+        value = getattr(args, name)
+        if value is not None:
+            out[name] = value
+    return out
+
+
+def _adapt_replace_page(args: Any) -> dict[str, Any]:
+    """``replace_page`` materializes a full page definition → create_page.
+
+    The chat surface knows the device from the editor context; server-side
+    execution falls back to the executor's flagship default.
+    """
+    kwargs: dict[str, Any] = {
+        "name": args.name,
+        "template_lines": args.template,
+        "duration_seconds": args.duration_seconds,
+    }
+    if args.line_metadata:
+        kwargs["line_metadata"] = [m.model_dump() for m in args.line_metadata]
+    return kwargs
+
+
+def _adapt_install_plugin(args: Any) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {"plugin_id": args.plugin_id, "auto_enable": args.auto_enable}
+    if args.initial_config:
+        kwargs["initial_config"] = args.initial_config
+    return kwargs
+
+
+OPERATIONS: tuple[Operation, ...] = (
+    # -- pages ------------------------------------------------------------
+    Operation(
+        name="create_page",
+        executor=executors.create_page,
+        chat_name="replace_page",
+        mcp_tool="create_page",
+        adapt_chat_args=_adapt_replace_page,
+    ),
+    Operation(name="update_page", executor=executors.update_page, mcp_tool="update_page"),
+    Operation(name="delete_page", executor=executors.delete_page, mcp_tool="delete_page"),
+    Operation(name="set_active_page", executor=executors.set_active_page, mcp_tool="set_active_page"),
+    # -- schedules --------------------------------------------------------
+    Operation(
+        name="create_schedule",
+        executor=executors.create_schedule,
+        chat_name="create_schedule",
+        mcp_tool="create_schedule",
+        adapt_chat_args=lambda a: {
+            "page_id": a.page_id,
+            "start_time": a.start_time,
+            "end_time": a.end_time,
+            "day_pattern": a.day_pattern,
+            "enabled": a.enabled,
+            **({"custom_days": a.custom_days} if a.custom_days is not None else {}),
+        },
+    ),
+    Operation(
+        name="update_schedule",
+        executor=executors.update_schedule,
+        chat_name="update_schedule",
+        mcp_tool="update_schedule",
+        adapt_chat_args=lambda a: {
+            "schedule_id": a.schedule_id,
+            **_model_fields(a, "page_id", "start_time", "end_time", "day_pattern", "custom_days", "enabled"),
+        },
+    ),
+    Operation(
+        name="delete_schedule",
+        executor=executors.delete_schedule,
+        chat_name="delete_schedule",
+        mcp_tool="delete_schedule",
+        adapt_chat_args=lambda a: {"schedule_id": a.schedule_id},
+    ),
+    Operation(name="set_schedule_mode", executor=executors.set_schedule_mode, mcp_tool="set_schedule_mode"),
+    # -- collections ------------------------------------------------------
+    Operation(
+        name="create_collection",
+        executor=executors.create_collection,
+        chat_name="create_collection",
+        mcp_tool="create_collection",
+        adapt_chat_args=lambda a: {
+            "name": a.name,
+            "page_ids": a.page_ids,
+            "interval_seconds": a.interval_seconds,
+        },
+    ),
+    Operation(
+        name="update_collection",
+        executor=executors.update_collection,
+        chat_name="update_collection",
+        mcp_tool="update_collection",
+        adapt_chat_args=lambda a: {
+            "collection_id": a.collection_id,
+            **_model_fields(a, "name", "page_ids", "interval_seconds"),
+        },
+    ),
+    Operation(name="delete_collection", executor=executors.delete_collection, mcp_tool="delete_collection"),
+    # -- plugins ----------------------------------------------------------
+    Operation(
+        name="install_plugin",
+        executor=executors.install_plugin,
+        chat_name="install_plugin",
+        mcp_tool="install_plugin",
+        adapt_chat_args=_adapt_install_plugin,
+    ),
+    Operation(
+        name="configure_plugin",
+        executor=executors.configure_plugin,
+        chat_name="update_plugin_config",
+        mcp_tool="configure_plugin",
+        adapt_chat_args=lambda a: {"plugin_id": a.plugin_id, "config": a.config},
+    ),
+    Operation(
+        name="enable_plugin",
+        executor=executors.enable_plugin,
+        chat_name="enable_plugin",
+        mcp_tool="enable_plugin",
+        adapt_chat_args=lambda a: {"plugin_id": a.plugin_id},
+    ),
+    Operation(
+        name="disable_plugin",
+        executor=executors.disable_plugin,
+        chat_name="disable_plugin",
+        mcp_tool="disable_plugin",
+        adapt_chat_args=lambda a: {"plugin_id": a.plugin_id},
+    ),
+    Operation(
+        name="uninstall_plugin",
+        executor=executors.uninstall_plugin,
+        chat_name="uninstall_plugin",
+        mcp_tool="uninstall_plugin",
+        adapt_chat_args=lambda a: {"plugin_id": a.plugin_id},
+    ),
+    Operation(
+        name="update_plugin",
+        executor=executors.update_plugin,
+        chat_name="update_plugin",
+        mcp_tool="update_plugin",
+        adapt_chat_args=lambda a: {"plugin_id": a.plugin_id},
+    ),
+    # -- settings / system ------------------------------------------------
+    Operation(
+        name="update_setting",
+        executor=executors.update_setting,
+        chat_name="update_setting",
+        adapt_chat_args=lambda a: {"category": a.category, "values": a.values},
+    ),
+    Operation(
+        name="trigger_system_update",
+        executor=executors.trigger_system_update,
+        chat_name="trigger_system_update",
+        adapt_chat_args=lambda a: {},
+    ),
+    # -- client-side chat ops (no server effect) --------------------------
+    Operation(name="apply_patch", chat_name="apply_patch", client_side=True),
+    Operation(name="suggest_variables", chat_name="suggest_variables", client_side=True),
+    Operation(name="navigate_to_page", chat_name="navigate_to_page", client_side=True),
+    Operation(name="navigate_to_schedule", chat_name="navigate_to_schedule", client_side=True),
+    Operation(name="update_task_list", chat_name="update_task_list", client_side=True),
+)
+
+
+def _build_alias_map() -> dict[str, Operation]:
+    by_alias: dict[str, Operation] = {}
+    for op in OPERATIONS:
+        for alias in op.aliases:
+            existing = by_alias.get(alias)
+            if existing is not None and existing is not op:
+                raise ValueError(f"operation alias collision: {alias!r} names both {existing.name} and {op.name}")
+            by_alias[alias] = op
+    return by_alias
+
+
+_BY_ALIAS: dict[str, Operation] = _build_alias_map()
+
+
+def get_operation(name: str) -> Operation:
+    """Resolve either grammar's spelling to its operation."""
+    op = _BY_ALIAS.get(name)
+    if op is None:
+        raise KeyError(f"unknown operation: {name!r}")
+    return op
+
+
+def operation_names() -> set[str]:
+    """Every name the registry resolves (canonical + both grammars)."""
+    return set(_BY_ALIAS)
+
+
+async def execute(name: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Execute an operation by chat-grammar or canonical name.
+
+    Chat names are validated against the chat-op schema first (the exact
+    validation ``parse_tool_call`` applies), then adapted onto the
+    canonical executor. Canonical/MCP names pass ``args`` straight through
+    as executor kwargs.
+    """
+    op = get_operation(name)
+    if op.client_side:
+        raise ClientSideOperationError(
+            f"operation {name!r} is applied client-side by the web UI and has no server executor"
+        )
+    assert op.executor is not None
+
+    if op.chat_name is not None and name == op.chat_name:
+        from src.ai.chat_ops import parse_tool_call
+
+        validated = parse_tool_call({"op": name, "args": args})
+        assert op.adapt_chat_args is not None, f"chat-named op {name!r} has no args adapter"
+        kwargs = op.adapt_chat_args(validated.args)
+    else:
+        kwargs = dict(args)
+
+    result = op.executor(**kwargs)
+    if inspect.isawaitable(result):
+        result = await result
+    return result
+
+
+def execute_sync(name: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Blocking convenience wrapper around :func:`execute`."""
+    return asyncio.run(execute(name, args))

--- a/src/ops/results.py
+++ b/src/ops/results.py
@@ -1,0 +1,62 @@
+"""Shared result envelopes for operation executors.
+
+Every mutating operation — whichever grammar named it — returns the same
+success/error envelope the MCP tools have always returned, so re-expressing
+a tool on the ops layer changes no observable output.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def ok(message: str, **fields: Any) -> dict[str, Any]:
+    """Standard success envelope for mutation operations."""
+    return {"status": "success", "message": message, **fields}
+
+
+def err(error: str) -> dict[str, Any]:
+    """Standard error envelope. Executors never raise — they return this instead."""
+    return {"status": "error", "error": error}
+
+
+def rest_detail(exc: Any) -> str:
+    """Flatten an HTTPException detail into a single message.
+
+    The plugin-config endpoint raises ``detail={"errors": [...]}``; the
+    rest raise a plain string.
+    """
+    detail = getattr(exc, "detail", exc)
+    if isinstance(detail, dict) and detail.get("errors"):
+        return "; ".join(str(e) for e in detail["errors"])
+    return str(detail)
+
+
+def serialize(obj: Any) -> Any:
+    """Convert Pydantic models / dataclasses / datetimes to JSON-compatible primitives.
+
+    Used when an executor returns Pydantic models (pages, schedules,
+    collections) or dataclasses (settings objects). Plain dicts/lists pass
+    through. Falls back to ``__dict__`` for other ad-hoc objects
+    (e.g. SimpleNamespace).
+    """
+    import dataclasses
+    from datetime import date, datetime, time
+
+    if obj is None or isinstance(obj, str | int | float | bool):
+        return obj
+    if hasattr(obj, "model_dump"):
+        return obj.model_dump(mode="json")
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return {k: serialize(v) for k, v in dataclasses.asdict(obj).items()}
+    if isinstance(obj, list):
+        return [serialize(x) for x in obj]
+    if isinstance(obj, tuple):
+        return [serialize(x) for x in obj]
+    if isinstance(obj, dict):
+        return {k: serialize(v) for k, v in obj.items()}
+    if isinstance(obj, datetime | date | time):
+        return obj.isoformat()
+    if hasattr(obj, "__dict__"):
+        return {k: serialize(v) for k, v in vars(obj).items() if not k.startswith("_")}
+    return str(obj)

--- a/src/ops/teaching.py
+++ b/src/ops/teaching.py
@@ -1,0 +1,139 @@
+"""Teaching text for AI surfaces, generated once from real platform metadata.
+
+Issue #1764: the chat system prompt (:mod:`src.ai.prompt_builder`) and the
+MCP server instructions (:mod:`src.mcp_server`) each taught the model about
+board dimensions and template syntax in their own hardcoded copy, and the
+MCP copy had drifted from the engine — it advertised ``|upper`` and
+``|lower`` filters that have never existed, omitted the real
+``|truncate``/``|zeropad`` ones, gave the numeric color range as 63-71
+where the named palette ends at 70, and froze a 15-function formula list
+while the engine's registry kept growing.
+
+Everything here is derived from the modules that define the behavior:
+
+- dimensions from :data:`src.devices.DEVICE_DIMENSIONS`
+- color tokens from :data:`src.templates.engine.COLOR_CODES`
+- filters from :data:`TEMPLATE_FILTERS` below, which
+  ``tests/test_ops_teaching.py`` verifies against the engine's actual
+  ``_apply_filter``/``|wrap`` implementation so this table cannot rot
+- formula functions from :func:`src.templates.expressions.function_signatures`
+"""
+
+from __future__ import annotations
+
+from src.devices import DEVICE_DIMENSIONS, get_dimensions
+
+#: The template filter chain the engine actually implements.
+#: (spelling as written in a template, one-line teaching summary)
+#: Kept in lock-step with ``TemplateEngine._apply_filter`` and the special
+#: ``|wrap`` handling by tests/test_ops_teaching.py.
+TEMPLATE_FILTERS: tuple[tuple[str, str], ...] = (
+    ("pad:N", "right-pad the value with spaces to N chars"),
+    ("truncate:N", "cut the value to N chars"),
+    ("zeropad:N", "left-pad the value with zeros to N chars"),
+    ("wrap", "let a long value flow into the empty lines below"),
+)
+
+
+def dimensions_phrase(device_type: str) -> str:
+    """``"22 columns x 6 rows"`` — the chat system prompt's device line."""
+    dims = get_dimensions(device_type)
+    return f"{dims.cols} columns x {dims.rows} rows"
+
+
+def _color_names_by_code() -> dict[int, list[str]]:
+    """Group the named color tokens by flap code, aliases together."""
+    from src.templates.engine import COLOR_CODES
+
+    by_code: dict[int, list[str]] = {}
+    for name, code in COLOR_CODES.items():
+        by_code.setdefault(code, []).append(name)
+    return by_code
+
+
+def color_tokens_phrase() -> str:
+    """``{{red}} {{orange}} ... {{black}}`` with aliases annotated."""
+    parts: list[str] = []
+    for _code, names in sorted(_color_names_by_code().items()):
+        token = "{{" + names[0] + "}}"
+        if len(names) > 1:
+            aliases = " ".join("{{" + n + "}}" for n in names[1:])
+            token += f" (alias {aliases})"
+        parts.append(token)
+    return " ".join(parts)
+
+
+def numeric_color_range() -> tuple[int, int]:
+    """The numeric flap-code range covered by the named palette."""
+    from src.templates.engine import COLOR_CODES
+
+    codes = COLOR_CODES.values()
+    return min(codes), max(codes)
+
+
+def filters_phrase() -> str:
+    """``{{var|pad:N}} {{var|truncate:N}} ...`` from :data:`TEMPLATE_FILTERS`."""
+    return " ".join("{{var|" + spelling + "}}" for spelling, _summary in TEMPLATE_FILTERS)
+
+
+def formula_function_names() -> list[str]:
+    """Every built-in formula function name, from the live registry."""
+    from src.templates.expressions import function_signatures
+
+    return sorted(function_signatures())
+
+
+def device_dimensions_block() -> str:
+    """The DEVICE DIMENSIONS section of the MCP server instructions."""
+    width = max(len(device) for device in DEVICE_DIMENSIONS) + 1
+    lines = ["DEVICE DIMENSIONS (template_lines length must match exactly)"]
+    for device, dims in DEVICE_DIMENSIONS.items():
+        lines.append(f"  • {device + ':':<{width}} {dims.cols} columns × {dims.rows} rows")
+    lines += [
+        "  Content longer than the board width is TRUNCATED at render time —",
+        "  prefer concise variable names, the |wrap filter, or {{= LEFT(...)}}",
+        "  over letting the engine silently cut text off.",
+    ]
+    return "\n".join(lines)
+
+
+def template_syntax_block() -> str:
+    """The TEMPLATE SYNTAX section of the MCP server instructions."""
+    low, high = numeric_color_range()
+    low_name = _color_names_by_code()[low][0]
+    filter_lines = [f"                |{spelling:<11} {summary}" for spelling, summary in TEMPLATE_FILTERS]
+    function_roster = ", ".join(formula_function_names())
+    lines = [
+        "TEMPLATE SYNTAX",
+        "  • Variables:  {{plugin_id.variable_name}}  e.g. {{weather.temperature}}",
+        f"  • Colors:     {color_tokens_phrase()}",
+        f"                Numeric equivalents {low}–{high} also work ({{{{{low}}}}} = {low_name}).",
+        "                Each color token renders as ONE solid tile (not a",
+        "                style for following text). Place the token where you",
+        "                want the dot/indicator to appear.",
+        f"  • Filters:    {filters_phrase()}",
+        *filter_lines,
+        "                |wrap needs blank lines beneath the wrapped line for",
+        "                its overflow.",
+        "  • Formulas:   {{= EXPRESSION }} for Excel-like logic.",
+        "                Functions include:",
+        *_wrap_roster(function_roster, indent=" " * 16, width=76),
+        '                Example: {{= IF(weather.temp_f > 80, "HOT", "OK")}}',
+    ]
+    return "\n".join(lines)
+
+
+def _wrap_roster(roster: str, indent: str, width: int) -> list[str]:
+    """Wrap a comma-separated roster into indented lines."""
+    import textwrap
+
+    return textwrap.wrap(roster, width=width, initial_indent=indent, subsequent_indent=indent)
+
+
+def dimensions_summary_sentence() -> str:
+    """One sentence for MCP prompt bodies, e.g. the create_display_page prompt."""
+    parts = [
+        f"{device.capitalize()} display is {dims.cols}×{dims.rows} characters"
+        for device, dims in DEVICE_DIMENSIONS.items()
+    ]
+    return "; ".join(parts) + "."

--- a/src/schedules/storage.py
+++ b/src/schedules/storage.py
@@ -295,6 +295,10 @@ class ScheduleStorage:
         # Fields that are allowed to be set to None explicitly
         nullable_fields = {
             "end_time",
+            # A stale custom day list must be clearable when day_pattern
+            # moves away from "custom" (#1873/#1874 review); validate_config
+            # still rejects clearing it while the pattern stays "custom".
+            "custom_days",
             "annual_date",
             "annual_end_date",
             "one_off_date",

--- a/tests/test_mcp_state_effects.py
+++ b/tests/test_mcp_state_effects.py
@@ -544,6 +544,78 @@ def test_update_schedule_changes_the_stored_start_time(mcp, services):
     assert stored["start_time"] == "09:30", "update_schedule reported success but start_time did not change"
 
 
+def test_update_schedule_preserves_end_time_on_partial_update(mcp, services):
+    """Wipe-protection: a partial update that does not mention end_time must
+    leave a stored end_time untouched (the #1764 exclude_unset contract)."""
+    page_id = _make_page(mcp)
+    created = assert_ok(
+        call(mcp, "create_schedule", page_id=page_id, start_time="08:00", end_time="17:00", day_pattern="all"),
+        "create_schedule",
+    )
+    schedule_id = created["schedule_id"]
+
+    assert_ok(call(mcp, "update_schedule", schedule_id=schedule_id, start_time="09:30"), "update_schedule")
+
+    after = assert_ok(call(mcp, "list_schedules"), "list_schedules")
+    stored = next(s for s in after if s["id"] == schedule_id)
+    assert stored["end_time"] == "17:00", "a partial update wiped end_time"
+
+
+def test_update_schedule_clear_end_time_makes_the_entry_open_ended(mcp, services):
+    """Intentional clear: clear_end_time=True must null a stored end_time.
+
+    The wipe-protection above means an explicit end_time=None is
+    indistinguishable from "unchanged" — the tool silently no-oped with
+    success and there was NO way to make a bounded entry open-ended again
+    (#1873/#1874 review). The explicit flag is the escape hatch.
+    """
+    page_id = _make_page(mcp)
+    created = assert_ok(
+        call(mcp, "create_schedule", page_id=page_id, start_time="08:00", end_time="17:00", day_pattern="all"),
+        "create_schedule",
+    )
+    schedule_id = created["schedule_id"]
+
+    assert_ok(
+        call(mcp, "update_schedule", schedule_id=schedule_id, clear_end_time=True),
+        "update_schedule",
+    )
+
+    after = assert_ok(call(mcp, "list_schedules"), "list_schedules")
+    stored = next(s for s in after if s["id"] == schedule_id)
+    assert stored.get("end_time") is None, "clear_end_time=True did not clear the stored end_time"
+
+
+def test_update_schedule_clear_custom_days_drops_the_stale_day_list(mcp, services):
+    """clear_custom_days: switching a custom entry back to an every-day
+    pattern can drop the stale day list in the same call."""
+    from src.ops import executors as ops_executors
+
+    page_id = _make_page(mcp)
+    # custom_days exists only on the canonical op / chat grammar (the MCP
+    # create tool never sends it), so create through the op layer directly.
+    created = assert_ok(
+        ops_executors.create_schedule(
+            page_id=page_id,
+            start_time="08:00",
+            day_pattern="custom",
+            custom_days=["monday", "friday"],
+        ),
+        "create_schedule",
+    )
+    schedule_id = created["schedule_id"]
+
+    assert_ok(
+        call(mcp, "update_schedule", schedule_id=schedule_id, day_pattern="all", clear_custom_days=True),
+        "update_schedule",
+    )
+
+    after = assert_ok(call(mcp, "list_schedules"), "list_schedules")
+    stored = next(s for s in after if s["id"] == schedule_id)
+    assert stored["day_pattern"] == "all"
+    assert not stored.get("custom_days"), "clear_custom_days=True left the stale custom day list behind"
+
+
 def test_delete_schedule_removes_it(mcp, services):
     page_id = _make_page(mcp)
     created = assert_ok(
@@ -657,6 +729,34 @@ def test_configure_plugin_returns_the_config_it_saved(mcp, plugins):
         "configure_plugin",
     )
     assert result["config"].get("station_id") == "9447427"
+
+
+def test_configure_plugin_never_persists_env_overlay_values(mcp, plugins, monkeypatch):
+    """The merge base must be the STORED config, not the env-overlaid read.
+
+    configure_plugin merges the caller's keys over the existing config and
+    persists the result. Merging over the overlaid read bakes every live
+    env override — the api_key itself included, unmasked — into config.json
+    on any unrelated MCP save (#1874/#1865 review, regression of the #1864
+    env-free-persistence contract).
+    """
+    from src.config_manager import ENV_PLUGIN_OVERRIDES
+
+    assert_ok(
+        call(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"station_id": "9447427"}),
+        "configure_plugin",
+    )
+    monkeypatch.setitem(ENV_PLUGIN_OVERRIDES, "HARNESS_TIDE_API_KEY", (PLUGIN_ID, "api_key", str))
+    monkeypatch.setenv("HARNESS_TIDE_API_KEY", "test_env_secret_zz99")
+
+    assert_ok(
+        call(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"station_id": "9447430"}),
+        "configure_plugin",
+    )
+
+    stored = stored_plugin_config(plugins["config_path"], PLUGIN_ID)
+    assert stored["station_id"] == "9447430"
+    assert stored.get("api_key", "") == "", "MCP configure persisted an env secret into config.json"
 
 
 def test_configure_plugin_masks_sensitive_values_in_its_response(mcp, plugins):

--- a/tests/test_op_parity.py
+++ b/tests/test_op_parity.py
@@ -1,0 +1,436 @@
+"""Cross-grammar parity: chat op and MCP tool must persist identical state.
+
+Issue #1764's acceptance test. For every operation both grammars can
+express, the same logical call is executed twice against isolated stores —
+once through the chat grammar (``src.ops.execute`` with the chat spelling
+and chat-shaped args, validated by the same schemas ``parse_tool_call``
+applies) and once through the registered MCP tool — and the persisted
+state (pages.json, schedules.json, collections.json, config.json,
+normalized for generated ids and timestamps) is compared.
+
+Fail-first history
+------------------
+
+Run pre-unification with the chat path transcribed from what the web
+client executes today (the REST handlers' service calls), three of these
+scenarios failed — captured in ``.fail-first-1764.txt`` on the PR:
+
+1. ``update_plugin_config`` replaced the stored config where
+   ``configure_plugin`` merges; a partial second write dropped
+   previously-set keys and 400'd on required-field validation.
+2. ``update_collection`` with only ``interval_seconds`` forced
+   ``selection_mode`` back to ``"time"`` on the chat path, while the MCP
+   path preserved a variable-mode collection.
+3. ``update_schedule`` on the MCP path passed every parameter explicitly,
+   so ``model_dump(exclude_unset=True)`` saw the ``None``s as set and
+   wiped ``end_time`` on any partial update.
+
+The ops layer resolves both spellings of each op to one executor, which is
+what makes these pass now; the remaining scenarios found no divergence and
+land as a regression lock.
+
+Not covered: ``set_active_page`` vs ``update_setting(active_page)`` —
+both resolve to the same executor (asserted structurally in
+tests/test_ops_registry.py), but executing it needs full board/render
+wiring, the same reason tests/test_mcp_state_effects.py lists the tool as
+UNCOVERED.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mcp", reason="mcp package not installed")
+
+from src.collections.models import CollectionCreate, TimeModeConfig, VariableModeConfig, VariableRule
+from src.collections.service import CollectionService
+from src.collections.storage import CollectionStorage
+from src.config_manager import ConfigManager
+from src.mcp_server import _build_mcp_server
+from src.ops import execute
+from src.pages.models import PageCreate
+from src.pages.service import PageService
+from src.pages.storage import PageStorage
+from src.schedules.service import ScheduleService
+from src.schedules.storage import ScheduleStorage
+
+# Real-plugin fixtures shared with the MCP state-effect suite.
+from tests.test_mcp_state_effects import (
+    PLUGIN_ID,
+    UNINSTALLED_PLUGIN_ID,
+    _LocalRegistry,
+    _write_plugin,
+)
+
+FLAGSHIP_TEMPLATE = ["HELLO", "", "", "", "", ""]
+
+
+# ---------------------------------------------------------------------------
+# Isolated environment — one fresh set of stores per executed path
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def isolated_env(base: Path, with_plugins: bool = False):
+    """Point every service singleton at throwaway storage under ``base``.
+
+    Mirrors the ``services``/``plugins`` fixtures in
+    tests/test_mcp_state_effects.py, packaged as a context manager so one
+    test can stand up two sequential environments (one per path).
+    """
+    import src.plugins.registry as registry_module
+    import src.templates.engine as engine_module
+
+    base.mkdir(parents=True, exist_ok=True)
+    mp = pytest.MonkeyPatch()
+    pages = PageService(PageStorage(str(base / "pages.json")))
+    schedules = ScheduleService(ScheduleStorage(str(base / "schedules.json")))
+    collections = CollectionService(CollectionStorage(str(base / "collections.json")))
+    ConfigManager._instance = None  # type: ignore[attr-defined]
+    config = ConfigManager(config_path=str(base / "config.json"))
+
+    mp.setattr("src.pages.service._page_service", pages)
+    mp.setattr("src.schedules.service._schedule_service", schedules)
+    mp.setattr("src.collections.service._collection_service", collections)
+    mp.setattr("src.config_manager.ConfigManager._instance", config, raising=False)
+
+    original_registry = registry_module._registry
+    if with_plugins:
+        builtin_dir = base / "builtin_plugins"
+        builtin_dir.mkdir()
+        external_dir = base / "external_plugins"
+        external_dir.mkdir()
+        staging_dir = base / "staged_plugins"
+        _write_plugin(staging_dir / PLUGIN_ID, PLUGIN_ID)
+        _write_plugin(staging_dir / UNINSTALLED_PLUGIN_ID, UNINSTALLED_PLUGIN_ID)
+        registry = _LocalRegistry(builtin_dir, external_dir, staging_dir)
+        registry.initialize()
+        registry_module._registry = registry
+        assert not registry.install_from_registry(PLUGIN_ID), "fixture failed to install the harness plugin"
+
+    try:
+        yield SimpleNamespace(base=base, pages=pages, schedules=schedules, collections=collections, config=config)
+    finally:
+        mp.undo()
+        registry_module._registry = original_registry
+        if engine_module._template_engine is not None:
+            engine_module.reset_template_engine()
+        ConfigManager._instance = None  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Snapshot + normalization
+# ---------------------------------------------------------------------------
+
+STORE_FILES = ("pages.json", "schedules.json", "collections.json", "config.json")
+VOLATILE_KEYS = {"created_at", "updated_at", "installed_at", "last_updated"}
+
+
+def _collect_ids(node: Any, ids: list[str]) -> None:
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if k == "id" and isinstance(v, str) and v not in ids:
+                ids.append(v)
+            else:
+                _collect_ids(v, ids)
+    elif isinstance(node, list):
+        for item in node:
+            _collect_ids(item, ids)
+
+
+def _scrub(node: Any, id_map: dict[str, str]) -> Any:
+    if isinstance(node, dict):
+        return {k: _scrub(v, id_map) for k, v in node.items() if k not in VOLATILE_KEYS}
+    if isinstance(node, list):
+        return [_scrub(x, id_map) for x in node]
+    if isinstance(node, str) and node in id_map:
+        return id_map[node]
+    return node
+
+
+def snapshot(env: SimpleNamespace) -> dict[str, Any]:
+    """The persisted state, with generated ids and timestamps normalized.
+
+    Ids are canonicalized in encounter order — both paths create objects
+    in the same order, so matching structure maps to matching
+    placeholders and any structural difference survives normalization.
+    """
+    raw: dict[str, Any] = {}
+    for fname in STORE_FILES:
+        path = env.base / fname
+        raw[fname] = json.loads(path.read_text(encoding="utf-8")) if path.exists() else None
+    ids: list[str] = []
+    for fname in STORE_FILES:
+        _collect_ids(raw[fname], ids)
+    id_map = {v: f"<id{i}>" for i, v in enumerate(ids)}
+    return {fname: _scrub(data, id_map) for fname, data in raw.items()}
+
+
+# ---------------------------------------------------------------------------
+# Drivers
+# ---------------------------------------------------------------------------
+
+
+def chat(op: str, args: dict[str, Any]) -> Any:
+    """The chat-grammar path: chat spelling + chat-shaped args through the ops layer."""
+    return asyncio.run(execute(op, args))
+
+
+def mcp_call(mcp: Any, tool: str, /, **kwargs: Any) -> Any:
+    """The MCP path: the registered tool, awaited when async."""
+    fn = mcp._tool_manager._tools[tool].fn
+    result = fn(**kwargs)
+    if asyncio.iscoroutine(result):
+        result = asyncio.run(result)
+    return result
+
+
+@pytest.fixture(scope="module")
+def mcp():
+    instance = _build_mcp_server()
+    assert instance is not None, "mcp installed but _build_mcp_server() returned None"
+    return instance
+
+
+def assert_parity(tmp_path, chat_steps, mcp_steps, with_plugins=False, setup=None):
+    """Run both paths against fresh stores and compare persisted state."""
+    with isolated_env(tmp_path / "chat_path", with_plugins=with_plugins) as env:
+        if setup:
+            setup(env)
+        chat_steps(env)
+        chat_state = snapshot(env)
+    with isolated_env(tmp_path / "mcp_path", with_plugins=with_plugins) as env:
+        if setup:
+            setup(env)
+        mcp_steps(env)
+        mcp_state = snapshot(env)
+    assert chat_state == mcp_state, "the two grammars persisted different state for the same logical operation"
+
+
+def _make_page(env, name: str = "P1") -> str:
+    page = env.pages.create_page(
+        PageCreate(name=name, type="template", device_type="flagship", template=FLAGSHIP_TEMPLATE)
+    )
+    return page.id
+
+
+# ---------------------------------------------------------------------------
+# Plugin operations
+# ---------------------------------------------------------------------------
+
+
+def test_parity_update_plugin_config_partial_second_write(tmp_path, mcp):
+    """Fail-first divergence 1: replace-vs-merge on partial config updates."""
+
+    def chat_steps(env):
+        chat("update_plugin_config", {"plugin_id": PLUGIN_ID, "config": {"station_id": "9447427"}})
+        chat("update_plugin_config", {"plugin_id": PLUGIN_ID, "config": {"api_key": "test_secret"}})
+
+    def mcp_steps(env):
+        mcp_call(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"station_id": "9447427"})
+        mcp_call(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"api_key": "test_secret"})
+
+    assert_parity(tmp_path, chat_steps, mcp_steps, with_plugins=True)
+
+
+def test_parity_install_plugin(tmp_path, mcp):
+    def chat_steps(env):
+        chat("install_plugin", {"plugin_id": UNINSTALLED_PLUGIN_ID, "auto_enable": True})
+
+    def mcp_steps(env):
+        mcp_call(mcp, "install_plugin", plugin_id=UNINSTALLED_PLUGIN_ID, auto_enable=True)
+
+    assert_parity(tmp_path, chat_steps, mcp_steps, with_plugins=True)
+
+
+def test_parity_enable_disable_plugin(tmp_path, mcp):
+    def chat_steps(env):
+        chat("enable_plugin", {"plugin_id": PLUGIN_ID})
+        chat("disable_plugin", {"plugin_id": PLUGIN_ID})
+        chat("enable_plugin", {"plugin_id": PLUGIN_ID})
+
+    def mcp_steps(env):
+        mcp_call(mcp, "enable_plugin", plugin_id=PLUGIN_ID)
+        mcp_call(mcp, "disable_plugin", plugin_id=PLUGIN_ID)
+        mcp_call(mcp, "enable_plugin", plugin_id=PLUGIN_ID)
+
+    assert_parity(tmp_path, chat_steps, mcp_steps, with_plugins=True)
+
+
+def test_parity_uninstall_plugin(tmp_path, mcp):
+    def chat_steps(env):
+        chat("uninstall_plugin", {"plugin_id": PLUGIN_ID})
+
+    def mcp_steps(env):
+        mcp_call(mcp, "uninstall_plugin", plugin_id=PLUGIN_ID)
+
+    assert_parity(tmp_path, chat_steps, mcp_steps, with_plugins=True)
+
+
+def test_parity_update_plugin_rejects_builtins_identically(tmp_path, mcp):
+    """The harness plugin has no git remote, so both paths must refuse and
+    leave state untouched — the guarded error path is part of the contract."""
+
+    def chat_steps(env):
+        result = chat("update_plugin", {"plugin_id": PLUGIN_ID})
+        assert result["status"] == "error"
+
+    def mcp_steps(env):
+        result = mcp_call(mcp, "update_plugin", plugin_id=PLUGIN_ID)
+        assert result["status"] == "error"
+
+    assert_parity(tmp_path, chat_steps, mcp_steps, with_plugins=True)
+
+
+# ---------------------------------------------------------------------------
+# Schedule operations
+# ---------------------------------------------------------------------------
+
+
+def test_parity_schedule_lifecycle(tmp_path, mcp):
+    """Fail-first divergence 3 lives in the update step: a partial
+    update must not wipe the end_time either grammar set at creation."""
+
+    ctx: dict[str, str] = {}
+
+    def setup(env):
+        ctx["page_id"] = _make_page(env)
+
+    def chat_steps(env):
+        created = chat(
+            "create_schedule",
+            {"page_id": ctx["page_id"], "start_time": "07:00", "end_time": "09:00", "day_pattern": "weekdays"},
+        )
+        chat("update_schedule", {"schedule_id": created["schedule_id"], "start_time": "08:00", "enabled": False})
+        doomed = chat("create_schedule", {"page_id": ctx["page_id"], "start_time": "10:00", "day_pattern": "all"})
+        chat("delete_schedule", {"schedule_id": doomed["schedule_id"]})
+
+    def mcp_steps(env):
+        created = mcp_call(
+            mcp,
+            "create_schedule",
+            page_id=ctx["page_id"],
+            start_time="07:00",
+            end_time="09:00",
+            day_pattern="weekdays",
+        )
+        mcp_call(mcp, "update_schedule", schedule_id=created["schedule_id"], start_time="08:00", enabled=False)
+        doomed = mcp_call(mcp, "create_schedule", page_id=ctx["page_id"], start_time="10:00", day_pattern="all")
+        mcp_call(mcp, "delete_schedule", schedule_id=doomed["schedule_id"])
+
+    assert_parity(tmp_path, chat_steps, mcp_steps, setup=setup)
+
+
+# ---------------------------------------------------------------------------
+# Collection operations
+# ---------------------------------------------------------------------------
+
+
+def test_parity_update_collection_interval_on_variable_mode(tmp_path, mcp):
+    """Fail-first divergence 2: an interval-only update must not flip a
+    variable-mode collection back to time mode on either path."""
+
+    ctx: dict[str, str] = {}
+
+    def setup(env):
+        page_id = _make_page(env)
+        collection = env.collections.create_collection(
+            CollectionCreate(
+                name="VarCol",
+                page_ids=[page_id],
+                selection_mode="variable",
+                time=TimeModeConfig(interval_seconds=30),
+                variable=VariableModeConfig(
+                    rules=[VariableRule(expression="1", page_id=page_id)],
+                    default_page_id=page_id,
+                    poll_seconds=10,
+                ),
+            )
+        )
+        ctx["collection_id"] = collection.id
+
+    def chat_steps(env):
+        chat("update_collection", {"collection_id": ctx["collection_id"], "interval_seconds": 45})
+
+    def mcp_steps(env):
+        mcp_call(mcp, "update_collection", collection_id=ctx["collection_id"], interval_seconds=45)
+
+    assert_parity(tmp_path, chat_steps, mcp_steps, setup=setup)
+
+
+def test_parity_collection_create_and_update(tmp_path, mcp):
+    ctx: dict[str, str] = {}
+
+    def setup(env):
+        ctx["p1"] = _make_page(env, "P1")
+        ctx["p2"] = _make_page(env, "P2")
+
+    def chat_steps(env):
+        created = chat(
+            "create_collection",
+            {"name": "Morning", "page_ids": [ctx["p1"], ctx["p2"]], "interval_seconds": 30},
+        )
+        chat(
+            "update_collection",
+            {"collection_id": created["collection_id"], "page_ids": [ctx["p2"], ctx["p1"]], "interval_seconds": 45},
+        )
+
+    def mcp_steps(env):
+        created = mcp_call(
+            mcp, "create_collection", name="Morning", page_ids=[ctx["p1"], ctx["p2"]], interval_seconds=30
+        )
+        mcp_call(
+            mcp,
+            "update_collection",
+            collection_id=created["collection_id"],
+            page_ids=[ctx["p2"], ctx["p1"]],
+            interval_seconds=45,
+        )
+
+    assert_parity(tmp_path, chat_steps, mcp_steps, setup=setup)
+
+
+# ---------------------------------------------------------------------------
+# Page operations
+# ---------------------------------------------------------------------------
+
+
+def test_parity_replace_page_vs_create_page(tmp_path, mcp):
+    def chat_steps(env):
+        chat("replace_page", {"name": "Weather", "template": FLAGSHIP_TEMPLATE, "duration_seconds": 120})
+
+    def mcp_steps(env):
+        mcp_call(
+            mcp,
+            "create_page",
+            name="Weather",
+            template_lines=FLAGSHIP_TEMPLATE,
+            device_type="flagship",
+            duration_seconds=120,
+        )
+
+    assert_parity(tmp_path, chat_steps, mcp_steps)
+
+
+# ---------------------------------------------------------------------------
+# Non-vacuity: the comparison must be able to fail
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_comparison_detects_a_real_state_difference(tmp_path, mcp):
+    """Prove assert_parity is not comparing air: paths that genuinely
+    persist different state must fail the comparison."""
+
+    with pytest.raises(AssertionError, match="persisted different state"):
+        assert_parity(
+            tmp_path,
+            lambda env: chat("replace_page", {"name": "Chat Page", "template": FLAGSHIP_TEMPLATE}),
+            lambda env: None,  # the MCP path creates nothing
+        )

--- a/tests/test_ops_registry.py
+++ b/tests/test_ops_registry.py
@@ -1,0 +1,210 @@
+"""The operation registry must cover both grammars, exactly.
+
+Issue #1764 collapsed the chat-op grammar and the MCP tools onto one set of
+canonical executors. These tests pin the mapping:
+
+- every chat op name resolves in the registry (client-side ops included);
+- every MCP tool the registry claims to back is really registered;
+- client-side ops carry no executor and refuse to execute();
+- chat-grammar execution validates args with the same schema
+  ``parse_tool_call`` uses, then actually reaches the executor (asserted
+  by re-reading persisted state, in the spirit of
+  tests/test_mcp_state_effects.py).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.ai.chat_ops import _OP_REGISTRY as CHAT_OPS
+from src.ai.chat_ops import ToolCallValidationError
+from src.ops import (
+    OPERATIONS,
+    ClientSideOperationError,
+    execute,
+    get_operation,
+    operation_names,
+)
+
+# ---------------------------------------------------------------------------
+# Registry shape
+# ---------------------------------------------------------------------------
+
+EXPECTED_CANONICAL = {
+    "create_page",
+    "update_page",
+    "delete_page",
+    "set_active_page",
+    "create_schedule",
+    "update_schedule",
+    "delete_schedule",
+    "set_schedule_mode",
+    "create_collection",
+    "update_collection",
+    "delete_collection",
+    "install_plugin",
+    "configure_plugin",
+    "enable_plugin",
+    "disable_plugin",
+    "uninstall_plugin",
+    "update_plugin",
+    "update_setting",
+    "trigger_system_update",
+    # client-side chat ops, registered so the registry is the whole grammar
+    "apply_patch",
+    "suggest_variables",
+    "navigate_to_page",
+    "navigate_to_schedule",
+    "update_task_list",
+}
+
+
+def test_canonical_operation_set_is_pinned():
+    assert {op.name for op in OPERATIONS} == EXPECTED_CANONICAL
+
+
+def test_every_chat_op_resolves_in_the_registry():
+    """The registry describes the whole chat grammar, not a subset."""
+    chat_names = {op.chat_name for op in OPERATIONS if op.chat_name}
+    assert chat_names == set(CHAT_OPS), (
+        "chat grammar and ops registry have drifted.\n"
+        f"  chat only: {sorted(set(CHAT_OPS) - chat_names)}\n"
+        f"  registry only: {sorted(chat_names - set(CHAT_OPS))}"
+    )
+    for name in CHAT_OPS:
+        assert get_operation(name) is not None
+
+
+def test_client_side_flag_and_executor_are_mutually_exclusive():
+    for op in OPERATIONS:
+        if op.client_side:
+            assert op.executor is None, f"{op.name} is client_side but has an executor"
+            assert op.mcp_tool is None, f"{op.name} is client_side but claims an MCP tool"
+        else:
+            assert op.executor is not None, f"{op.name} has no executor and is not client_side"
+
+
+def test_every_chat_named_executor_op_has_an_args_adapter():
+    for op in OPERATIONS:
+        if op.chat_name and not op.client_side:
+            assert op.adapt_chat_args is not None, f"{op.name} accepts chat name {op.chat_name} but cannot adapt args"
+
+
+def test_alias_resolution_covers_both_spellings_of_shared_ops():
+    assert get_operation("update_plugin_config") is get_operation("configure_plugin")
+    assert get_operation("replace_page") is get_operation("create_page")
+
+
+def test_unknown_operation_name_raises():
+    with pytest.raises(KeyError):
+        get_operation("definitely_not_an_op")
+
+
+def test_operation_names_include_both_grammars():
+    names = operation_names()
+    assert "update_plugin_config" in names  # chat spelling
+    assert "configure_plugin" in names  # MCP spelling
+
+
+# ---------------------------------------------------------------------------
+# MCP coverage — every tool the registry claims must really be registered
+# ---------------------------------------------------------------------------
+
+
+def test_registry_mcp_tools_are_registered_mcp_tools():
+    pytest.importorskip("mcp", reason="mcp package not installed")
+    from src.mcp_server import _build_mcp_server
+
+    mcp = _build_mcp_server()
+    assert mcp is not None
+    registered = set(mcp._tool_manager._tools)
+    claimed = {op.mcp_tool for op in OPERATIONS if op.mcp_tool}
+    phantom = claimed - registered
+    assert not phantom, f"ops registry claims MCP tools that do not exist: {sorted(phantom)}"
+
+
+# ---------------------------------------------------------------------------
+# execute() semantics
+# ---------------------------------------------------------------------------
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_execute_refuses_client_side_ops():
+    with pytest.raises(ClientSideOperationError):
+        _run(execute("apply_patch", {"changes": []}))
+
+
+def test_execute_validates_chat_args_with_the_chat_schema():
+    """A chat-grammar call goes through the same validation parse_tool_call
+    applies — bad args fail before any executor runs."""
+    with pytest.raises(ToolCallValidationError):
+        _run(execute("update_plugin_config", {"config": {}}))  # plugin_id missing
+
+
+def test_execute_unknown_name_raises_key_error():
+    with pytest.raises(KeyError):
+        _run(execute("no_such_op", {}))
+
+
+# ---------------------------------------------------------------------------
+# execute() reaches real executors — asserted on re-read state, no mocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def services(tmp_path, monkeypatch):
+    """Real page/schedule/collection services on throwaway storage."""
+    from src.collections.service import CollectionService
+    from src.collections.storage import CollectionStorage
+    from src.pages.service import PageService
+    from src.pages.storage import PageStorage
+    from src.schedules.service import ScheduleService
+    from src.schedules.storage import ScheduleStorage
+
+    pages = PageService(PageStorage(str(tmp_path / "pages.json")))
+    schedules = ScheduleService(ScheduleStorage(str(tmp_path / "schedules.json")))
+    collections = CollectionService(CollectionStorage(str(tmp_path / "collections.json")))
+    monkeypatch.setattr("src.pages.service._page_service", pages)
+    monkeypatch.setattr("src.schedules.service._schedule_service", schedules)
+    monkeypatch.setattr("src.collections.service._collection_service", collections)
+    return {"pages": pages, "schedules": schedules, "collections": collections}
+
+
+FLAGSHIP_TEMPLATE = ["HELLO", "", "", "", "", ""]
+
+
+def test_execute_replace_page_creates_a_persisted_page(services):
+    result = _run(
+        execute(
+            "replace_page",
+            {"name": "From Chat Grammar", "template": FLAGSHIP_TEMPLATE, "duration_seconds": 120},
+        )
+    )
+    assert result["status"] == "success"
+    stored = services["pages"].get_page(result["page_id"])
+    assert stored is not None
+    assert stored.name == "From Chat Grammar"
+    assert stored.duration_seconds == 120
+
+
+def test_execute_update_schedule_via_chat_name_changes_only_supplied_fields(services):
+    page = _run(execute("create_page", {"name": "P", "template_lines": FLAGSHIP_TEMPLATE}))
+    created = _run(
+        execute(
+            "create_schedule",
+            {"page_id": page["page_id"], "start_time": "07:00", "end_time": "09:00", "day_pattern": "weekdays"},
+        )
+    )
+    assert created["status"] == "success"
+
+    updated = _run(execute("update_schedule", {"schedule_id": created["schedule_id"], "start_time": "08:00"}))
+    assert updated["status"] == "success"
+
+    stored = next(s for s in services["schedules"].list_schedules() if s.id == created["schedule_id"])
+    assert stored.start_time == "08:00"
+    assert stored.end_time == "09:00", "a partial update must not wipe end_time (#1764 divergence 3)"

--- a/tests/test_ops_teaching.py
+++ b/tests/test_ops_teaching.py
@@ -1,0 +1,117 @@
+"""The generated teaching text must describe what the platform actually does.
+
+Issue #1764: the MCP server's hardcoded teaching copy had rotted — it
+advertised ``|upper``/``|lower`` template filters that never existed and a
+15-function formula roster frozen in time. The fix is generation
+(:mod:`src.ops.teaching` derives every fact from the defining module), and
+these tests are the lock: each claim the teaching text makes is checked
+against the engine that has to honor it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.devices import DEVICE_DIMENSIONS, get_dimensions
+from src.ops import teaching
+from src.templates.engine import COLOR_CODES, TemplateEngine
+from src.templates.expressions import function_signatures
+
+# ---------------------------------------------------------------------------
+# Filters: every filter the teaching text advertises must actually transform
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("spelling", "value", "expected"),
+    [
+        ("pad:5", "7", "7    "),
+        ("truncate:2", "SUNNY", "SU"),
+        ("zeropad:3", "7", "007"),
+    ],
+)
+def test_advertised_value_filters_are_implemented_by_the_engine(spelling, value, expected):
+    engine = TemplateEngine.__new__(TemplateEngine)  # filter logic needs no engine state
+    assert engine._apply_filter(value, spelling) == expected
+
+
+def test_advertised_wrap_filter_is_recognized_by_the_engine():
+    found = TemplateEngine._find_wrap_expression("{{weather.summary|wrap}}")
+    assert found is not None, "the teaching text advertises |wrap but the engine no longer detects it"
+
+
+def test_the_filters_the_old_mcp_copy_invented_still_do_not_exist():
+    """``|upper`` and ``|lower`` were taught by the stale MCP text but were
+    never implemented — a value passes through them unchanged. If the engine
+    ever grows them, TEMPLATE_FILTERS (and this test) must be updated."""
+    engine = TemplateEngine.__new__(TemplateEngine)
+    assert engine._apply_filter("sunny", "upper:1") == "sunny"
+    advertised = {spelling.split(":")[0] for spelling, _ in teaching.TEMPLATE_FILTERS}
+    assert "upper" not in advertised
+    assert "lower" not in advertised
+
+
+def test_every_advertised_filter_appears_in_the_syntax_block():
+    block = teaching.template_syntax_block()
+    for spelling, summary in teaching.TEMPLATE_FILTERS:
+        assert f"|{spelling}" in block
+        assert summary in block
+
+
+# ---------------------------------------------------------------------------
+# Colors
+# ---------------------------------------------------------------------------
+
+
+def test_every_named_color_token_is_taught():
+    phrase = teaching.color_tokens_phrase()
+    for name in COLOR_CODES:
+        assert "{{" + name + "}}" in phrase
+
+
+def test_numeric_color_range_matches_the_engine_palette():
+    low, high = teaching.numeric_color_range()
+    assert low == min(COLOR_CODES.values())
+    assert high == max(COLOR_CODES.values())
+    assert f"{low}–{high}" in teaching.template_syntax_block()
+
+
+# ---------------------------------------------------------------------------
+# Dimensions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device_type", sorted(DEVICE_DIMENSIONS))
+def test_dimensions_phrase_matches_device_metadata(device_type):
+    dims = get_dimensions(device_type)
+    assert teaching.dimensions_phrase(device_type) == f"{dims.cols} columns x {dims.rows} rows"
+
+
+def test_device_dimensions_block_lists_every_device():
+    block = teaching.device_dimensions_block()
+    for device, dims in DEVICE_DIMENSIONS.items():
+        assert device in block
+        assert f"{dims.cols} columns × {dims.rows} rows" in block
+
+
+def test_dimensions_summary_sentence_covers_every_device():
+    sentence = teaching.dimensions_summary_sentence()
+    for device, dims in DEVICE_DIMENSIONS.items():
+        assert f"{dims.cols}×{dims.rows}" in sentence
+        assert device.capitalize() in sentence
+
+
+# ---------------------------------------------------------------------------
+# Formula functions
+# ---------------------------------------------------------------------------
+
+
+def test_formula_roster_is_the_live_registry_not_a_frozen_list():
+    names = teaching.formula_function_names()
+    assert names == sorted(function_signatures())
+    # The stale hardcoded list had 15 entries; the live registry is larger,
+    # which is exactly why a frozen copy rots.
+    assert len(names) > 15
+    block = teaching.template_syntax_block()
+    for name in names:
+        assert name in block

--- a/tests/test_service_wiring.py
+++ b/tests/test_service_wiring.py
@@ -43,6 +43,11 @@ import pytest
 SCANNED_MODULES = [
     "src/mcp_server.py",
     "src/mqtt/commands.py",
+    # #1764: the mutating MCP tool bodies moved into the shared operation
+    # layer, which is now the surface that resolves service singletons by
+    # lazy import and swallows exceptions into an error envelope — exactly
+    # the failure mode this scan exists to catch.
+    "src/ops/executors.py",
 ]
 
 # A scan that resolves nothing passes vacuously. If the import or call style in
@@ -54,10 +59,14 @@ MIN_RESOLVED_CALLS = {
     # one fewer directly-resolvable service call in this module. Dropped
     # 34 -> 33 in #1741 for the same reason: update_plugin no longer calls
     # registry.reload_plugin() itself, it awaits the REST handler so the
-    # built-in / realpath-containment / .git guards run. Lower this only
-    # alongside a change that genuinely removes a direct service call.
-    "src/mcp_server.py": 33,
+    # built-in / realpath-containment / .git guards run. Dropped 33 -> 22 in
+    # #1764: the mutating tool bodies (11 direct service calls) moved to
+    # src/ops/executors.py, which is scanned with its own floor below, so
+    # the total across both modules is unchanged. Lower this only alongside
+    # a change that genuinely removes a direct service call.
+    "src/mcp_server.py": 22,
     "src/mqtt/commands.py": 15,
+    "src/ops/executors.py": 11,
 }
 
 


### PR DESCRIPTION
Closes #1764; part of #1849. **Track A**, stacked on #1869 (sibling of #1872, the conventions doc).

## What

`src/ai/chat_ops.py` defined a second, parallel grammar of 19 ops with different names for the same actions as the 28 MCP tools, and the teaching text (dimensions, template syntax) was written twice with the MCP copy hardcoded. Now:

- **`src/ops/`**: a 24-operation canonical registry — 19 server executors calling the domain services, 5 client-side chat ops registered grammar-only. Both spellings resolve (`update_plugin_config` ↔ `configure_plugin`, `replace_page` ↔ `create_page`); chat args validate against the exact `parse_tool_call` schemas. `chat_ops.py` is a byte-compatible re-export shim over `src/ops/grammar.py`; MCP tools dispatch into the same executors.
- **Teaching text generated once** (`src/ops/teaching.py`) from live device/engine metadata, consumed by both the chat system prompt and MCP prompts.

## The divergences the unification fixed (fail-first, all three observed pre-fix)

1. **Plugin config**: chat/REST *replaced*, MCP *merged* — a partial second write via chat dropped `station_id` and 400'd. Canonical: merge (the pinned MCP contract).
2. **Interval-only collection update** force-flipped a variable-mode collection to `time` on the chat path. Canonical: mode preserved.
3. **Partial schedule update** through MCP **wiped `end_time`** (explicit `None`s defeating `exclude_unset` — the same defect class `update_page` had already fixed). Canonical: only-supplied-fields.

Stale teaching text fixed by generation: filters `|upper`/`|lower` **never existed** (real ones were missing), color range was off by one (63–70), and the formula roster was frozen at 15 of the live 50 functions — all now generated and drift-locked by tests.

## Zero-regression evidence

- Existing AI/MCP suites pass **unmodified**: `test_ai_op_contract`, `tests/ai/*`, `test_mcp_state_effects`, `test_mcp_prompts_and_resources`, `test_mcp_server`, `test_mcp_skill_quality` (413→439 with the 26 new ops tests). One deliberate wiring-test update: the ≥33-service-call vacuity floor split across mcp_server (22) + executors (11) with in-place justification — total unchanged.
- **Parity suite** (10 cross-grammar tests) locks the ops with no divergence; non-vacuity proven by deliberately re-diverging the chat adapter.
- Full suite: baseline `5689 passed / 1 failed` → `5726 passed / same 1 environmental failure`. Goldens untouched; ruff + import sanity clean.

Noted for the #1766 follow-up: the web drawer still executes chat ops client-side via REST, so the browser path keeps replace-semantics until execution moves onto the server op layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP