### PR TITLE
feat(mcp): multi-board parity, read-back tools, protocol errors, paginated registry

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -63,7 +63,7 @@ from .schedules.service import get_schedule_service  # noqa: E402, F401
 from .settings.service import VALID_OUTPUT_TARGETS, VALID_STRATEGIES, get_settings_service  # noqa: E402
 from .templates.engine import get_template_engine, reset_template_engine  # noqa: E402, F401
 from .templates.expressions import function_signatures  # noqa: E402
-from .text_to_board import text_to_board_array, wrap_message_text  # noqa: E402
+from .text_to_board import text_to_board_array  # noqa: E402
 from .time_service import reset_time_service  # noqa: E402
 from .virtual_board_client import release_virtual_board_state  # noqa: E402
 
@@ -2476,16 +2476,17 @@ async def send_message(request: MessageRequest):
             notes_wide = primary_board.get("notes_wide", 1)
             notes_tall = primary_board.get("notes_tall", 1)
         dims = resolve_dimensions(device_type, notes_wide, notes_tall)
-        # Word-wrap to the board width (in tiles) and honor real newlines
-        # (issue #1793), then convert to a board array for proper
-        # character/color support. Backslashes are left alone: a JSON body
-        # can carry a real newline, so rewriting "\n" here would only corrupt
-        # legitimate text like C:\new.
-        wrapped = wrap_message_text(request.text, rows=dims.rows, cols=dims.cols)
-        board_array = text_to_board_array(wrapped, rows=dims.rows, cols=dims.cols)
+        # Word-wrap/convert/render is the shared message core (#1765): the
+        # MCP send_message executor calls the same function, so the two
+        # surfaces cannot render a message differently. See
+        # src/displays/messages.py for the #1793 newline/backslash notes.
+        from .displays.messages import render_message
 
-        success, was_sent = service.vb_client.render(
-            board_array,
+        success, was_sent = render_message(
+            service.vb_client,
+            request.text,
+            rows=dims.rows,
+            cols=dims.cols,
             strategy=transition.strategy,
             step_interval_ms=transition.step_interval_ms,
             step_size=transition.step_size,

--- a/src/displays/messages.py
+++ b/src/displays/messages.py
@@ -1,0 +1,44 @@
+"""Ad-hoc board message rendering — the shared core of ``POST /send-message``.
+
+Issue #1765: the MCP surface needed a ``send_message`` equivalent, and the
+wrap/convert/render core lived only inside the REST handler in
+``src.api_server``. It lives here now; the REST handler and the
+``send_message`` executor (:mod:`src.ops.executors`) both call it, so the
+two surfaces render a message identically: word-wrap to the board's tile
+width, honor real newlines (issue #1793), and keep full character/color
+marker support (``{red}``, ``{63}``).
+
+Backslashes are deliberately left alone: a JSON body can carry a real
+newline, so rewriting a literal ``\\n`` here would only corrupt legitimate
+text like ``C:\\new``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.text_to_board import text_to_board_array, wrap_message_text
+
+
+def render_message(
+    client: Any,
+    text: str,
+    *,
+    rows: int,
+    cols: int,
+    strategy: str,
+    step_interval_ms: int,
+    step_size: int,
+) -> tuple[bool, bool]:
+    """Wrap ``text`` to a ``rows``×``cols`` grid and render it through ``client``.
+
+    Returns the client's ``(success, was_sent)`` pair unchanged.
+    """
+    wrapped = wrap_message_text(text, rows=rows, cols=cols)
+    board_array = text_to_board_array(wrapped, rows=rows, cols=cols)
+    return client.render(
+        board_array,
+        strategy=strategy,
+        step_interval_ms=step_interval_ms,
+        step_size=step_size,
+    )

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -572,6 +572,91 @@ def _build_mcp_server() -> Any:
         except Exception as exc:
             return _err(str(exc))
 
+    @mcp.tool()
+    def preview_saved_page(page_id: str, board_id: str | None = None) -> dict[str, Any]:
+        """Render a SAVED page exactly as the display engine would send it.
+
+        Complements render_page_preview(), which renders unsaved template
+        lines: use this one to verify an existing page — with its stored
+        line_metadata (alignment, wrap) applied — before set_active_page().
+        Read-only; nothing is sent to the board.
+
+        Args:
+            page_id: The page identifier (from list_pages()).
+            board_id: Optional board to check the page against (from the boards
+                      list in get_settings_summary()). Adds fits_board and
+                      board_warnings to the response; rendering itself always
+                      uses the page's own device geometry.
+
+        Returns: {page_id, name, device_type, rendered, rows, line_metadata,
+        and — when board_id is given — fits_board, board_warnings}.
+        """
+        try:
+            from .pages.service import check_ref_board_compatibility, get_page_service
+
+            svc = get_page_service()
+            page = svc.get_page(page_id)
+            if page is None:
+                return _err(f"Page '{page_id}' not found.")
+            result = svc.preview_page(page_id, force_refresh=True)
+            if result is None:
+                return _err(f"Page '{page_id}' not found.")
+            if not result.available:
+                return _err(result.error or "Page rendering failed.")
+
+            out: dict[str, Any] = {
+                "page_id": page_id,
+                "name": page.name,
+                "device_type": page.device_type,
+                "rendered": result.formatted,
+                "rows": result.formatted.split("\n"),
+                "line_metadata": ([m.model_dump() for m in page.line_metadata] if page.line_metadata else None),
+            }
+            if board_id is not None:
+                compat = check_ref_board_compatibility(page_id, board_id)
+                out["board_id"] = board_id
+                out["fits_board"] = compat.ok
+                out["board_warnings"] = compat.warnings
+                if not compat.ok:
+                    out["board_error"] = compat.error
+            return out
+        except Exception as exc:
+            return _err(str(exc))
+
+    @mcp.tool()
+    def validate_template(template: list[str] | str, device_type: str = "flagship") -> dict[str, Any]:
+        """Check template syntax without rendering, saving, or touching the board.
+
+        Catches malformed {{...}} references, unknown plugins/variables,
+        formula errors ({{= ... }}), and unknown filters — cheaper than
+        render_page_preview() when you only need a syntax verdict.
+
+        Args:
+            template: Template string or list of template lines.
+            device_type: Which board type's width to validate against —
+                         'flagship' (22 cols), 'note' (15 cols).
+
+        Returns: {valid: bool, errors: [{line, column, message}], device_type}.
+        """
+        try:
+            from .devices import resolve_dimensions
+            from .templates.engine import get_template_engine
+
+            try:
+                cols = resolve_dimensions(device_type).cols
+            except Exception:
+                return _err(f"Unknown device_type: {device_type}")
+
+            text = "\n".join(template) if isinstance(template, list) else template
+            errors = get_template_engine().validate_template(text, cols=cols)
+            return {
+                "valid": len(errors) == 0,
+                "errors": [{"line": e.line, "column": e.column, "message": e.message} for e in errors],
+                "device_type": device_type,
+            }
+        except Exception as exc:
+            return _err(str(exc))
+
     # -----------------------------------------------------------------------
     # Schedule tools
     # -----------------------------------------------------------------------
@@ -887,6 +972,160 @@ def _build_mcp_server() -> Any:
                       list in get_settings_summary()). Omitted = the primary board.
         """
         return ops_executors.set_schedule_mode(enabled, board_id=board_id)
+
+    @mcp.tool()
+    def get_active_page(board_id: str | None = None) -> dict[str, Any]:
+        """What a board is CONFIGURED to show right now, fully resolved.
+
+        Resolves schedule mode (when enabled for the board) and collections
+        down to the concrete page. Distinct from get_board_content(), which
+        reports what was last physically sent to the flaps.
+
+        Args:
+            board_id: Board to inspect on a multi-board install (from the boards
+                      list in get_settings_summary()). Omitted = the primary board.
+
+        Returns: {board_id, schedule_enabled, source ('schedule' or 'manual'),
+        active_ref (the stored page/collection id), resolved_page_id (after
+        collection resolution), page (summary of the resolved page, or null)}.
+        """
+        try:
+            from .collections.models import is_collection_id
+            from .settings.service import get_settings_service
+
+            svc = get_settings_service()
+            if board_id is not None:
+                boards = svc.get_board_settings().boards or []
+                if not any(isinstance(b, dict) and b.get("id") == board_id for b in boards):
+                    return _err(f"Board not found: {board_id}")
+
+            # Mirrors GET /pages/current-display: schedule mode owns the
+            # answer when enabled; otherwise the manual per-board selection.
+            schedule_enabled = bool(svc.is_schedule_enabled(board_id))
+            if schedule_enabled:
+                from .schedules.service import get_schedule_service
+                from .time_service import get_time_service
+
+                now = get_time_service().get_current_time()
+                active_ref = get_schedule_service().get_active_page_id(
+                    now.time(), now.strftime("%A").lower(), board_id=board_id
+                )
+                source = "schedule"
+            else:
+                active_ref = svc.get_active_page_id(board_id)
+                source = "manual"
+
+            resolved_page_id = active_ref
+            if active_ref and is_collection_id(active_ref):
+                from .collections.service import get_collection_service
+
+                resolved_page_id = get_collection_service().resolve_page_id(active_ref)
+
+            page_summary = None
+            if resolved_page_id:
+                from .pages.service import get_page_service
+
+                page = get_page_service().get_page(resolved_page_id)
+                if page is not None:
+                    page_summary = {
+                        "id": page.id,
+                        "name": page.name,
+                        "type": page.type,
+                        "device_type": page.device_type,
+                    }
+            return {
+                "board_id": board_id,
+                "schedule_enabled": schedule_enabled,
+                "source": source,
+                "active_ref": active_ref,
+                "resolved_page_id": resolved_page_id,
+                "page": page_summary,
+            }
+        except Exception as exc:
+            return _err(str(exc))
+
+    @mcp.tool()
+    def get_board_content(board_id: str | None = None) -> dict[str, Any]:
+        """What is currently ON a board — the last known flap content. Read-only.
+
+        Served from FiestaBoard's own caches (background poll / last-sent
+        content); never writes to the board and never triggers a live read.
+        Use it to check whether the board matches what get_active_page() says
+        it should be showing. characters and message are null when nothing
+        has been observed or sent yet.
+
+        Args:
+            board_id: Board to read on a multi-board install (from the boards
+                      list in get_settings_summary()). Omitted = the primary
+                      board. Secondary boards are served from their runtime
+                      cache — board-state polling is primary-only.
+
+        Returns: {characters (2-D grid of flap codes or null), message
+        (formatted string or null), rows, cols, source ('polled' or
+        'last_sent' or null), board_id}.
+        """
+        try:
+            # get_service is the DisplayService singleton accessor — the same
+            # seam get_system_status uses; no REST handler is called.
+            from .api_server import _characters_to_message, get_service
+
+            service = get_service()
+            if not service:
+                return _err("Display service not initialized.")
+
+            characters = None
+            source = None
+            if board_id is None:
+                characters = service._polled_characters
+                source = "polled" if characters is not None else None
+                if characters is None and service.vb_client is not None:
+                    characters = getattr(service.vb_client, "_last_characters", None)
+                    source = "last_sent" if characters is not None else None
+            else:
+                from .settings.service import get_settings_service
+
+                boards = get_settings_service().get_board_settings().boards or []
+                if not any(isinstance(b, dict) and b.get("id") == board_id for b in boards):
+                    return _err(f"Board not found: {board_id}")
+                rt = service.get_runtime(board_id)
+                if rt is not None:
+                    characters = rt.polled_characters
+                    source = "polled" if characters is not None else None
+                    if characters is None and rt.client is not None:
+                        characters = getattr(rt.client, "_last_characters", None)
+                        source = "last_sent" if characters is not None else None
+
+            if characters is None:
+                return {"characters": None, "message": None, "rows": 0, "cols": 0, "source": None, "board_id": board_id}
+            return {
+                "characters": _serialize(characters),
+                "message": _characters_to_message(characters),
+                "rows": len(characters),
+                "cols": len(characters[0]) if characters else 0,
+                "source": source,
+                "board_id": board_id,
+            }
+        except Exception as exc:
+            return _err(str(exc))
+
+    @mcp.tool()
+    def send_message(text: str, board_id: str | None = None) -> dict[str, Any]:
+        """Send a one-off text message directly to a board.
+
+        The text is word-wrapped to the board's width; real newlines are
+        honored; single-brace color markers like {red} or {63} render as one
+        colored tile each. This bypasses pages entirely — the message stays
+        up until the active page next changes or the display refreshes.
+
+        A paused board or active silence mode returns status "blocked"
+        (deliberate policy — relay it to the user, don't retry).
+
+        Args:
+            text: The message text to display.
+            board_id: Board to target on a multi-board install (from the boards
+                      list in get_settings_summary()). Omitted = the primary board.
+        """
+        return ops_executors.send_message(text, board_id=board_id)
 
     # -----------------------------------------------------------------------
     # MCP Resources

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -84,6 +84,77 @@ except ImportError:  # pragma: no cover
     )
 
 
+def _boards_summary(settings_service: Any) -> list[dict[str, Any]]:
+    """Per-board roster for ``get_settings_summary`` (#1765).
+
+    An explicit field projection, never the raw board dicts — those carry
+    credentials (host, API keys, note-array tokens) that must not cross the
+    MCP boundary even masked. ``error`` is the #1813 per-board init failure,
+    read defensively off the engine service when one exists.
+    """
+    from .devices import resolve_dimensions
+
+    init_errors: dict[str, str] = {}
+    try:
+        # peek, never create: a read-only summary must not boot the engine.
+        from .api_server import peek_service
+
+        engine = peek_service()
+        maybe = getattr(engine, "board_init_errors", None)
+        if isinstance(maybe, dict):
+            init_errors = maybe
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("get_settings_summary: could not read board init errors: %s", exc)
+
+    boards_out: list[dict[str, Any]] = []
+    try:
+        boards = settings_service.get_board_settings().boards or []
+        primary_id = settings_service.get_primary_board_id()
+    except Exception as exc:
+        logger.debug("get_settings_summary: could not read boards list: %s", exc)
+        return boards_out
+
+    for board in boards:
+        if not isinstance(board, dict) or not board.get("id"):
+            continue
+        bid = board["id"]
+        rows = cols = None
+        try:
+            dims = resolve_dimensions(
+                board.get("device_type") or "flagship",
+                board.get("notes_wide") or 1,
+                board.get("notes_tall") or 1,
+            )
+            rows, cols = dims.rows, dims.cols
+        except Exception as exc:
+            logger.debug("get_settings_summary: could not resolve dims for board %s: %s", bid, exc)
+        try:
+            active_page_id = settings_service.get_active_page_id(board_id=bid)
+        except Exception:
+            active_page_id = None
+        if not isinstance(active_page_id, str):
+            active_page_id = None
+        error = init_errors.get(bid)
+        boards_out.append(
+            {
+                "id": bid,
+                "name": board.get("name", ""),
+                "device_type": board.get("device_type", "flagship"),
+                "rows": rows,
+                "cols": cols,
+                "notes_wide": board.get("notes_wide", 1),
+                "notes_tall": board.get("notes_tall", 1),
+                "primary": bid == primary_id,
+                "enabled": bool(board.get("enabled", True)),
+                "paused": bool(board.get("paused", False)),
+                "schedule_enabled": bool(board.get("schedule_enabled", False)),
+                "active_page_id": active_page_id,
+                "error": error if isinstance(error, str) else None,
+            }
+        )
+    return boards_out
+
+
 def _build_mcp_server() -> Any:
     """Construct and return the MCPServer instance.
 
@@ -117,6 +188,12 @@ def _build_mcp_server() -> Any:
             "  • get_plugin_data(plugin_id) — see the LIVE values a plugin is\n"
             "    currently exposing. Use this when a page renders '???' or wrong\n"
             "    values; it tells you whether the plugin or the template is at fault.\n\n"
+            "MULTI-BOARD\n"
+            "  An install can drive several boards. get_settings_summary() returns\n"
+            "  a boards list (id, name, device_type, rows/cols, active page, error).\n"
+            "  Board-targeting tools take an optional board_id — omitted always\n"
+            "  means the primary board. When working against a specific board, use\n"
+            "  ITS device_type and dimensions, not the primary's.\n\n"
             # Board-dimensions and template-syntax teaching is GENERATED from
             # the defining modules (#1764) — the previous hardcoded copy had
             # rotted (nonexistent |upper/|lower filters, a 63–71 color range,
@@ -736,7 +813,15 @@ def _build_mcp_server() -> Any:
     def get_settings_summary() -> dict[str, Any]:
         """Get a summary of current FiestaBoard settings (non-sensitive fields only).
 
-        Returns display, output, location, and schedule settings.
+        Returns display, location, and output settings, plus:
+        - schedule: {enabled} — whether schedule mode drives the primary board
+        - active_page_id: the primary board's manually-selected page (or null)
+        - boards: one entry per configured board with id, name, device_type,
+          rows/cols, notes_wide/notes_tall, primary, enabled, paused,
+          schedule_enabled, active_page_id, and error (why the board failed to
+          initialize, or null). Use a board's id as the board_id argument to
+          board-targeting tools, and its rows/cols to size templates for it.
+
         AI provider credentials and board API keys are intentionally excluded.
         """
         try:
@@ -757,36 +842,51 @@ def _build_mcp_server() -> Any:
                         key,
                         exc,
                     )
+
+            # Schedule mode + active page (#1765): the troubleshoot prompt
+            # walks both, and until now no tool returned them.
+            try:
+                summary["schedule"] = {"enabled": bool(svc.is_schedule_enabled())}
+                summary["active_page_id"] = svc.get_active_page_id()
+            except Exception as exc:
+                logger.debug("get_settings_summary: could not fetch schedule/active page: %s", exc)
+
+            summary["boards"] = _boards_summary(svc)
             return summary
         except Exception as exc:
             return _err(str(exc))
 
     @mcp.tool()
-    async def set_active_page(page_id: str) -> dict[str, Any]:
+    async def set_active_page(page_id: str, board_id: str | None = None) -> dict[str, Any]:
         """Set which page is currently shown on the FiestaBoard display.
 
         This immediately changes what's visible on the board.
 
         Args:
             page_id: The page or collection ID to display (from list_pages() or list_collections()).
+            board_id: Board to target on a multi-board install (from the boards
+                      list in get_settings_summary()). Omitted = the primary board.
         """
         # The executor delegates to the REST handler rather than
         # reimplementing it (#1559): selecting a page validates the ref,
         # enforces page<->board size compatibility, dismisses active plugin
         # triggers (#856), and renders to the board.
-        return await ops_executors.set_active_page(page_id)
+        return await ops_executors.set_active_page(page_id, board_id=board_id)
 
     @mcp.tool()
-    def set_schedule_mode(enabled: bool) -> dict[str, Any]:
+    def set_schedule_mode(enabled: bool, board_id: str | None = None) -> dict[str, Any]:
         """Enable or disable schedule mode.
 
         When enabled, FiestaBoard automatically switches pages according to
         the schedule you've configured. When disabled, it shows a fixed page.
+        Schedule mode is per-board on a multi-board install.
 
         Args:
             enabled: True to enable schedule-based display, False to disable.
+            board_id: Board to target on a multi-board install (from the boards
+                      list in get_settings_summary()). Omitted = the primary board.
         """
-        return ops_executors.set_schedule_mode(enabled)
+        return ops_executors.set_schedule_mode(enabled, board_id=board_id)
 
     # -----------------------------------------------------------------------
     # MCP Resources

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -47,6 +47,8 @@ including why claude.ai web Connectors can't reach a LAN host.
 
 from __future__ import annotations
 
+import functools
+import inspect
 import logging
 from typing import Annotated, Any
 
@@ -60,7 +62,6 @@ from pydantic import Field
 # get real JSON instead of a JSON string that has to be parsed again.
 from .ops import executors as ops_executors
 from .ops import teaching as ops_teaching
-from .ops.results import err as _err
 from .ops.results import serialize as _serialize
 
 logger = logging.getLogger(__name__)
@@ -73,11 +74,13 @@ logger = logging.getLogger(__name__)
 
 try:
     from mcp.server import MCPServer  # type: ignore[import-untyped]
+    from mcp.server.mcpserver.exceptions import ToolError  # type: ignore[import-untyped]
 
     _MCP_AVAILABLE = True
 except ImportError:  # pragma: no cover
     _MCP_AVAILABLE = False
     MCPServer = None  # type: ignore[assignment,misc]
+    ToolError = None  # type: ignore[assignment,misc]
     logger.warning(
         "mcp package not installed — FiestaBoard MCP server is disabled. "
         "Add `mcp>=2.0.0` to requirements.txt and rebuild the container."
@@ -155,6 +158,35 @@ def _boards_summary(settings_service: Any) -> list[dict[str, Any]]:
     return boards_out
 
 
+def _tool_failure(tool_name: str, exc: Exception) -> Exception:
+    """Map an unexpected exception to a concise protocol error (#1765).
+
+    The full traceback goes to the server log; the wire gets a one-line
+    message naming the tool and the exception class but no internal detail
+    — raw exception text routinely carries paths, config values, and other
+    things an MCP client has no business seeing.
+    """
+    logger.exception("MCP tool %s failed", tool_name)
+    return ToolError(f"{tool_name} failed unexpectedly ({type(exc).__name__}); details are in the server log.")
+
+
+def _raise_error_envelope(result: Any) -> Any:
+    """Turn an executor ``{"status": "error"}`` envelope into a ToolError.
+
+    The ops executors never raise (their envelope contract predates #1765
+    and the chat grammar still consumes it); at the MCP boundary the
+    envelope becomes a raised ToolError so the framework answers with
+    ``CallToolResult(isError=True)`` carrying the executor's own
+    domain-worded message. Success and policy-"blocked" payloads pass
+    through unchanged.
+    """
+    if isinstance(result, dict) and result.get("status") == "error":
+        message = str(result.get("error") or "The operation failed.")
+        logger.info("MCP tool error: %s", message)
+        raise ToolError(message)
+    return result
+
+
 def _build_mcp_server() -> Any:
     """Construct and return the MCPServer instance.
 
@@ -222,6 +254,38 @@ def _build_mcp_server() -> Any:
         ),
     )
 
+    # Every tool registers through this wrapper: the #1765 error contract in
+    # one place. Executor error envelopes become raised ToolErrors (protocol
+    # isError=True with the domain message); unexpected exceptions are logged
+    # server-side with their traceback and mapped to a concise message. A
+    # ToolError raised by a tool body passes through untouched.
+    def _tool(fn: Any) -> Any:
+        if inspect.iscoroutinefunction(fn):
+
+            @functools.wraps(fn)
+            async def wrapper(*args: Any, **kwargs: Any) -> Any:
+                try:
+                    result = await fn(*args, **kwargs)
+                except ToolError:
+                    raise
+                except Exception as exc:
+                    raise _tool_failure(fn.__name__, exc) from exc
+                return _raise_error_envelope(result)
+
+        else:
+
+            @functools.wraps(fn)
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
+                try:
+                    result = fn(*args, **kwargs)
+                except ToolError:
+                    raise
+                except Exception as exc:
+                    raise _tool_failure(fn.__name__, exc) from exc
+                return _raise_error_envelope(result)
+
+        return mcp.tool()(wrapper)
+
     # -----------------------------------------------------------------------
     # Plugin tools
     #
@@ -237,7 +301,7 @@ def _build_mcp_server() -> Any:
     # what keeps mcp_server importable without api_server.
     # -----------------------------------------------------------------------
 
-    @mcp.tool()
+    @_tool
     def list_installed_plugins() -> list[dict[str, Any]] | dict[str, Any]:
         """List all installed FiestaBoard plugins with their status and config schema.
 
@@ -250,22 +314,19 @@ def _build_mcp_server() -> Any:
         - settings_schema: JSON Schema describing configurable fields
         - config: current configuration (sensitive values masked as '***')
         """
-        try:
-            from .config_manager import get_config_manager
-            from .plugins import get_plugin_registry
+        from .config_manager import get_config_manager
+        from .plugins import get_plugin_registry
 
-            registry = get_plugin_registry()
-            cm = get_config_manager()
-            plugins = registry.list_plugins()
-            for p in plugins:
-                cfg = cm.get_plugin_config(p["id"])
-                p["config"] = cm._mask_sensitive(cfg) if cfg else {}
-                p["configured"] = bool(cfg)
-            return _serialize(plugins)
-        except Exception as exc:
-            return _err(str(exc))
+        registry = get_plugin_registry()
+        cm = get_config_manager()
+        plugins = registry.list_plugins()
+        for p in plugins:
+            cfg = cm.get_plugin_config(p["id"])
+            p["config"] = cm._mask_sensitive(cfg) if cfg else {}
+            p["configured"] = bool(cfg)
+        return _serialize(plugins)
 
-    @mcp.tool()
+    @_tool
     def list_registry_plugins() -> list[dict[str, Any]] | dict[str, Any]:
         """List all plugins available to install from the FiestaBoard registry.
 
@@ -274,15 +335,12 @@ def _build_mcp_server() -> Any:
         - name, description, category
         - installed: true if already installed
         """
-        try:
-            from .plugins import get_plugin_registry
+        from .plugins import get_plugin_registry
 
-            registry = get_plugin_registry()
-            return _serialize(registry.get_registry_entries())
-        except Exception as exc:
-            return _err(str(exc))
+        registry = get_plugin_registry()
+        return _serialize(registry.get_registry_entries())
 
-    @mcp.tool()
+    @_tool
     async def install_plugin(plugin_id: str, auto_enable: bool = True) -> dict[str, Any]:
         """Install a plugin from the official FiestaBoard registry and optionally enable it.
 
@@ -295,7 +353,7 @@ def _build_mcp_server() -> Any:
         """
         return await ops_executors.install_plugin(plugin_id, auto_enable=auto_enable)
 
-    @mcp.tool()
+    @_tool
     async def enable_plugin(plugin_id: str) -> dict[str, Any]:
         """Enable an installed but currently-disabled plugin.
 
@@ -307,7 +365,7 @@ def _build_mcp_server() -> Any:
         """
         return ops_executors.enable_plugin(plugin_id)
 
-    @mcp.tool()
+    @_tool
     async def disable_plugin(plugin_id: str) -> dict[str, Any]:
         """Disable an installed plugin without uninstalling it.
 
@@ -318,7 +376,7 @@ def _build_mcp_server() -> Any:
         """
         return ops_executors.disable_plugin(plugin_id)
 
-    @mcp.tool()
+    @_tool
     async def uninstall_plugin(plugin_id: str) -> dict[str, Any]:
         """Permanently remove an installed plugin.
 
@@ -331,7 +389,7 @@ def _build_mcp_server() -> Any:
         """
         return ops_executors.uninstall_plugin(plugin_id)
 
-    @mcp.tool()
+    @_tool
     async def configure_plugin(plugin_id: str, config: dict[str, Any]) -> dict[str, Any]:
         """Update configuration settings for an installed plugin.
 
@@ -352,7 +410,7 @@ def _build_mcp_server() -> Any:
         """
         return ops_executors.configure_plugin(plugin_id, config)
 
-    @mcp.tool()
+    @_tool
     async def update_plugin(plugin_id: str) -> dict[str, Any]:
         """Update an installed plugin to its latest version from its git remote.
 
@@ -365,7 +423,7 @@ def _build_mcp_server() -> Any:
         # PluginService.apply_update — the shared, guarded path.
         return await ops_executors.update_plugin(plugin_id)
 
-    @mcp.tool()
+    @_tool
     def get_template_variables() -> dict[str, Any]:
         """Get all template variables available from enabled plugins.
 
@@ -374,18 +432,15 @@ def _build_mcp_server() -> Any:
 
         Example: {{weather.temperature}}, {{stocks.price}}, {{date_time.time_12h}}
         """
-        try:
-            from .plugins import get_plugin_registry
+        from .plugins import get_plugin_registry
 
-            registry = get_plugin_registry()
-            # #1739: get_all_variables() returns {plugin: [name, ...]}, not the
-            # nested metadata this tool documents. GET /templates/variables
-            # already uses the *_with_metadata variant; this call site drifted.
-            return _serialize(registry.get_all_variables_with_metadata())
-        except Exception as exc:
-            return _err(str(exc))
+        registry = get_plugin_registry()
+        # #1739: get_all_variables() returns {plugin: [name, ...]}, not the
+        # nested metadata this tool documents. GET /templates/variables
+        # already uses the *_with_metadata variant; this call site drifted.
+        return _serialize(registry.get_all_variables_with_metadata())
 
-    @mcp.tool()
+    @_tool
     def get_plugin_data(plugin_id: str) -> dict[str, Any]:
         """Fetch the CURRENT live values a plugin is exposing to template variables.
 
@@ -401,24 +456,21 @@ def _build_mcp_server() -> Any:
         'error' explains why; no exception is raised. Cached values may be
         returned if the plugin's refresh interval hasn't elapsed.
         """
-        try:
-            from .plugins import get_plugin_registry
+        from .plugins import get_plugin_registry
 
-            registry = get_plugin_registry()
-            result = registry.fetch_plugin_data(plugin_id)
-            return {
-                "available": result.available,
-                "data": _serialize(result.data),
-                "error": result.error,
-            }
-        except Exception as exc:
-            return _err(str(exc))
+        registry = get_plugin_registry()
+        result = registry.fetch_plugin_data(plugin_id)
+        return {
+            "available": result.available,
+            "data": _serialize(result.data),
+            "error": result.error,
+        }
 
     # -----------------------------------------------------------------------
     # Page tools
     # -----------------------------------------------------------------------
 
-    @mcp.tool()
+    @_tool
     def list_pages() -> list[dict[str, Any]] | dict[str, Any]:
         """List all display pages on this FiestaBoard.
 
@@ -429,15 +481,12 @@ def _build_mcp_server() -> Any:
         - device_type: 'flagship' or 'note'
         - duration_seconds: how long to show the page in time-mode collections
         """
-        try:
-            from .pages.service import get_page_service
+        from .pages.service import get_page_service
 
-            svc = get_page_service()
-            return _serialize(svc.list_pages())
-        except Exception as exc:
-            return _err(str(exc))
+        svc = get_page_service()
+        return _serialize(svc.list_pages())
 
-    @mcp.tool()
+    @_tool
     def get_page(page_id: str) -> dict[str, Any]:
         """Get full details of a specific page including its template content.
 
@@ -448,18 +497,15 @@ def _build_mcp_server() -> Any:
         line can contain {{plugin.variable}} references and {{color}} tokens
         like {{red}}, {{green}}, {{white}} etc.
         """
-        try:
-            from .pages.service import get_page_service
+        from .pages.service import get_page_service
 
-            svc = get_page_service()
-            page = svc.get_page(page_id)
-            if page is None:
-                return _err(f"Page '{page_id}' not found.")
-            return _serialize(page)
-        except Exception as exc:
-            return _err(str(exc))
+        svc = get_page_service()
+        page = svc.get_page(page_id)
+        if page is None:
+            raise ToolError(f"Page '{page_id}' not found.")
+        return _serialize(page)
 
-    @mcp.tool()
+    @_tool
     def create_page(
         name: str,
         template_lines: list[str],
@@ -493,7 +539,7 @@ def _build_mcp_server() -> Any:
             duration_seconds=duration_seconds,
         )
 
-    @mcp.tool()
+    @_tool
     def update_page(
         page_id: str,
         name: str | None = None,
@@ -515,7 +561,7 @@ def _build_mcp_server() -> Any:
             duration_seconds=duration_seconds,
         )
 
-    @mcp.tool()
+    @_tool
     def delete_page(page_id: str) -> dict[str, Any]:
         """Delete a page permanently.
 
@@ -527,7 +573,7 @@ def _build_mcp_server() -> Any:
         """
         return ops_executors.delete_page(page_id)
 
-    @mcp.tool()
+    @_tool
     def render_page_preview(
         template_lines: list[str],
         device_type: str = "flagship",
@@ -554,25 +600,22 @@ def _build_mcp_server() -> Any:
         plugin that's disabled/unconfigured. Lines longer than the board width
         will appear truncated in the output, matching real-device behavior.
         """
-        try:
-            from .templates.engine import get_template_engine
+        from .templates.engine import get_template_engine
 
-            engine = get_template_engine()
-            context = engine._build_context()
-            rendered = engine.render_lines(
-                template_lines,
-                context=context,
-                device_type=device_type,
-            )
-            return {
-                "rendered": rendered,
-                "device_type": device_type,
-                "context_plugins": sorted(context.keys()),
-            }
-        except Exception as exc:
-            return _err(str(exc))
+        engine = get_template_engine()
+        context = engine._build_context()
+        rendered = engine.render_lines(
+            template_lines,
+            context=context,
+            device_type=device_type,
+        )
+        return {
+            "rendered": rendered,
+            "device_type": device_type,
+            "context_plugins": sorted(context.keys()),
+        }
 
-    @mcp.tool()
+    @_tool
     def preview_saved_page(page_id: str, board_id: str | None = None) -> dict[str, Any]:
         """Render a SAVED page exactly as the display engine would send it.
 
@@ -591,39 +634,36 @@ def _build_mcp_server() -> Any:
         Returns: {page_id, name, device_type, rendered, rows, line_metadata,
         and — when board_id is given — fits_board, board_warnings}.
         """
-        try:
-            from .pages.service import check_ref_board_compatibility, get_page_service
+        from .pages.service import check_ref_board_compatibility, get_page_service
 
-            svc = get_page_service()
-            page = svc.get_page(page_id)
-            if page is None:
-                return _err(f"Page '{page_id}' not found.")
-            result = svc.preview_page(page_id, force_refresh=True)
-            if result is None:
-                return _err(f"Page '{page_id}' not found.")
-            if not result.available:
-                return _err(result.error or "Page rendering failed.")
+        svc = get_page_service()
+        page = svc.get_page(page_id)
+        if page is None:
+            raise ToolError(f"Page '{page_id}' not found.")
+        result = svc.preview_page(page_id, force_refresh=True)
+        if result is None:
+            raise ToolError(f"Page '{page_id}' not found.")
+        if not result.available:
+            raise ToolError(result.error or "Page rendering failed.")
 
-            out: dict[str, Any] = {
-                "page_id": page_id,
-                "name": page.name,
-                "device_type": page.device_type,
-                "rendered": result.formatted,
-                "rows": result.formatted.split("\n"),
-                "line_metadata": ([m.model_dump() for m in page.line_metadata] if page.line_metadata else None),
-            }
-            if board_id is not None:
-                compat = check_ref_board_compatibility(page_id, board_id)
-                out["board_id"] = board_id
-                out["fits_board"] = compat.ok
-                out["board_warnings"] = compat.warnings
-                if not compat.ok:
-                    out["board_error"] = compat.error
-            return out
-        except Exception as exc:
-            return _err(str(exc))
+        out: dict[str, Any] = {
+            "page_id": page_id,
+            "name": page.name,
+            "device_type": page.device_type,
+            "rendered": result.formatted,
+            "rows": result.formatted.split("\n"),
+            "line_metadata": ([m.model_dump() for m in page.line_metadata] if page.line_metadata else None),
+        }
+        if board_id is not None:
+            compat = check_ref_board_compatibility(page_id, board_id)
+            out["board_id"] = board_id
+            out["fits_board"] = compat.ok
+            out["board_warnings"] = compat.warnings
+            if not compat.ok:
+                out["board_error"] = compat.error
+        return out
 
-    @mcp.tool()
+    @_tool
     def validate_template(template: list[str] | str, device_type: str = "flagship") -> dict[str, Any]:
         """Check template syntax without rendering, saving, or touching the board.
 
@@ -638,30 +678,27 @@ def _build_mcp_server() -> Any:
 
         Returns: {valid: bool, errors: [{line, column, message}], device_type}.
         """
+        from .devices import resolve_dimensions
+        from .templates.engine import get_template_engine
+
         try:
-            from .devices import resolve_dimensions
-            from .templates.engine import get_template_engine
-
-            try:
-                cols = resolve_dimensions(device_type).cols
-            except Exception:
-                return _err(f"Unknown device_type: {device_type}")
-
-            text = "\n".join(template) if isinstance(template, list) else template
-            errors = get_template_engine().validate_template(text, cols=cols)
-            return {
-                "valid": len(errors) == 0,
-                "errors": [{"line": e.line, "column": e.column, "message": e.message} for e in errors],
-                "device_type": device_type,
-            }
+            cols = resolve_dimensions(device_type).cols
         except Exception as exc:
-            return _err(str(exc))
+            raise ToolError(f"Unknown device_type: {device_type}") from exc
+
+        text = "\n".join(template) if isinstance(template, list) else template
+        errors = get_template_engine().validate_template(text, cols=cols)
+        return {
+            "valid": len(errors) == 0,
+            "errors": [{"line": e.line, "column": e.column, "message": e.message} for e in errors],
+            "device_type": device_type,
+        }
 
     # -----------------------------------------------------------------------
     # Schedule tools
     # -----------------------------------------------------------------------
 
-    @mcp.tool()
+    @_tool
     def list_schedules() -> list[dict[str, Any]] | dict[str, Any]:
         """List all scheduled time slots for page display.
 
@@ -672,15 +709,12 @@ def _build_mcp_server() -> Any:
         - day_pattern: 'all', 'weekdays', 'weekends', or 'custom'
         - enabled: whether the schedule entry is active
         """
-        try:
-            from .schedules.service import get_schedule_service
+        from .schedules.service import get_schedule_service
 
-            svc = get_schedule_service()
-            return _serialize(svc.list_schedules())
-        except Exception as exc:
-            return _err(str(exc))
+        svc = get_schedule_service()
+        return _serialize(svc.list_schedules())
 
-    @mcp.tool()
+    @_tool
     def create_schedule(
         page_id: str,
         start_time: str,
@@ -708,7 +742,7 @@ def _build_mcp_server() -> Any:
             enabled=enabled,
         )
 
-    @mcp.tool()
+    @_tool
     def update_schedule(
         schedule_id: str,
         page_id: str | None = None,
@@ -747,7 +781,7 @@ def _build_mcp_server() -> Any:
             clear_custom_days=clear_custom_days,
         )
 
-    @mcp.tool()
+    @_tool
     def delete_schedule(schedule_id: str) -> dict[str, Any]:
         """Delete a schedule entry permanently.
 
@@ -760,7 +794,7 @@ def _build_mcp_server() -> Any:
     # Collection tools
     # -----------------------------------------------------------------------
 
-    @mcp.tool()
+    @_tool
     def list_collections() -> list[dict[str, Any]] | dict[str, Any]:
         """List all collections (ordered page groups with a selection mode).
 
@@ -770,15 +804,12 @@ def _build_mcp_server() -> Any:
         - selection_mode: "time" (rotate on interval) or "variable" (pick by rule)
         - time / variable: mode-specific config block
         """
-        try:
-            from .collections.service import get_collection_service
+        from .collections.service import get_collection_service
 
-            svc = get_collection_service()
-            return _serialize(svc.list_collections())
-        except Exception as exc:
-            return _err(str(exc))
+        svc = get_collection_service()
+        return _serialize(svc.list_collections())
 
-    @mcp.tool()
+    @_tool
     def create_collection(
         name: str,
         page_ids: list[str],
@@ -819,7 +850,7 @@ def _build_mcp_server() -> Any:
             poll_seconds=poll_seconds,
         )
 
-    @mcp.tool()
+    @_tool
     def update_collection(
         collection_id: str,
         name: str | None = None,
@@ -857,7 +888,7 @@ def _build_mcp_server() -> Any:
             poll_seconds=poll_seconds,
         )
 
-    @mcp.tool()
+    @_tool
     def delete_collection(collection_id: str) -> dict[str, Any]:
         """Delete a collection permanently.
 
@@ -870,31 +901,28 @@ def _build_mcp_server() -> Any:
     # System tools
     # -----------------------------------------------------------------------
 
-    @mcp.tool()
+    @_tool
     def get_system_status() -> dict[str, Any]:
         """Get the current status of the FiestaBoard system.
 
         Returns version, whether the display service is running, plugin system
         status, and the number of installed/enabled plugins.
         """
-        try:
-            from .api_server import __version__, _service_running, get_service
-            from .plugins import get_plugin_registry
+        from .api_server import __version__, _service_running, get_service
+        from .plugins import get_plugin_registry
 
-            registry = get_plugin_registry()
-            plugins = registry.list_plugins()
-            service = get_service()
-            return {
-                "version": __version__,
-                "service_running": _service_running and service is not None,
-                "plugin_system_available": True,
-                "plugins_installed": len(plugins),
-                "plugins_enabled": sum(1 for p in plugins if p.get("enabled")),
-            }
-        except Exception as exc:
-            return _err(str(exc))
+        registry = get_plugin_registry()
+        plugins = registry.list_plugins()
+        service = get_service()
+        return {
+            "version": __version__,
+            "service_running": _service_running and service is not None,
+            "plugin_system_available": True,
+            "plugins_installed": len(plugins),
+            "plugins_enabled": sum(1 for p in plugins if p.get("enabled")),
+        }
 
-    @mcp.tool()
+    @_tool
     def get_settings_summary() -> dict[str, Any]:
         """Get a summary of current FiestaBoard settings (non-sensitive fields only).
 
@@ -909,39 +937,36 @@ def _build_mcp_server() -> Any:
 
         AI provider credentials and board API keys are intentionally excluded.
         """
-        try:
-            from .settings.service import get_settings_service
+        from .settings.service import get_settings_service
 
-            svc = get_settings_service()
-            summary: dict[str, Any] = {}
-            for key, fetch in (
-                ("display", svc.get_display_settings),
-                ("location", svc.get_location_settings),
-                ("output", svc.get_output_settings),
-            ):
-                try:
-                    summary[key] = _serialize(fetch())
-                except Exception as exc:
-                    logger.debug(
-                        "get_settings_summary: could not fetch %s settings: %s",
-                        key,
-                        exc,
-                    )
-
-            # Schedule mode + active page (#1765): the troubleshoot prompt
-            # walks both, and until now no tool returned them.
+        svc = get_settings_service()
+        summary: dict[str, Any] = {}
+        for key, fetch in (
+            ("display", svc.get_display_settings),
+            ("location", svc.get_location_settings),
+            ("output", svc.get_output_settings),
+        ):
             try:
-                summary["schedule"] = {"enabled": bool(svc.is_schedule_enabled())}
-                summary["active_page_id"] = svc.get_active_page_id()
+                summary[key] = _serialize(fetch())
             except Exception as exc:
-                logger.debug("get_settings_summary: could not fetch schedule/active page: %s", exc)
+                logger.debug(
+                    "get_settings_summary: could not fetch %s settings: %s",
+                    key,
+                    exc,
+                )
 
-            summary["boards"] = _boards_summary(svc)
-            return summary
+        # Schedule mode + active page (#1765): the troubleshoot prompt
+        # walks both, and until now no tool returned them.
+        try:
+            summary["schedule"] = {"enabled": bool(svc.is_schedule_enabled())}
+            summary["active_page_id"] = svc.get_active_page_id()
         except Exception as exc:
-            return _err(str(exc))
+            logger.debug("get_settings_summary: could not fetch schedule/active page: %s", exc)
 
-    @mcp.tool()
+        summary["boards"] = _boards_summary(svc)
+        return summary
+
+    @_tool
     async def set_active_page(page_id: str, board_id: str | None = None) -> dict[str, Any]:
         """Set which page is currently shown on the FiestaBoard display.
 
@@ -958,7 +983,7 @@ def _build_mcp_server() -> Any:
         # triggers (#856), and renders to the board.
         return await ops_executors.set_active_page(page_id, board_id=board_id)
 
-    @mcp.tool()
+    @_tool
     def set_schedule_mode(enabled: bool, board_id: str | None = None) -> dict[str, Any]:
         """Enable or disable schedule mode.
 
@@ -973,7 +998,7 @@ def _build_mcp_server() -> Any:
         """
         return ops_executors.set_schedule_mode(enabled, board_id=board_id)
 
-    @mcp.tool()
+    @_tool
     def get_active_page(board_id: str | None = None) -> dict[str, Any]:
         """What a board is CONFIGURED to show right now, fully resolved.
 
@@ -989,62 +1014,59 @@ def _build_mcp_server() -> Any:
         active_ref (the stored page/collection id), resolved_page_id (after
         collection resolution), page (summary of the resolved page, or null)}.
         """
-        try:
-            from .collections.models import is_collection_id
-            from .settings.service import get_settings_service
+        from .collections.models import is_collection_id
+        from .settings.service import get_settings_service
 
-            svc = get_settings_service()
-            if board_id is not None:
-                boards = svc.get_board_settings().boards or []
-                if not any(isinstance(b, dict) and b.get("id") == board_id for b in boards):
-                    return _err(f"Board not found: {board_id}")
+        svc = get_settings_service()
+        if board_id is not None:
+            boards = svc.get_board_settings().boards or []
+            if not any(isinstance(b, dict) and b.get("id") == board_id for b in boards):
+                raise ToolError(f"Board not found: {board_id}")
 
-            # Mirrors GET /pages/current-display: schedule mode owns the
-            # answer when enabled; otherwise the manual per-board selection.
-            schedule_enabled = bool(svc.is_schedule_enabled(board_id))
-            if schedule_enabled:
-                from .schedules.service import get_schedule_service
-                from .time_service import get_time_service
+        # Mirrors GET /pages/current-display: schedule mode owns the
+        # answer when enabled; otherwise the manual per-board selection.
+        schedule_enabled = bool(svc.is_schedule_enabled(board_id))
+        if schedule_enabled:
+            from .schedules.service import get_schedule_service
+            from .time_service import get_time_service
 
-                now = get_time_service().get_current_time()
-                active_ref = get_schedule_service().get_active_page_id(
-                    now.time(), now.strftime("%A").lower(), board_id=board_id
-                )
-                source = "schedule"
-            else:
-                active_ref = svc.get_active_page_id(board_id)
-                source = "manual"
+            now = get_time_service().get_current_time()
+            active_ref = get_schedule_service().get_active_page_id(
+                now.time(), now.strftime("%A").lower(), board_id=board_id
+            )
+            source = "schedule"
+        else:
+            active_ref = svc.get_active_page_id(board_id)
+            source = "manual"
 
-            resolved_page_id = active_ref
-            if active_ref and is_collection_id(active_ref):
-                from .collections.service import get_collection_service
+        resolved_page_id = active_ref
+        if active_ref and is_collection_id(active_ref):
+            from .collections.service import get_collection_service
 
-                resolved_page_id = get_collection_service().resolve_page_id(active_ref)
+            resolved_page_id = get_collection_service().resolve_page_id(active_ref)
 
-            page_summary = None
-            if resolved_page_id:
-                from .pages.service import get_page_service
+        page_summary = None
+        if resolved_page_id:
+            from .pages.service import get_page_service
 
-                page = get_page_service().get_page(resolved_page_id)
-                if page is not None:
-                    page_summary = {
-                        "id": page.id,
-                        "name": page.name,
-                        "type": page.type,
-                        "device_type": page.device_type,
-                    }
-            return {
-                "board_id": board_id,
-                "schedule_enabled": schedule_enabled,
-                "source": source,
-                "active_ref": active_ref,
-                "resolved_page_id": resolved_page_id,
-                "page": page_summary,
-            }
-        except Exception as exc:
-            return _err(str(exc))
+            page = get_page_service().get_page(resolved_page_id)
+            if page is not None:
+                page_summary = {
+                    "id": page.id,
+                    "name": page.name,
+                    "type": page.type,
+                    "device_type": page.device_type,
+                }
+        return {
+            "board_id": board_id,
+            "schedule_enabled": schedule_enabled,
+            "source": source,
+            "active_ref": active_ref,
+            "resolved_page_id": resolved_page_id,
+            "page": page_summary,
+        }
 
-    @mcp.tool()
+    @_tool
     def get_board_content(board_id: str | None = None) -> dict[str, Any]:
         """What is currently ON a board — the last known flap content. Read-only.
 
@@ -1064,51 +1086,48 @@ def _build_mcp_server() -> Any:
         (formatted string or null), rows, cols, source ('polled' or
         'last_sent' or null), board_id}.
         """
-        try:
-            # get_service is the DisplayService singleton accessor — the same
-            # seam get_system_status uses; no REST handler is called.
-            from .api_server import _characters_to_message, get_service
+        # get_service is the DisplayService singleton accessor — the same
+        # seam get_system_status uses; no REST handler is called.
+        from .api_server import _characters_to_message, get_service
 
-            service = get_service()
-            if not service:
-                return _err("Display service not initialized.")
+        service = get_service()
+        if not service:
+            raise ToolError("Display service not initialized.")
 
-            characters = None
-            source = None
-            if board_id is None:
-                characters = service._polled_characters
+        characters = None
+        source = None
+        if board_id is None:
+            characters = service._polled_characters
+            source = "polled" if characters is not None else None
+            if characters is None and service.vb_client is not None:
+                characters = getattr(service.vb_client, "_last_characters", None)
+                source = "last_sent" if characters is not None else None
+        else:
+            from .settings.service import get_settings_service
+
+            boards = get_settings_service().get_board_settings().boards or []
+            if not any(isinstance(b, dict) and b.get("id") == board_id for b in boards):
+                raise ToolError(f"Board not found: {board_id}")
+            rt = service.get_runtime(board_id)
+            if rt is not None:
+                characters = rt.polled_characters
                 source = "polled" if characters is not None else None
-                if characters is None and service.vb_client is not None:
-                    characters = getattr(service.vb_client, "_last_characters", None)
+                if characters is None and rt.client is not None:
+                    characters = getattr(rt.client, "_last_characters", None)
                     source = "last_sent" if characters is not None else None
-            else:
-                from .settings.service import get_settings_service
 
-                boards = get_settings_service().get_board_settings().boards or []
-                if not any(isinstance(b, dict) and b.get("id") == board_id for b in boards):
-                    return _err(f"Board not found: {board_id}")
-                rt = service.get_runtime(board_id)
-                if rt is not None:
-                    characters = rt.polled_characters
-                    source = "polled" if characters is not None else None
-                    if characters is None and rt.client is not None:
-                        characters = getattr(rt.client, "_last_characters", None)
-                        source = "last_sent" if characters is not None else None
+        if characters is None:
+            return {"characters": None, "message": None, "rows": 0, "cols": 0, "source": None, "board_id": board_id}
+        return {
+            "characters": _serialize(characters),
+            "message": _characters_to_message(characters),
+            "rows": len(characters),
+            "cols": len(characters[0]) if characters else 0,
+            "source": source,
+            "board_id": board_id,
+        }
 
-            if characters is None:
-                return {"characters": None, "message": None, "rows": 0, "cols": 0, "source": None, "board_id": board_id}
-            return {
-                "characters": _serialize(characters),
-                "message": _characters_to_message(characters),
-                "rows": len(characters),
-                "cols": len(characters[0]) if characters else 0,
-                "source": source,
-                "board_id": board_id,
-            }
-        except Exception as exc:
-            return _err(str(exc))
-
-    @mcp.tool()
+    @_tool
     def send_message(text: str, board_id: str | None = None) -> dict[str, Any]:
         """Send a one-off text message directly to a board.
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -718,6 +718,15 @@ def _build_mcp_server() -> Any:
             "line_metadata": ([m.model_dump() for m in page.line_metadata] if page.line_metadata else None),
         }
         if board_id is not None:
+            # Same roster existence check as the sibling board tools:
+            # compatibility against a board that does not exist would come
+            # back fits_board: true (unresolvable boards pass, by design of
+            # the compat helper) — an answer about nothing (#1874 review).
+            from .settings.service import get_settings_service
+
+            known = get_settings_service().get_board_settings().boards or []
+            if not any(isinstance(b, dict) and b.get("id") == board_id for b in known):
+                raise ToolError(f"Board not found: {board_id}")
             compat = check_ref_board_compatibility(page_id, board_id)
             out["board_id"] = board_id
             out["fits_board"] = compat.ok
@@ -1168,10 +1177,26 @@ def _build_mcp_server() -> Any:
         else:
             from .settings.service import get_settings_service
 
-            boards = get_settings_service().get_board_settings().boards or []
+            settings = get_settings_service()
+            boards = settings.get_board_settings().boards or []
             if not any(isinstance(b, dict) and b.get("id") == board_id for b in boards):
                 raise ToolError(f"Board not found: {board_id}")
             rt = service.get_runtime(board_id)
+            if rt is None:
+                # Legacy installs may key the primary runtime under the
+                # fallback sentinel rather than its settings board id — route
+                # the primary's own id to the primary caches (mirrors
+                # DisplayService.mark_showing_out_of_band, #1874 review).
+                try:
+                    primary_id = settings.get_primary_board_id()
+                except Exception:
+                    primary_id = None
+                if board_id == primary_id:
+                    characters = service._polled_characters
+                    source = "polled" if characters is not None else None
+                    if characters is None and service.vb_client is not None:
+                        characters = getattr(service.vb_client, "_last_characters", None)
+                        source = "last_sent" if characters is not None else None
             if rt is not None:
                 characters = rt.polled_characters
                 source = "polled" if characters is not None else None

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -327,18 +327,61 @@ def _build_mcp_server() -> Any:
         return _serialize(plugins)
 
     @_tool
-    def list_registry_plugins() -> list[dict[str, Any]] | dict[str, Any]:
-        """List all plugins available to install from the FiestaBoard registry.
+    def list_registry_plugins(
+        page: int = 1,
+        page_size: int = 20,
+        fields: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """List plugins available to install from the FiestaBoard registry (paginated).
 
-        Returns a list. Each entry includes:
-        - id: use this as plugin_id when calling install_plugin()
-        - name, description, category
-        - installed: true if already installed
+        Each entry includes id (use it as plugin_id for install_plugin()),
+        name, description, category, plugin_type, and installed. The
+        board-preview fields (teaser, previews) are omitted by default —
+        they are large literal board grids; opt in via fields when you
+        actually need to show what a plugin looks like on a board.
+
+        Args:
+            page: 1-based page number (default 1).
+            page_size: Entries per page, 1-100 (default 20).
+            fields: Optional exact projection — each entry then carries only
+                    these fields plus id (e.g. ["name", "previews"]).
+
+        Returns: {plugins: [...], total, page, page_size, total_pages}.
         """
         from .plugins import get_plugin_registry
 
-        registry = get_plugin_registry()
-        return _serialize(registry.get_registry_entries())
+        if page < 1:
+            raise ToolError("page must be >= 1")
+        if not 1 <= page_size <= 100:
+            raise ToolError("page_size must be between 1 and 100")
+
+        entries = _serialize(get_plugin_registry().get_registry_entries())
+
+        if fields is not None:
+            known = {key for entry in entries for key in entry}
+            unknown = sorted(set(fields) - known)
+            if entries and unknown:
+                raise ToolError(f"Unknown fields: {', '.join(unknown)}. Valid fields: {', '.join(sorted(known))}")
+            keep = set(fields) | {"id"}
+
+            def project(entry: dict[str, Any]) -> dict[str, Any]:
+                return {k: v for k, v in entry.items() if k in keep}
+
+        else:
+            # Default projection: everything except the fat preview grids
+            # (#1765 audit finding 4 — they made this response ~33KB).
+            def project(entry: dict[str, Any]) -> dict[str, Any]:
+                return {k: v for k, v in entry.items() if k not in ("teaser", "previews")}
+
+        total = len(entries)
+        start = (page - 1) * page_size
+        return {
+            "plugins": [project(e) for e in entries[start : start + page_size]],
+            "total": total,
+            "page": page,
+            "page_size": page_size,
+            "total_pages": max(1, -(-total // page_size)),
+        }
 
     @_tool
     async def install_plugin(plugin_id: str, auto_enable: bool = True) -> dict[str, Any]:

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -620,6 +620,7 @@ def _build_mcp_server() -> Any:
     def render_page_preview(
         template_lines: list[str],
         device_type: str = "flagship",
+        line_metadata: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Render a template to see how it will look BEFORE saving it as a page.
 
@@ -632,6 +633,10 @@ def _build_mcp_server() -> Any:
             template_lines: Template strings to render (one per row). Extra
                             rows are dropped; missing rows are filled with blanks.
             device_type: 'flagship' (22×6) or 'note' (15×3).
+            line_metadata: Optional per-line dicts with "alignment"
+                           ('left'/'center'/'right') and "wrap" (bool) — the
+                           same metadata saved pages carry. Include it to
+                           preview alignment and wrap faithfully.
 
         Returns:
             {
@@ -643,13 +648,28 @@ def _build_mcp_server() -> Any:
         plugin that's disabled/unconfigured. Lines longer than the board width
         will appear truncated in the output, matching real-device behavior.
         """
+        from .devices import DEFAULT_DEVICE_TYPE, BoardContext, resolve_dimensions
         from .templates.engine import get_template_engine
 
         engine = get_template_engine()
-        context = engine._build_context()
+        # Build the plugin context around the real BoardContext — the same
+        # construction render_lines performs internally and the saved-page
+        # render path (PageService._render_template) relies on — so
+        # board-aware plugins see the true geometry. The pre-#1765 call
+        # passed no board at all, and every plugin previewed board-blind.
+        # Unknown device types fall back to the default, matching
+        # render_lines' own never-crash fallback.
+        render_device_type = device_type or DEFAULT_DEVICE_TYPE
+        try:
+            dims = resolve_dimensions(render_device_type)
+        except ValueError:
+            render_device_type = DEFAULT_DEVICE_TYPE
+            dims = resolve_dimensions(render_device_type)
+        context = engine._build_context(BoardContext(render_device_type, rows=dims.rows, cols=dims.cols))
         rendered = engine.render_lines(
             template_lines,
             context=context,
+            line_metadata=line_metadata,
             device_type=device_type,
         )
         return {

--- a/src/ops/executors.py
+++ b/src/ops/executors.py
@@ -328,6 +328,124 @@ async def set_active_page(page_id: str, board_id: str | None = None) -> dict[str
     )
 
 
+def send_message(text: str, board_id: str | None = None) -> dict[str, Any]:
+    """Send an ad-hoc text message straight to a board (issue #1765).
+
+    Mirrors ``POST /send-message`` gate for gate — silence (#1788), pause
+    (#970), out-of-band bookkeeping and MQTT state push (#1794/#1831),
+    adaptive refresh — through the same service seams, and shares the
+    wrap/convert/render core (:mod:`src.displays.messages`) with the REST
+    handler so the two surfaces render identically. On top of the REST
+    behavior it can target a secondary board via ``board_id``.
+
+    Silence and pause come back as ``status: "blocked"`` results, not
+    errors — they are deliberate policy, and the model should relay them
+    rather than retry.
+    """
+    try:
+        # get_service is the DisplayService singleton accessor — api_server
+        # owns it, but this is the same seam get_system_status and
+        # set_active_page already use; no REST handler is called.
+        from src.api_server import get_service
+        from src.config import Config
+        from src.devices import resolve_dimensions
+        from src.displays.messages import render_message
+        from src.settings.service import get_settings_service
+
+        service = get_service()
+        if not service:
+            return err("Display service not initialized.")
+
+        settings_service = get_settings_service()
+        primary_id = settings_service.get_primary_board_id()
+        board: dict[str, Any] | None = None
+        if board_id is not None:
+            boards = settings_service.get_board_settings().boards or []
+            board = next((b for b in boards if isinstance(b, dict) and b.get("id") == board_id), None)
+            if board is None:
+                return err(f"Board not found: {board_id}")
+
+        # Silence gate (#1788): resolve the *target* board's window; omitted
+        # board_id resolves the primary, exactly like the REST handler.
+        if Config.is_silence_mode_active(board_id if board_id is not None else primary_id):
+            return {
+                "status": "blocked",
+                "message": "Manual sends blocked during silence mode to prevent wake-ups",
+                "silence_mode": True,
+                "board_id": board_id,
+            }
+
+        # Pause gate (#970): a paused board is left untouched.
+        if settings_service.is_paused(board_id=board_id) is True:
+            return {
+                "status": "blocked",
+                "message": "Board is paused — sends are blocked until it is resumed.",
+                "paused": True,
+                "board_id": board_id,
+            }
+
+        client = service.get_board_client(board_id) if board_id is not None else service.vb_client
+        if not client:
+            return err(
+                f"Board client not initialized: {board_id}" if board_id is not None else "Board client not initialized."
+            )
+
+        # Size the grid to the target board (the REST handler's active-first-
+        # board sizing when board_id is omitted).
+        if board is None:
+            board_settings = settings_service.get_board_settings()
+            board = board_settings.boards[0] if board_settings.boards else {}
+        dims = resolve_dimensions(
+            board.get("device_type") or "flagship",
+            board.get("notes_wide") or 1,
+            board.get("notes_tall") or 1,
+        )
+
+        transition = settings_service.get_transition_settings()
+        success, was_sent = render_message(
+            client,
+            text,
+            rows=dims.rows,
+            cols=dims.cols,
+            strategy=transition.strategy,
+            step_interval_ms=transition.step_interval_ms,
+            step_size=transition.step_size,
+        )
+        if not success:
+            return err("Failed to send message to the board.")
+        if not was_sent:
+            return ok("Message unchanged, no update needed.", skipped=True, board_id=board_id)
+
+        # Out-of-band bookkeeping (#1794/#1831): the board now shows content
+        # the display loop didn't put there. The dedupe cache is deliberately
+        # left alone so the message survives the next engine tick.
+        try:
+            service.mark_showing_out_of_band(board_id)
+        except Exception as exc:
+            logger.debug("Out-of-band mark after MCP send failed: %s", exc)
+        try:
+            from src.mqtt import get_mqtt_client
+
+            mqtt_client = get_mqtt_client()
+            publisher = getattr(mqtt_client, "_state_publisher", None) if mqtt_client else None
+            if publisher is not None:
+                publisher.mark_display_updated()
+                publisher.gather_and_publish()
+        except Exception as exc:
+            logger.debug("MQTT state publish after MCP send failed: %s", exc)
+        # Adaptive post-send refresh is primary-only (board-state polling
+        # tracks only the primary board — issue #1243).
+        if board_id is None or board_id == primary_id:
+            try:
+                service.request_board_refresh()
+            except Exception as exc:
+                logger.debug("Board refresh after MCP send failed: %s", exc)
+
+        return ok("Message sent successfully.", board_id=board_id)
+    except Exception as exc:
+        return err(f"Error sending message: {exc}")
+
+
 # ---------------------------------------------------------------------------
 # Schedule operations
 # ---------------------------------------------------------------------------

--- a/src/ops/executors.py
+++ b/src/ops/executors.py
@@ -285,26 +285,35 @@ def delete_page(page_id: str) -> dict[str, Any]:
         return err(f"Error deleting page '{page_id}': {exc}")
 
 
-async def set_active_page(page_id: str) -> dict[str, Any]:
+async def set_active_page(page_id: str, board_id: str | None = None) -> dict[str, Any]:
     """Set which page is currently shown on the display.
 
     Delegates to the REST handler rather than reimplementing it: selecting
     a page validates the ref, enforces page<->board size compatibility,
     dismisses active plugin triggers (#856), and renders to the board.
     Issue #1559 was a reimplementation going its own way.
+
+    ``board_id`` targets that board's active-page slot (#1765); omitted is
+    the legacy primary-board call, exactly as before — the REST handler
+    already speaks per-board (#1244), so the parameter simply flows through.
     """
     from fastapi import HTTPException
 
     from src.api_server import set_active_page as _rest_set_active_page
 
+    body: dict[str, Any] = {"page_id": page_id}
+    if board_id is not None:
+        body["board_id"] = board_id
     try:
-        response = await _rest_set_active_page({"page_id": page_id})
+        response = await _rest_set_active_page(body)
     except HTTPException as exc:
         return err(f"Error setting active page: {exc.detail}")
     except Exception as exc:
         return err(f"Error setting active page: {exc}")
 
     message = f"Active page set to '{page_id}'."
+    if board_id is not None:
+        message = f"Active page set to '{page_id}' on board '{board_id}'."
     if response.get("paused"):
         message += " The board is paused, so it will appear when you resume it."
     elif not response.get("sent_to_board"):
@@ -312,6 +321,7 @@ async def set_active_page(page_id: str) -> dict[str, Any]:
     return ok(
         message,
         page_id=page_id,
+        board_id=board_id,
         sent_to_board=bool(response.get("sent_to_board")),
         paused=bool(response.get("paused")),
         warnings=response.get("warnings", []),
@@ -435,19 +445,31 @@ def delete_schedule(schedule_id: str) -> dict[str, Any]:
         return err(f"Error deleting schedule '{schedule_id}': {exc}")
 
 
-def set_schedule_mode(enabled: bool) -> dict[str, Any]:
+def set_schedule_mode(enabled: bool, board_id: str | None = None) -> dict[str, Any]:
     """Enable or disable schedule-based display.
 
     Schedule mode is a settings flag (per-board since #1244), not
     something ScheduleService owns — same mixup as issue #1559.
+
+    ``board_id`` targets that board's flag (#1765); omitted keeps the
+    legacy primary-board call. An unknown board is an error here because
+    ``SettingsService.set_schedule_enabled`` logs-and-no-ops on one, which
+    over MCP would read as success while changing nothing.
     """
     try:
         from src.settings.service import get_settings_service
 
         svc = get_settings_service()
-        svc.set_schedule_enabled(enabled)
+        if board_id is not None:
+            boards = svc.get_board_settings().boards or []
+            if not any(isinstance(b, dict) and b.get("id") == board_id for b in boards):
+                return err(f"Board not found: {board_id}")
+            svc.set_schedule_enabled(enabled, board_id=board_id)
+        else:
+            svc.set_schedule_enabled(enabled)
         state = "enabled" if enabled else "disabled"
-        return ok(f"Schedule mode {state}.", enabled=enabled)
+        target = f" for board '{board_id}'" if board_id is not None else ""
+        return ok(f"Schedule mode {state}{target}.", enabled=enabled, board_id=board_id)
     except Exception as exc:
         return err(f"Error setting schedule mode: {exc}")
 

--- a/src/ops/registry.py
+++ b/src/ops/registry.py
@@ -139,6 +139,10 @@ OPERATIONS: tuple[Operation, ...] = (
         adapt_chat_args=lambda a: {"schedule_id": a.schedule_id},
     ),
     Operation(name="set_schedule_mode", executor=executors.set_schedule_mode, mcp_tool="set_schedule_mode"),
+    # -- board messages ---------------------------------------------------
+    # MCP-only server op (#1765): the ad-hoc send the REST surface has as
+    # POST /send-message. The chat grammar has no spelling for it today.
+    Operation(name="send_message", executor=executors.send_message, mcp_tool="send_message"),
     # -- collections ------------------------------------------------------
     Operation(
         name="create_collection",

--- a/tests/test_mcp_plugin_tools_decoupled.py
+++ b/tests/test_mcp_plugin_tools_decoupled.py
@@ -86,9 +86,16 @@ with (
     assert call("disable_plugin", plugin_id="stocks")["status"] == "success"
     assert call("configure_plugin", plugin_id="stocks", config={"api_key": "k"})["status"] == "success"
     assert call("uninstall_plugin", plugin_id="stocks")["status"] == "success"
-    # No source for the plugin: the guarded update path answers with an
-    # error result — the point is that it did so without api_server.
-    assert call("update_plugin", plugin_id="stocks")["status"] == "error"
+    # No source for the plugin: the guarded update path refuses. #1765 made
+    # tool failures raise ToolError (protocol isError) instead of returning
+    # an error envelope — the point here is that it refused without
+    # api_server, whatever the error surface.
+    from mcp.server.mcpserver.exceptions import ToolError
+    try:
+        call("update_plugin", plugin_id="stocks")
+        raise AssertionError("update_plugin with no source must fail")
+    except ToolError:
+        pass
 
 # Not vacuous: the tools really drove the collaborators.
 registry.install_from_registry.assert_called_once_with("stocks")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -429,15 +429,95 @@ class TestListInstalledPlugins:
         assert "db unavailable" not in message, "raw exception text must not cross the MCP boundary"
 
 
+@pytest.fixture
+def fat_registry():
+    """A registry whose entries carry realistic (large) board-preview blobs.
+
+    #1765 audit finding 4: list_registry_plugins shipped every entry's
+    teaser + previews grids unpaginated (~33KB). The fixture makes the
+    fat fields big enough that leaking them back is unmissable.
+    """
+    from src.plugins.registry import PluginRegistry
+
+    registry = create_autospec(PluginRegistry, instance=True)
+    registry.get_registry_entries.return_value = [
+        {
+            "id": f"plugin_{i:02d}",
+            "name": f"Plugin {i:02d}",
+            "description": "A registry plugin",
+            "category": "utility",
+            "plugin_type": "data",
+            "installed": i == 0,
+            "teaser": "TEASER ROW",
+            "previews": [{"shape": "flagship", "rows": ["X" * 22] * 6 * 8}],
+        }
+        for i in range(30)
+    ]
+    return registry
+
+
 class TestListRegistryPlugins:
+    """Pagination + projection (#1765): the old contract returned every
+    entry with its preview grids in one unpaginated list. Deliberately
+    replaced — the response now pages and drops the fat fields by default;
+    test_returns_registry_entries used to pin the bare list shape."""
+
     def test_returns_registry_entries(self, mcp, mock_registry):
         with patch("src.plugins.get_plugin_registry", return_value=mock_registry):
             result = _call_tool(mcp, "list_registry_plugins")
-        data = result
+        data = result["plugins"]
         assert len(data) == 2
         ids = {d["id"] for d in data}
         assert "openweather" in ids
         assert "stocks" in ids
+        assert result["total"] == 2
+
+    def test_default_response_omits_the_preview_grids(self, mcp, fat_registry):
+        with patch("src.plugins.get_plugin_registry", return_value=fat_registry):
+            result = _call_tool(mcp, "list_registry_plugins")
+        assert result["plugins"], "expected a page of entries"
+        for entry in result["plugins"]:
+            assert "previews" not in entry
+            assert "teaser" not in entry
+            assert entry["id"]
+
+    def test_default_response_stays_small(self, mcp, fat_registry):
+        import json as _json
+
+        with patch("src.plugins.get_plugin_registry", return_value=fat_registry):
+            result = _call_tool(mcp, "list_registry_plugins")
+        size = len(_json.dumps(result))
+        assert size < 8_000, f"default registry listing is {size} bytes — the preview grids are leaking back"
+
+    def test_pages_slice_and_report_totals(self, mcp, fat_registry):
+        with patch("src.plugins.get_plugin_registry", return_value=fat_registry):
+            page1 = _call_tool(mcp, "list_registry_plugins", page=1, page_size=20)
+            page2 = _call_tool(mcp, "list_registry_plugins", page=2, page_size=20)
+        assert page1["total"] == 30
+        assert page1["total_pages"] == 2
+        assert (page1["page"], page2["page"]) == (1, 2)
+        assert len(page1["plugins"]) == 20
+        assert len(page2["plugins"]) == 10
+        ids1 = {e["id"] for e in page1["plugins"]}
+        ids2 = {e["id"] for e in page2["plugins"]}
+        assert not ids1 & ids2, "page 2 repeated entries from page 1"
+
+    def test_fields_opt_in_returns_the_previews(self, mcp, fat_registry):
+        with patch("src.plugins.get_plugin_registry", return_value=fat_registry):
+            result = _call_tool(mcp, "list_registry_plugins", page_size=2, fields=["name", "previews"])
+        entry = result["plugins"][0]
+        assert set(entry) == {"id", "name", "previews"}
+        assert entry["previews"], "opting into previews returned nothing"
+
+    def test_unknown_field_is_an_error(self, mcp, fat_registry):
+        with patch("src.plugins.get_plugin_registry", return_value=fat_registry):
+            message = _call_tool_expect_error(mcp, "list_registry_plugins", fields=["not_a_field"])
+        assert "not_a_field" in message
+
+    def test_page_below_one_is_an_error(self, mcp, fat_registry):
+        with patch("src.plugins.get_plugin_registry", return_value=fat_registry):
+            message = _call_tool_expect_error(mcp, "list_registry_plugins", page=0)
+        assert "page" in message
 
 
 @pytest.fixture

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1297,8 +1297,11 @@ class TestProtocolIsError:
     # class-scoped: the app lifespan starts the MCP StreamableHTTP session
     # manager, whose .run() is once-per-instance — a second lifespan startup
     # in the same process raises. One client serves every test in the class.
+    # @classmethod per pytest's class-scoped-fixture-as-instance-method
+    # deprecation.
     @pytest.fixture(scope="class")
-    def rpc(self):
+    @classmethod
+    def rpc(cls):
         from fastapi.testclient import TestClient
 
         from src.api_server import app
@@ -1322,10 +1325,10 @@ class TestProtocolIsError:
                         "clientInfo": {"name": "pytest", "version": "0"},
                     },
                 },
-                headers=self.HEADERS,
+                headers=cls.HEADERS,
             )
             assert init.status_code == 200, init.text
-            headers = dict(self.HEADERS)
+            headers = dict(cls.HEADERS)
             sid = init.headers.get("mcp-session-id")
             if sid:
                 headers["mcp-session-id"] = sid

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1268,11 +1268,13 @@ class TestPluginSystemUnavailable:
 
         monkeypatch.setitem(sys.modules, "src.plugins.service", None)
 
-        result = _call_tool(mcp, "enable_plugin", plugin_id="openweather")
+        # On this branch tool failures surface as protocol errors (ToolError
+        # with the envelope's message), not {"status": "error"} payloads.
+        message = _call_tool_expect_error(mcp, "enable_plugin", plugin_id="openweather")
 
-        assert result["status"] == "error"
-        assert "Plugin system is not available" in result["error"]
-        assert "No module named" not in result["error"]
+        assert "Plugin system is not available" in message
+        assert "No module named" not in message
+
 
 # ---------------------------------------------------------------------------
 # Protocol errors — issue #1765

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -17,6 +17,7 @@ Strategy
 
 from __future__ import annotations
 
+import tempfile
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, create_autospec, patch
@@ -1302,8 +1303,6 @@ class TestProtocolIsError:
     @pytest.fixture(scope="class")
     @classmethod
     def rpc(cls):
-        from fastapi.testclient import TestClient
-
         from src.api_server import app
 
         # conftest's autouse auth-off env fixture is function-scoped and runs
@@ -1311,6 +1310,18 @@ class TestProtocolIsError:
         # class-time initialize handshake with 409 "Setup required".
         mp = pytest.MonkeyPatch()
         mp.setenv("FIESTABOARD_AUTH_ENABLED", "false")
+        # Same ordering hazard for the #1762 data-dir seam: the lifespan
+        # startup below constructs ConfigManager/services before the
+        # function-scoped ``_isolated_data_dir`` fixture sets the env, so
+        # without this the class handshake writes the developer's real
+        # ``data/`` (caught by the CI checksum guard).
+        with tempfile.TemporaryDirectory() as class_data_dir:
+            mp.setenv("FIESTABOARD_DATA_DIR", class_data_dir)
+            yield from cls._run_rpc_client(app, mp)
+
+    @classmethod
+    def _run_rpc_client(cls, app, mp):
+        from fastapi.testclient import TestClient
 
         with TestClient(app) as client:
             init = client.post(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -355,6 +355,12 @@ EXPECTED_TOOLS = {
     "get_settings_summary",
     "set_active_page",
     "set_schedule_mode",
+    # Read-back / action tools (#1765)
+    "get_active_page",
+    "get_board_content",
+    "send_message",
+    "preview_saved_page",
+    "validate_template",
 }
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -56,6 +56,23 @@ def _call_tool(mcp_instance: Any, tool_name: str, **kwargs: Any) -> Any:
     return result
 
 
+def _call_tool_expect_error(mcp_instance: Any, tool_name: str, /, **kwargs: Any) -> str:
+    """Call a tool whose failure is the point; return its error message.
+
+    #1765 contract reversal: failures used to come back as *successful*
+    results containing ``{"status": "error", "error": "..."}`` — invisible
+    to MCP clients' error handling. A failing tool now raises ToolError,
+    which the framework converts to ``CallToolResult(isError=True)`` (see
+    TestProtocolIsError for the wire-level proof). Tests that previously
+    asserted on the envelope assert on the raised message instead.
+    """
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    with pytest.raises(ToolError) as excinfo:
+        _call_tool(mcp_instance, tool_name, **kwargs)
+    return str(excinfo.value)
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -405,11 +422,11 @@ class TestListInstalledPlugins:
         assert "config" in data[0]
 
     def test_error_handling(self, mcp):
-        """Returns JSON error object when service call fails."""
+        """A failing service call is a protocol error, with no internal detail (#1765)."""
         with patch("src.plugins.get_plugin_registry", side_effect=RuntimeError("db unavailable")):
-            result = _call_tool(mcp, "list_installed_plugins")
-        data = result
-        assert "error" in data
+            message = _call_tool_expect_error(mcp, "list_installed_plugins")
+        assert "list_installed_plugins" in message
+        assert "db unavailable" not in message, "raw exception text must not cross the MCP boundary"
 
 
 class TestListRegistryPlugins:
@@ -463,17 +480,15 @@ class TestInstallPlugin:
     def test_install_error(self, mcp, plugin_services):
         registry, _ = plugin_services
         registry.install_from_registry.return_value = ["Plugin 'unknown' not found in the registry"]
-        result = _call_tool(mcp, "install_plugin", plugin_id="unknown")
-        assert result["status"] == "error"
-        assert "not found in the registry" in result["error"]
+        message = _call_tool_expect_error(mcp, "install_plugin", plugin_id="unknown")
+        assert "not found in the registry" in message
 
     def test_install_reports_a_failed_enable(self, mcp, plugin_services):
         """Installed-but-not-enabled must not be reported as fully successful."""
         registry, _ = plugin_services
         registry.get_plugin.return_value = None
-        result = _call_tool(mcp, "install_plugin", plugin_id="stocks")
-        assert result["status"] == "error"
-        assert "installed but could not be enabled" in result["error"]
+        message = _call_tool_expect_error(mcp, "install_plugin", plugin_id="stocks")
+        assert "installed but could not be enabled" in message
 
 
 class TestEnablePlugin:
@@ -488,15 +503,13 @@ class TestEnablePlugin:
     def test_enable_unknown_plugin_is_an_error(self, mcp, plugin_services):
         registry, config_manager = plugin_services
         registry.get_plugin.return_value = None
-        result = _call_tool(mcp, "enable_plugin", plugin_id="nope")
-        assert result["status"] == "error"
+        _call_tool_expect_error(mcp, "enable_plugin", plugin_id="nope")
         config_manager.enable_plugin.assert_not_called()
 
     def test_enable_error(self, mcp, plugin_services):
         registry, _ = plugin_services
         registry.enable_plugin.side_effect = KeyError("openweather not found")
-        result = _call_tool(mcp, "enable_plugin", plugin_id="openweather")
-        assert result["status"] == "error"
+        _call_tool_expect_error(mcp, "enable_plugin", plugin_id="openweather")
 
 
 class TestDisablePlugin:
@@ -510,8 +523,7 @@ class TestDisablePlugin:
     def test_disable_unknown_plugin_is_an_error(self, mcp, plugin_services):
         registry, config_manager = plugin_services
         registry.get_plugin.return_value = None
-        result = _call_tool(mcp, "disable_plugin", plugin_id="nope")
-        assert result["status"] == "error"
+        _call_tool_expect_error(mcp, "disable_plugin", plugin_id="nope")
         config_manager.disable_plugin.assert_not_called()
 
 
@@ -526,9 +538,8 @@ class TestUninstallPlugin:
     def test_uninstall_builtin_is_an_error(self, mcp, plugin_services):
         registry, _ = plugin_services
         registry.uninstall_external_plugin.return_value = ["Cannot uninstall a built-in plugin"]
-        result = _call_tool(mcp, "uninstall_plugin", plugin_id="date_time")
-        assert result["status"] == "error"
-        assert "built-in" in result["error"]
+        message = _call_tool_expect_error(mcp, "uninstall_plugin", plugin_id="date_time")
+        assert "built-in" in message
 
 
 class TestConfigurePlugin:
@@ -563,26 +574,25 @@ class TestConfigurePlugin:
     def test_validation_errors_are_reported_not_swallowed(self, mcp, plugin_services):
         registry, config_manager = plugin_services
         registry.set_plugin_config.return_value = ["station_id is required"]
-        result = _call_tool(
+        message = _call_tool_expect_error(
             mcp,
             "configure_plugin",
             plugin_id="openweather",
             config={"station_id": ""},
         )
-        assert result["status"] == "error"
-        assert "station_id is required" in result["error"]
+        assert "station_id is required" in message
         config_manager.set_plugin_config.assert_not_called()
 
     def test_configure_error(self, mcp, plugin_services):
         _, config_manager = plugin_services
         config_manager.get_plugin_config.side_effect = KeyError("plugin not found")
-        result = _call_tool(
+        message = _call_tool_expect_error(
             mcp,
             "configure_plugin",
             plugin_id="nonexistent",
             config={"api_key": "x"},
         )
-        assert result["status"] == "error"
+        assert "Error configuring plugin" in message
 
 
 class TestGetTemplateVariables:
@@ -642,9 +652,9 @@ class TestListPages:
         mock_svc = MagicMock()
         mock_svc.list_pages.side_effect = RuntimeError("service down")
         with patch("src.pages.service.get_page_service", return_value=mock_svc):
-            result = _call_tool(mcp, "list_pages")
-        data = result
-        assert "error" in data
+            message = _call_tool_expect_error(mcp, "list_pages")
+        assert "list_pages" in message
+        assert "service down" not in message, "raw exception text must not cross the MCP boundary"
 
 
 class TestGetPage:
@@ -659,10 +669,8 @@ class TestGetPage:
         mock_svc = MagicMock()
         mock_svc.get_page.return_value = None
         with patch("src.pages.service.get_page_service", return_value=mock_svc):
-            result = _call_tool(mcp, "get_page", page_id="missing")
-        data = result
-        assert "error" in data
-        assert "not found" in data["error"]
+            message = _call_tool_expect_error(mcp, "get_page", page_id="missing")
+        assert "not found" in message
 
 
 class TestCreatePage:
@@ -682,13 +690,13 @@ class TestCreatePage:
         mock_svc = MagicMock()
         mock_svc.create_page.side_effect = ValueError("invalid template")
         with patch("src.pages.service.get_page_service", return_value=mock_svc):
-            result = _call_tool(
+            message = _call_tool_expect_error(
                 mcp,
                 "create_page",
                 name="Bad Page",
                 template_lines=["only one line"],
             )
-        assert result["status"] == "error"
+        assert "Error creating page" in message
 
 
 class TestUpdatePage:
@@ -702,9 +710,8 @@ class TestUpdatePage:
         mock_svc = MagicMock()
         mock_svc.update_page.return_value = None
         with patch("src.pages.service.get_page_service", return_value=mock_svc):
-            result = _call_tool(mcp, "update_page", page_id="missing")
-        data = result
-        assert "error" in data
+            message = _call_tool_expect_error(mcp, "update_page", page_id="missing", name="x")
+        assert "not found" in message
 
 
 class TestDeletePage:
@@ -728,9 +735,8 @@ class TestDeletePage:
         mock_svc = create_autospec(PageService, instance=True)
         mock_svc.delete_page.return_value = DeleteResult(deleted=False)
         with patch("src.pages.service.get_page_service", return_value=mock_svc):
-            result = _call_tool(mcp, "delete_page", page_id="page-001")
-        assert result["status"] == "error"
-        assert "not deleted" in result["error"]
+            message = _call_tool_expect_error(mcp, "delete_page", page_id="page-001")
+        assert "not deleted" in message
 
     def test_delete_reports_default_page_creation(self, mcp):
         """Deleting the last page creates a default one; the client is told."""
@@ -804,13 +810,13 @@ class TestCreateSchedule:
         mock_svc = MagicMock()
         mock_svc.create_schedule.side_effect = ValueError("invalid time format")
         with patch("src.schedules.service.get_schedule_service", return_value=mock_svc):
-            result = _call_tool(
+            message = _call_tool_expect_error(
                 mcp,
                 "create_schedule",
                 page_id="page-001",
                 start_time="not-a-time",
             )
-        assert result["status"] == "error"
+        assert "Error creating schedule" in message
 
 
 class TestUpdateSchedule:
@@ -824,8 +830,8 @@ class TestUpdateSchedule:
         mock_svc = MagicMock()
         mock_svc.update_schedule.return_value = None
         with patch("src.schedules.service.get_schedule_service", return_value=mock_svc):
-            result = _call_tool(mcp, "update_schedule", schedule_id="missing")
-        assert "not found" in result["error"]
+            message = _call_tool_expect_error(mcp, "update_schedule", schedule_id="missing")
+        assert "not found" in message
 
 
 class TestDeleteSchedule:
@@ -875,8 +881,8 @@ class TestUpdateCollection:
         mock_svc = MagicMock()
         mock_svc.update_collection.return_value = None
         with patch("src.collections.service.get_collection_service", return_value=mock_svc):
-            result = _call_tool(mcp, "update_collection", collection_id="missing")
-        assert "not found" in result["error"]
+            message = _call_tool_expect_error(mcp, "update_collection", collection_id="missing")
+        assert "not found" in message
 
 
 class TestDeleteCollection:
@@ -957,10 +963,9 @@ class TestSetActivePage:
     def test_unknown_page_reports_error_and_persists_nothing(self, mcp, api_stack):
         api_stack["pages"].get_page.return_value = None
 
-        result = _call_tool(mcp, "set_active_page", page_id="no-such-page")
+        message = _call_tool_expect_error(mcp, "set_active_page", page_id="no-such-page")
 
-        assert result["status"] == "error"
-        assert "no-such-page" in result["error"]
+        assert "no-such-page" in message
         api_stack["settings"].set_active_page_id.assert_not_called()
 
 
@@ -1095,7 +1100,15 @@ class TestMCPPrompts:
 
 
 class TestToolErrorResilience:
-    """All tools should catch exceptions and return a structured response."""
+    """Every tool maps a total service failure to a clean protocol error.
+
+    #1765 contract reversal: tools used to catch everything and return a
+    successful ``{"status": "error"}`` payload; now they raise ToolError so
+    the framework sets ``CallToolResult.isError``. What this class still
+    guards is the failure *shape*: no tool may leak an unhandled non-MCP
+    exception, a traceback, or (for the tools whose errors are mapped, not
+    domain-worded) the raw internal exception text.
+    """
 
     @pytest.mark.parametrize(
         "tool_name,kwargs",
@@ -1130,8 +1143,16 @@ class TestToolErrorResilience:
             ("set_schedule_mode", {"enabled": True}),
         ],
     )
-    def test_tool_does_not_raise(self, mcp, tool_name: str, kwargs: dict):
-        """Each tool returns a dict/list (not raises) even when all services fail."""
+    def test_tool_fails_as_a_protocol_error_without_a_traceback(self, mcp, tool_name: str, kwargs: dict):
+        """Each tool raises ToolError (never a bare exception) when all services fail.
+
+        Pre-#1765 this test pinned the opposite: "returns a dict, never
+        raises". That contract hid every failure from MCP clients behind
+        isError=false. Reversed deliberately; the wire-level counterpart is
+        TestProtocolIsError.
+        """
+        from mcp.server.mcpserver.exceptions import ToolError
+
         with (
             patch("src.plugins.get_plugin_registry", side_effect=RuntimeError("boom")),
             patch("src.pages.service.get_page_service", side_effect=RuntimeError("boom")),
@@ -1141,13 +1162,16 @@ class TestToolErrorResilience:
             patch("src.config_manager.get_config_manager", side_effect=RuntimeError("boom")),
             patch("src.api_server.get_service", side_effect=RuntimeError("boom")),
         ):
-            result = _call_tool(mcp, tool_name, **kwargs)
-        assert result is not None
-        # Every tool returns a dict (success/error envelope, get_plugin_data
-        # shape, system_status, etc.) or list (list_* tools that succeed
-        # despite our boom — e.g., get_settings_summary swallows per-field
-        # errors and returns {}). Either way it must be a structured value,
-        # never a raw exception.
+            try:
+                result = _call_tool(mcp, tool_name, **kwargs)
+            except ToolError as exc:
+                message = str(exc)
+                assert "Traceback" not in message
+                assert message.strip(), "a protocol error must carry a usable message"
+                return
+        # A tool that still succeeds under the boom (get_settings_summary
+        # swallows per-field failures, get_plugin_data reports availability
+        # as data) must return a structured value, never a bare exception.
         assert isinstance(result, dict | list)
 
 
@@ -1168,3 +1192,141 @@ class TestPluginSystemUnavailable:
         assert result["status"] == "error"
         assert "Plugin system is not available" in result["error"]
         assert "No module named" not in result["error"]
+
+# ---------------------------------------------------------------------------
+# Protocol errors — issue #1765
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolIsError:
+    """MCP tool failures must set the protocol error flag (issue #1765).
+
+    Before this contract every failure came back as a *successful* tool
+    result whose payload happened to contain ``{"status": "error", ...}`` —
+    invisible to an MCP client's error handling — and unexpected exceptions
+    were stringified onto the wire verbatim.
+
+    These tests go through the real JSON-RPC endpoint (TestClient against
+    the mounted streamable-http app at ``/api/mcp/`` — the app carries
+    ``root_path="/api"``, so ``/mcp/`` 404s by design) so the assertion is
+    on the actual ``CallToolResult.isError`` bit, not an internal helper.
+    """
+
+    HEADERS = {"Accept": "application/json, text/event-stream", "Content-Type": "application/json"}
+
+    # class-scoped: the app lifespan starts the MCP StreamableHTTP session
+    # manager, whose .run() is once-per-instance — a second lifespan startup
+    # in the same process raises. One client serves every test in the class.
+    @pytest.fixture(scope="class")
+    def rpc(self):
+        from fastapi.testclient import TestClient
+
+        from src.api_server import app
+
+        # conftest's autouse auth-off env fixture is function-scoped and runs
+        # AFTER class-scoped setup, so the middleware would still gate the
+        # class-time initialize handshake with 409 "Setup required".
+        mp = pytest.MonkeyPatch()
+        mp.setenv("FIESTABOARD_AUTH_ENABLED", "false")
+
+        with TestClient(app) as client:
+            init = client.post(
+                "/api/mcp/",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-06-18",
+                        "capabilities": {},
+                        "clientInfo": {"name": "pytest", "version": "0"},
+                    },
+                },
+                headers=self.HEADERS,
+            )
+            assert init.status_code == 200, init.text
+            headers = dict(self.HEADERS)
+            sid = init.headers.get("mcp-session-id")
+            if sid:
+                headers["mcp-session-id"] = sid
+
+            def call(name: str, arguments: dict):
+                res = client.post(
+                    "/api/mcp/",
+                    json={
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "method": "tools/call",
+                        "params": {"name": name, "arguments": arguments},
+                    },
+                    headers=headers,
+                )
+                assert res.status_code == 200, res.text
+                body = res.json()
+                assert "error" not in body, (
+                    f"a tool failure must be a CallToolResult (isError), not a JSON-RPC error: {body}"
+                )
+                return body["result"]
+
+            try:
+                yield call
+            finally:
+                mp.undo()
+
+    @staticmethod
+    def _text(result: dict) -> str:
+        return " ".join(c.get("text", "") for c in result.get("content", []))
+
+    def test_domain_failure_sets_is_error_with_the_domain_message(self, rpc):
+        mock_svc = MagicMock()
+        mock_svc.get_page.return_value = None
+        with patch("src.pages.service.get_page_service", return_value=mock_svc):
+            result = rpc("get_page", {"page_id": "missing"})
+
+        assert result.get("isError") is True, f"error flag not set: {result}"
+        text = self._text(result)
+        assert "Page 'missing' not found." in text
+        assert "Traceback" not in text
+
+    def test_executor_failure_sets_is_error(self, rpc):
+        mock_svc = MagicMock()
+        mock_svc.update_schedule.return_value = None
+        with patch("src.schedules.service.get_schedule_service", return_value=mock_svc):
+            result = rpc("update_schedule", {"schedule_id": "missing"})
+
+        assert result.get("isError") is True, f"error flag not set: {result}"
+        assert "not found" in self._text(result)
+
+    def test_unexpected_exception_is_concise_and_not_leaked(self, rpc):
+        with patch("src.pages.service.get_page_service", side_effect=RuntimeError("secret internal xyzzy")):
+            result = rpc("list_pages", {})
+
+        assert result.get("isError") is True, f"error flag not set: {result}"
+        text = self._text(result)
+        assert "xyzzy" not in text, f"internal exception detail leaked to the MCP client: {text}"
+        assert "Traceback" not in text
+        assert "list_pages" in text, f"the failing tool is not named: {text}"
+
+    def test_success_is_not_flagged_as_error(self, rpc, mock_page_service):
+        with patch("src.pages.service.get_page_service", return_value=mock_page_service):
+            result = rpc("list_pages", {})
+        assert not result.get("isError"), f"a successful call was flagged as an error: {result}"
+
+    def test_blocked_send_is_a_result_not_an_error(self, rpc):
+        """Silence/pause blocks are policy, not failures — the model should
+        relay them, so they stay ordinary results the payload explains."""
+        from src.settings.service import SettingsService
+
+        settings = create_autospec(SettingsService, instance=True)
+        settings.get_primary_board_id.return_value = "b1"
+        settings.get_board_settings.return_value = SimpleNamespace(boards=[{"id": "b1", "device_type": "flagship"}])
+        settings.is_paused.return_value = True
+        with (
+            patch("src.api_server.get_service", return_value=MagicMock()),
+            patch("src.settings.service.get_settings_service", return_value=settings),
+            patch("src.config.Config.is_silence_mode_active", return_value=False),
+        ):
+            result = rpc("send_message", {"text": "HI"})
+
+        assert not result.get("isError"), f"a policy block was flagged as a protocol error: {result}"
+        assert result["structuredContent"]["status"] == "blocked"

--- a/tests/test_mcp_state_effects.py
+++ b/tests/test_mcp_state_effects.py
@@ -331,6 +331,22 @@ def call(mcp: Any, tool_name: str, /, **kwargs: Any) -> Any:
     return result
 
 
+def call_expect_error(mcp: Any, tool_name: str, /, **kwargs: Any) -> str:
+    """Invoke a tool whose failure is the point; return its error message.
+
+    #1765 contract reversal: failures used to be *successful* results whose
+    payload said ``{"status": "error"}``; a failing tool now raises
+    ToolError (protocol ``isError`` on the wire — pinned end-to-end by
+    tests/test_mcp_server.py::TestProtocolIsError). Every error-path test
+    below asserts on the raised message instead of the old envelope.
+    """
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    with pytest.raises(ToolError) as excinfo:
+        call(mcp, tool_name, **kwargs)
+    return str(excinfo.value)
+
+
 def assert_ok(result: Any, what: str) -> Any:
     """Fail with the tool's own error string rather than a shape mismatch.
 
@@ -473,8 +489,8 @@ def test_update_page_with_no_fields_is_reported_not_silently_ignored(mcp, servic
         call(mcp, "create_page", name="Untouched", template_lines=FLAGSHIP_TEMPLATE, device_type="flagship"),
         "create_page",
     )
-    result = call(mcp, "update_page", page_id=created["page_id"])
-    assert isinstance(result, dict) and result.get("error"), "a no-op update should say so, not report success"
+    message = call_expect_error(mcp, "update_page", page_id=created["page_id"])
+    assert "Nothing to update" in message, "a no-op update should say so, not report success"
 
 
 def test_delete_page_removes_it_from_list_pages(mcp, services):
@@ -795,12 +811,9 @@ def test_configure_plugin_merges_with_the_existing_stored_config(mcp, plugins):
 
 def test_configure_plugin_reports_validation_errors_instead_of_success(mcp, plugins):
     """``registry.set_plugin_config()`` returns errors; the tool discarded them."""
-    result = call(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"station_id": ""})
+    message = call_expect_error(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"station_id": ""})
 
-    assert result.get("status") == "error", "an invalid config was reported as a successful update"
-    assert "station_id" in str(result.get("error", "")), (
-        f"the plugin's own validation message was not surfaced: {result}"
-    )
+    assert "station_id" in message, f"the plugin's own validation message was not surfaced: {message}"
 
 
 def test_configure_plugin_does_not_overwrite_a_good_config_with_a_rejected_one(mcp, plugins):
@@ -809,15 +822,14 @@ def test_configure_plugin_does_not_overwrite_a_good_config_with_a_rejected_one(m
         "configure_plugin",
     )
 
-    call(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"station_id": ""})
+    call_expect_error(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"station_id": ""})
 
     stored = stored_plugin_config(plugins["config_path"], PLUGIN_ID)
     assert stored["station_id"] == "9447427", "a rejected config was persisted over a valid one"
 
 
 def test_configure_plugin_reports_an_error_for_an_unknown_plugin(mcp, plugins):
-    result = call(mcp, "configure_plugin", plugin_id="not_a_plugin", config={"station_id": "1"})
-    assert result.get("status") == "error"
+    call_expect_error(mcp, "configure_plugin", plugin_id="not_a_plugin", config={"station_id": "1"})
     assert stored_plugin_config(plugins["config_path"], "not_a_plugin") is None
 
 
@@ -840,13 +852,11 @@ def test_disable_plugin_persists_enabled_false(mcp, plugins):
 
 def test_enable_plugin_reports_an_error_for_an_unknown_plugin(mcp, plugins):
     """``registry.enable_plugin()`` returns False here; the tool ignored it."""
-    result = call(mcp, "enable_plugin", plugin_id="not_a_plugin")
-    assert result.get("status") == "error", "enabling a plugin that does not exist reported success"
+    call_expect_error(mcp, "enable_plugin", plugin_id="not_a_plugin")
 
 
 def test_disable_plugin_reports_an_error_for_an_unknown_plugin(mcp, plugins):
-    result = call(mcp, "disable_plugin", plugin_id="not_a_plugin")
-    assert result.get("status") == "error", "disabling a plugin that does not exist reported success"
+    call_expect_error(mcp, "disable_plugin", plugin_id="not_a_plugin")
 
 
 def test_enable_plugin_does_not_disturb_the_stored_settings(mcp, plugins):
@@ -939,13 +949,13 @@ def test_plugin_configured_over_mcp_survives_a_container_recreate(mcp, plugins):
 
 
 def test_delete_schedule_reports_an_error_for_an_unknown_id(mcp, services):
-    result = call(mcp, "delete_schedule", schedule_id="no-such-schedule")
-    assert result.get("status") == "error", f"deleting a schedule that does not exist reported success: {result}"
+    message = call_expect_error(mcp, "delete_schedule", schedule_id="no-such-schedule")
+    assert "not found" in message, f"deleting a schedule that does not exist reported success: {message}"
 
 
 def test_delete_collection_reports_an_error_for_an_unknown_id(mcp, services):
-    result = call(mcp, "delete_collection", collection_id="no-such-collection")
-    assert result.get("status") == "error", f"deleting a collection that does not exist reported success: {result}"
+    message = call_expect_error(mcp, "delete_collection", collection_id="no-such-collection")
+    assert "not found" in message, f"deleting a collection that does not exist reported success: {message}"
 
 
 # ---------------------------------------------------------------------------
@@ -1095,12 +1105,9 @@ def test_update_plugin_fetches_the_new_version_from_the_remote(mcp, updatable_pl
 
 def test_update_plugin_refuses_a_builtin_plugin(mcp, updatable_plugins):
     """``POST /plugins/{id}/update`` 400s here; the MCP tool reloaded it."""
-    result = call(mcp, "update_plugin", plugin_id=BUILTIN_PLUGIN_ID)
+    message = call_expect_error(mcp, "update_plugin", plugin_id=BUILTIN_PLUGIN_ID)
 
-    assert result.get("status") == "error", f"a built-in plugin was reported as updated: {result}"
-    assert "built-in" in str(result.get("error", "")).lower(), (
-        f"the rejection did not say why a built-in cannot be updated: {result}"
-    )
+    assert "built-in" in message.lower(), f"the rejection did not say why a built-in cannot be updated: {message}"
 
 
 def test_update_plugin_refuses_a_plugin_that_is_not_a_git_checkout(mcp, updatable_plugins):
@@ -1109,17 +1116,13 @@ def test_update_plugin_refuses_a_plugin_that_is_not_a_git_checkout(mcp, updatabl
     Without the REST path's ``.git`` check the tool reports success for a
     directory it has no way to update.
     """
-    result = call(mcp, "update_plugin", plugin_id=PLUGIN_ID)
+    message = call_expect_error(mcp, "update_plugin", plugin_id=PLUGIN_ID)
 
-    assert result.get("status") == "error", f"a plugin with no git checkout was reported as updated: {result}"
-    assert "git" in str(result.get("error", "")).lower(), (
-        f"the rejection did not name the missing git checkout: {result}"
-    )
+    assert "git" in message.lower(), f"the rejection did not name the missing git checkout: {message}"
 
 
 def test_update_plugin_reports_an_error_for_an_unknown_plugin(mcp, updatable_plugins):
-    result = call(mcp, "update_plugin", plugin_id="not_a_plugin")
-    assert result.get("status") == "error", f"updating a plugin that does not exist reported success: {result}"
+    call_expect_error(mcp, "update_plugin", plugin_id="not_a_plugin")
 
 
 # ---------------------------------------------------------------------------
@@ -1205,10 +1208,9 @@ def test_set_schedule_mode_without_board_id_keeps_targeting_the_primary_board(mc
 
 
 def test_set_schedule_mode_reports_an_unknown_board(mcp, services, two_boards):
-    result = call(mcp, "set_schedule_mode", enabled=True, board_id="no-such-board")
+    message = call_expect_error(mcp, "set_schedule_mode", enabled=True, board_id="no-such-board")
 
-    assert result.get("status") == "error", f"an unknown board_id was reported as success: {result}"
-    assert "no-such-board" in str(result.get("error", ""))
+    assert "no-such-board" in message
     assert two_boards.is_schedule_enabled("board-main") is False
     assert two_boards.is_schedule_enabled("board-note") is False
 
@@ -1373,10 +1375,9 @@ def test_send_message_to_a_paused_board_is_blocked_without_touching_it(mcp, serv
 
 
 def test_send_message_reports_an_unknown_board(mcp, services, engine):
-    result = call(mcp, "send_message", text="HI", board_id="no-such-board")
+    message = call_expect_error(mcp, "send_message", text="HI", board_id="no-such-board")
 
-    assert result.get("status") == "error"
-    assert "no-such-board" in str(result.get("error", ""))
+    assert "no-such-board" in message
     assert engine.vb_client.rendered == []
 
 
@@ -1430,9 +1431,8 @@ def test_get_active_page_resolves_a_collection_to_its_member(mcp, services, two_
 
 
 def test_get_active_page_reports_an_unknown_board(mcp, services, two_boards):
-    result = call(mcp, "get_active_page", board_id="no-such-board")
-    assert result.get("status") == "error"
-    assert "no-such-board" in str(result.get("error", ""))
+    message = call_expect_error(mcp, "get_active_page", board_id="no-such-board")
+    assert "no-such-board" in message
 
 
 # -- get_board_content ------------------------------------------------------
@@ -1500,9 +1500,8 @@ def test_preview_saved_page_reports_board_fit(mcp, services, two_boards, monkeyp
 
 
 def test_preview_saved_page_unknown_page_is_an_error(mcp, services):
-    result = call(mcp, "preview_saved_page", page_id="no-such-page")
-    assert result.get("status") == "error"
-    assert "no-such-page" in str(result.get("error", ""))
+    message = call_expect_error(mcp, "preview_saved_page", page_id="no-such-page")
+    assert "no-such-page" in message
 
 
 # -- validate_template ------------------------------------------------------
@@ -1523,5 +1522,5 @@ def test_validate_template_reports_a_broken_formula_with_position(mcp, services)
 
 
 def test_validate_template_rejects_an_unknown_device_type(mcp, services):
-    result = call(mcp, "validate_template", template="HI", device_type="jumbotron")
-    assert result.get("status") == "error"
+    message = call_expect_error(mcp, "validate_template", template="HI", device_type="jumbotron")
+    assert "jumbotron" in message

--- a/tests/test_mcp_state_effects.py
+++ b/tests/test_mcp_state_effects.py
@@ -1567,9 +1567,7 @@ def test_render_page_preview_gives_plugins_the_real_board_context(mcp, plugins):
     )
 
     first_row = result["rendered"].split("\n")[0]
-    assert "15" in first_row, (
-        f"a note render must hand plugins a 15-column BoardContext; the plugin saw: {first_row!r}"
-    )
+    assert "15" in first_row, f"a note render must hand plugins a 15-column BoardContext; the plugin saw: {first_row!r}"
     assert PLUGIN_ID in result["context_plugins"]
 
 

--- a/tests/test_mcp_state_effects.py
+++ b/tests/test_mcp_state_effects.py
@@ -89,6 +89,11 @@ COVERED = {
     "update_plugin",
     "set_active_page",
     "set_schedule_mode",
+    "get_active_page",
+    "get_board_content",
+    "send_message",
+    "preview_saved_page",
+    "validate_template",
 }
 
 #: Tools not yet covered here, each with the reason. Not an exemption list.
@@ -1261,3 +1266,262 @@ def test_get_settings_summary_boards_never_leak_credentials(mcp, services, two_b
     flat = json.dumps(result.get("boards", []))
     assert "test_secret_key" not in flat, "a board API key leaked through get_settings_summary"
     assert "192.168.0.99" not in flat, "a board host leaked through get_settings_summary"
+
+
+# ---------------------------------------------------------------------------
+# Read-back and action tools — issue #1765
+#
+# The MCP surface was write-only: nothing reported the resolved active page,
+# the board's current content, or a saved page's rendered output, and there
+# was no ad-hoc send. The display engine is faked with a minimal object (not
+# a MagicMock) so a tool calling a method that does not exist raises.
+# ---------------------------------------------------------------------------
+
+
+class _FakeClient:
+    def __init__(self):
+        self.rendered: list[list[list[int]]] = []
+        self._last_characters = None
+
+    def render(self, board_array, **kwargs):
+        self.rendered.append(board_array)
+        self._last_characters = board_array
+        return (True, True)
+
+
+class _FakeRuntime:
+    def __init__(self, client):
+        self.client = client
+        self.polled_characters = None
+        self.polled_at = None
+
+
+class _FakeEngine:
+    """Just the DisplayService surface the board tools are allowed to touch."""
+
+    def __init__(self, board_ids):
+        self.runtimes = {bid: _FakeRuntime(_FakeClient()) for bid in board_ids}
+        self._primary_id = board_ids[0]
+        self.out_of_band: list = []
+        self.refreshes = 0
+        self._polled_characters = None
+        self._polled_at = None
+
+    @property
+    def vb_client(self):
+        return self.runtimes[self._primary_id].client
+
+    def get_board_client(self, board_id):
+        rt = self.runtimes.get(board_id)
+        return rt.client if rt else None
+
+    def get_runtime(self, board_id):
+        return self.runtimes.get(board_id)
+
+    def mark_showing_out_of_band(self, board_id=None):
+        self.out_of_band.append(board_id)
+
+    def request_board_refresh(self):
+        self.refreshes += 1
+
+
+@pytest.fixture
+def engine(two_boards, monkeypatch):
+    fake = _FakeEngine(["board-main", "board-note"])
+    monkeypatch.setattr("src.api_server.get_service", lambda: fake)
+    return fake
+
+
+# -- send_message -----------------------------------------------------------
+
+
+def test_send_message_renders_to_the_primary_board_client(mcp, services, engine):
+    result = assert_ok(call(mcp, "send_message", text="HELLO"), "send_message")
+
+    assert result["status"] == "success"
+    grids = engine.vb_client.rendered
+    assert len(grids) == 1, "send_message did not render exactly once"
+    assert (len(grids[0]), len(grids[0][0])) == (6, 22), "primary flagship grid must be 6x22"
+    assert engine.runtimes["board-note"].client.rendered == [], "the other board was touched"
+
+
+def test_send_message_with_board_id_targets_that_board_at_its_own_size(mcp, services, engine):
+    assert_ok(call(mcp, "send_message", text="HI", board_id="board-note"), "send_message")
+
+    grids = engine.runtimes["board-note"].client.rendered
+    assert len(grids) == 1
+    assert (len(grids[0]), len(grids[0][0])) == (3, 15), "note board grid must be 3x15, not flagship 6x22"
+    assert engine.vb_client.rendered == [], "the primary board was touched"
+
+
+def test_send_message_marks_the_write_out_of_band(mcp, services, engine):
+    """Issue #1794/#1831: an ad-hoc send bypasses the display loop and the
+    state publisher must know the board no longer shows the configured page."""
+    assert_ok(call(mcp, "send_message", text="HELLO"), "send_message")
+
+    assert engine.out_of_band == [None], "primary send must be marked out-of-band"
+
+
+def test_send_message_to_a_paused_board_is_blocked_without_touching_it(mcp, services, engine, two_boards):
+    two_boards.set_paused(True, board_id="board-note")
+
+    result = call(mcp, "send_message", text="HI", board_id="board-note")
+
+    assert result.get("status") == "blocked", f"a paused board accepted a send: {result}"
+    assert result.get("paused") is True
+    assert engine.runtimes["board-note"].client.rendered == []
+
+
+def test_send_message_reports_an_unknown_board(mcp, services, engine):
+    result = call(mcp, "send_message", text="HI", board_id="no-such-board")
+
+    assert result.get("status") == "error"
+    assert "no-such-board" in str(result.get("error", ""))
+    assert engine.vb_client.rendered == []
+
+
+# -- get_active_page --------------------------------------------------------
+
+
+def test_get_active_page_reads_back_the_selection_per_board(mcp, services, two_boards, monkeypatch):
+    monkeypatch.setattr("src.api_server.get_service", lambda: None)
+    main_page = assert_ok(
+        call(mcp, "create_page", name="Main", template_lines=FLAGSHIP_TEMPLATE, device_type="flagship"),
+        "create_page",
+    )
+    note_page = assert_ok(
+        call(mcp, "create_page", name="Note", template_lines=NOTE_TEMPLATE, device_type="note"),
+        "create_page",
+    )
+    assert_ok(call(mcp, "set_active_page", page_id=main_page["page_id"]), "set_active_page")
+    assert_ok(
+        call(mcp, "set_active_page", page_id=note_page["page_id"], board_id="board-note"),
+        "set_active_page",
+    )
+
+    primary = assert_ok(call(mcp, "get_active_page"), "get_active_page")
+    assert primary["active_ref"] == main_page["page_id"]
+    assert primary["resolved_page_id"] == main_page["page_id"]
+    assert primary["source"] == "manual"
+    assert primary["page"]["name"] == "Main"
+
+    note = assert_ok(call(mcp, "get_active_page", board_id="board-note"), "get_active_page")
+    assert note["active_ref"] == note_page["page_id"]
+    assert note["page"]["device_type"] == "note"
+
+
+def test_get_active_page_resolves_a_collection_to_its_member(mcp, services, two_boards, monkeypatch):
+    monkeypatch.setattr("src.api_server.get_service", lambda: None)
+    page = assert_ok(
+        call(mcp, "create_page", name="Member", template_lines=FLAGSHIP_TEMPLATE, device_type="flagship"),
+        "create_page",
+    )
+    coll = assert_ok(
+        call(mcp, "create_collection", name="Loop", page_ids=[page["page_id"]]),
+        "create_collection",
+    )
+    assert_ok(call(mcp, "set_active_page", page_id=coll["collection_id"]), "set_active_page")
+
+    result = assert_ok(call(mcp, "get_active_page"), "get_active_page")
+
+    assert result["active_ref"] == coll["collection_id"]
+    assert result["resolved_page_id"] == page["page_id"]
+    assert result["page"]["name"] == "Member"
+
+
+def test_get_active_page_reports_an_unknown_board(mcp, services, two_boards):
+    result = call(mcp, "get_active_page", board_id="no-such-board")
+    assert result.get("status") == "error"
+    assert "no-such-board" in str(result.get("error", ""))
+
+
+# -- get_board_content ------------------------------------------------------
+
+
+def test_get_board_content_reads_the_primary_poll_cache(mcp, services, engine):
+    grid = [[1] * 22 for _ in range(6)]
+    engine._polled_characters = grid
+
+    result = assert_ok(call(mcp, "get_board_content"), "get_board_content")
+
+    assert result["characters"] == grid
+    assert result["source"] == "polled"
+    assert (result["rows"], result["cols"]) == (6, 22)
+    assert result["message"].splitlines()[0] == "A" * 22
+
+
+def test_get_board_content_reads_a_secondary_boards_runtime_cache(mcp, services, engine):
+    """After a send to board-note, its content is readable without a live poll."""
+    assert_ok(call(mcp, "send_message", text="HI", board_id="board-note"), "send_message")
+
+    result = assert_ok(call(mcp, "get_board_content", board_id="board-note"), "get_board_content")
+
+    assert result["source"] == "last_sent"
+    assert (result["rows"], result["cols"]) == (3, 15)
+    assert result["characters"] == engine.runtimes["board-note"].client._last_characters
+
+
+def test_get_board_content_is_null_when_nothing_was_ever_sent(mcp, services, engine):
+    result = assert_ok(call(mcp, "get_board_content", board_id="board-note"), "get_board_content")
+    assert result["characters"] is None
+    assert result["message"] is None
+
+
+# -- preview_saved_page -----------------------------------------------------
+
+
+def test_preview_saved_page_renders_the_stored_page(mcp, services):
+    created = assert_ok(
+        call(mcp, "create_page", name="Stored", template_lines=FLAGSHIP_TEMPLATE, device_type="flagship"),
+        "create_page",
+    )
+
+    result = assert_ok(call(mcp, "preview_saved_page", page_id=created["page_id"]), "preview_saved_page")
+
+    assert result["name"] == "Stored"
+    assert len(result["rows"]) == 6, "a flagship page must render 6 rows"
+    assert result["rows"][0].strip() == "HELLO"
+    assert "line_metadata" in result
+
+
+def test_preview_saved_page_reports_board_fit(mcp, services, two_boards, monkeypatch):
+    monkeypatch.setattr("src.api_server.get_service", lambda: None)
+    created = assert_ok(
+        call(mcp, "create_page", name="Flag", template_lines=FLAGSHIP_TEMPLATE, device_type="flagship"),
+        "create_page",
+    )
+
+    result = assert_ok(
+        call(mcp, "preview_saved_page", page_id=created["page_id"], board_id="board-note"),
+        "preview_saved_page",
+    )
+
+    assert result["fits_board"] is False, "a flagship page does not fit a note board"
+
+
+def test_preview_saved_page_unknown_page_is_an_error(mcp, services):
+    result = call(mcp, "preview_saved_page", page_id="no-such-page")
+    assert result.get("status") == "error"
+    assert "no-such-page" in str(result.get("error", ""))
+
+
+# -- validate_template ------------------------------------------------------
+
+
+def test_validate_template_accepts_a_clean_template(mcp, services):
+    result = assert_ok(call(mcp, "validate_template", template=["HELLO", ""]), "validate_template")
+    assert result["valid"] is True
+    assert result["errors"] == []
+
+
+def test_validate_template_reports_a_broken_formula_with_position(mcp, services):
+    result = call(mcp, "validate_template", template="{{= 1 + @ }}")
+
+    assert result["valid"] is False
+    assert result["errors"], "a broken formula produced no errors"
+    assert all({"line", "column", "message"} <= set(e) for e in result["errors"])
+
+
+def test_validate_template_rejects_an_unknown_device_type(mcp, services):
+    result = call(mcp, "validate_template", template="HI", device_type="jumbotron")
+    assert result.get("status") == "error"

--- a/tests/test_mcp_state_effects.py
+++ b/tests/test_mcp_state_effects.py
@@ -174,7 +174,13 @@ def _manifest(plugin_id: str, version: str = "1.0.0") -> dict[str, Any]:
                     "type": "string",
                     "max_length": 5,
                     "example": "06:12",
-                }
+                },
+                "board_cols": {
+                    "description": "Column count of the board being rendered on",
+                    "type": "string",
+                    "max_length": 8,
+                    "example": "22",
+                },
             }
         },
     }
@@ -199,7 +205,11 @@ class HarnessPlugin(PluginBase):
         return []
 
     def fetch_data(self) -> PluginResult:
-        return PluginResult(available=True, data={{"next_high": "06:12"}})
+        # board_cols makes render fidelity observable: a render that builds
+        # its plugin context WITHOUT a BoardContext sees "no-board" here.
+        board = getattr(self, "board", None)
+        cols = str(board.cols) if board is not None else "no-board"
+        return PluginResult(available=True, data={{"next_high": "06:12", "board_cols": cols}})
 '''
 
 
@@ -1524,3 +1534,57 @@ def test_validate_template_reports_a_broken_formula_with_position(mcp, services)
 def test_validate_template_rejects_an_unknown_device_type(mcp, services):
     message = call_expect_error(mcp, "validate_template", template="HI", device_type="jumbotron")
     assert "jumbotron" in message
+
+
+# ---------------------------------------------------------------------------
+# render_page_preview fidelity — issue #1765
+#
+# The ad-hoc preview built its plugin context with NO BoardContext and took
+# no line_metadata, so board-aware plugins previewed wrong and alignment/
+# wrap could not be previewed at all — unlike the saved-page render path.
+# ---------------------------------------------------------------------------
+
+
+def _enable_harness_plugin(mcp):
+    assert_ok(
+        call(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"station_id": "9447427"}),
+        "configure_plugin",
+    )
+    assert_ok(call(mcp, "enable_plugin", plugin_id=PLUGIN_ID), "enable_plugin")
+
+
+def test_render_page_preview_gives_plugins_the_real_board_context(mcp, plugins):
+    _enable_harness_plugin(mcp)
+
+    result = assert_ok(
+        call(
+            mcp,
+            "render_page_preview",
+            template_lines=["{{" + PLUGIN_ID + ".board_cols}}", "", ""],
+            device_type="note",
+        ),
+        "render_page_preview",
+    )
+
+    first_row = result["rendered"].split("\n")[0]
+    assert "15" in first_row, (
+        f"a note render must hand plugins a 15-column BoardContext; the plugin saw: {first_row!r}"
+    )
+    assert PLUGIN_ID in result["context_plugins"]
+
+
+def test_render_page_preview_applies_line_metadata(mcp, services):
+    result = assert_ok(
+        call(
+            mcp,
+            "render_page_preview",
+            template_lines=["HI", "", "", "", "", ""],
+            device_type="flagship",
+            line_metadata=[{"alignment": "center"}],
+        ),
+        "render_page_preview",
+    )
+
+    first_row = result["rendered"].split("\n")[0]
+    assert first_row.strip() == "HI"
+    assert first_row.index("HI") > 0, "center alignment from line_metadata was not applied"

--- a/tests/test_mcp_state_effects.py
+++ b/tests/test_mcp_state_effects.py
@@ -1477,6 +1477,25 @@ def test_get_board_content_is_null_when_nothing_was_ever_sent(mcp, services, eng
     assert result["message"] is None
 
 
+def test_get_board_content_serves_the_primary_by_its_own_id_when_sentinel_keyed(mcp, services, two_boards, monkeypatch):
+    """Legacy installs key the primary runtime under the __primary__ sentinel,
+    not its settings board id. Asking for the primary by its OWN id then
+    missed every cache and returned nulls, while omitting board_id worked —
+    mirror the mark_showing_out_of_band fallback and route the primary's id
+    to the primary path (#1874 review).
+    """
+    fake = _FakeEngine(["__primary__", "board-note"])
+    grid = [[1] * 22 for _ in range(6)]
+    fake._polled_characters = grid
+    monkeypatch.setattr("src.api_server.get_service", lambda: fake)
+
+    result = assert_ok(call(mcp, "get_board_content", board_id="board-main"), "get_board_content")
+
+    assert result["characters"] == grid, "the primary's own id missed the sentinel-keyed cache"
+    assert result["source"] == "polled"
+    assert result["board_id"] == "board-main"
+
+
 # -- preview_saved_page -----------------------------------------------------
 
 
@@ -1507,6 +1526,20 @@ def test_preview_saved_page_reports_board_fit(mcp, services, two_boards, monkeyp
     )
 
     assert result["fits_board"] is False, "a flagship page does not fit a note board"
+
+
+def test_preview_saved_page_reports_an_unknown_board(mcp, services, two_boards):
+    """fits_board: true for a board that does not exist is an answer about
+    nothing. Same roster existence check as the sibling board tools —
+    ToolError "Board not found" (#1874 review)."""
+    created = assert_ok(
+        call(mcp, "create_page", name="Flag", template_lines=FLAGSHIP_TEMPLATE, device_type="flagship"),
+        "create_page",
+    )
+
+    message = call_expect_error(mcp, "preview_saved_page", page_id=created["page_id"], board_id="no-such-board")
+
+    assert "no-such-board" in message
 
 
 def test_preview_saved_page_unknown_page_is_an_error(mcp, services):

--- a/tests/test_mcp_state_effects.py
+++ b/tests/test_mcp_state_effects.py
@@ -87,13 +87,13 @@ COVERED = {
     "configure_plugin",
     "get_plugin_data",
     "update_plugin",
+    "set_active_page",
+    "set_schedule_mode",
 }
 
 #: Tools not yet covered here, each with the reason. Not an exemption list.
 UNCOVERED = {
     "list_registry_plugins": "hits the network-backed registry; needs a fixture",
-    "set_active_page": "delegates to the REST handler; needs board render wiring",
-    "set_schedule_mode": "routes through SettingsService; needs settings wiring",
 }
 
 
@@ -1115,3 +1115,149 @@ def test_update_plugin_refuses_a_plugin_that_is_not_a_git_checkout(mcp, updatabl
 def test_update_plugin_reports_an_error_for_an_unknown_plugin(mcp, updatable_plugins):
     result = call(mcp, "update_plugin", plugin_id="not_a_plugin")
     assert result.get("status") == "error", f"updating a plugin that does not exist reported success: {result}"
+
+
+# ---------------------------------------------------------------------------
+# Multi-board — issue #1765
+#
+# On a multi-board install, set_active_page and set_schedule_mode silently
+# targeted only the primary board while reporting success. These tests run a
+# real SettingsService over two configured boards and read the per-board
+# state back after each call.
+# ---------------------------------------------------------------------------
+
+NOTE_TEMPLATE = ["HI", "", ""]
+
+
+@pytest.fixture
+def two_boards(services, tmp_path, monkeypatch):
+    """A real SettingsService over tmp storage with two configured boards."""
+    import src.settings.service as settings_module
+
+    svc = settings_module.SettingsService(settings_file=str(tmp_path / "settings.json"))
+    svc.set_boards(
+        [
+            {"id": "board-main", "name": "Living Room", "device_type": "flagship"},
+            {"id": "board-note", "name": "Kitchen", "device_type": "note"},
+        ]
+    )
+    monkeypatch.setattr(settings_module, "_settings_service", svc)
+    # No display engine in this harness: selection must persist even when the
+    # immediate board send is skipped.
+    monkeypatch.setattr("src.api_server.get_service", lambda: None)
+    return svc
+
+
+def test_set_active_page_with_board_id_changes_only_that_board(mcp, services, two_boards):
+    main_page = assert_ok(
+        call(mcp, "create_page", name="Main", template_lines=FLAGSHIP_TEMPLATE, device_type="flagship"),
+        "create_page",
+    )
+    note_page = assert_ok(
+        call(mcp, "create_page", name="Note", template_lines=NOTE_TEMPLATE, device_type="note"),
+        "create_page",
+    )
+
+    assert_ok(call(mcp, "set_active_page", page_id=main_page["page_id"]), "set_active_page (primary)")
+    assert_ok(
+        call(mcp, "set_active_page", page_id=note_page["page_id"], board_id="board-note"),
+        "set_active_page (board-note)",
+    )
+
+    assert two_boards.get_active_page_id(board_id="board-note") == note_page["page_id"]
+    assert two_boards.get_active_page_id() == main_page["page_id"], (
+        "targeting board-note must leave the primary board's active page untouched"
+    )
+
+
+def test_set_active_page_without_board_id_keeps_targeting_the_primary_board(mcp, services, two_boards):
+    """Backward compatibility: omitting board_id is the legacy primary-board call."""
+    page = assert_ok(
+        call(mcp, "create_page", name="Legacy", template_lines=FLAGSHIP_TEMPLATE, device_type="flagship"),
+        "create_page",
+    )
+
+    assert_ok(call(mcp, "set_active_page", page_id=page["page_id"]), "set_active_page")
+
+    assert two_boards.get_active_page_id() == page["page_id"]
+    assert two_boards.get_active_page_id(board_id="board-note") is None
+
+
+def test_set_schedule_mode_with_board_id_changes_only_that_board(mcp, services, two_boards):
+    assert_ok(call(mcp, "set_schedule_mode", enabled=True, board_id="board-note"), "set_schedule_mode")
+
+    assert two_boards.is_schedule_enabled("board-note") is True
+    assert two_boards.is_schedule_enabled("board-main") is False, (
+        "targeting board-note must leave the primary board's schedule mode untouched"
+    )
+
+
+def test_set_schedule_mode_without_board_id_keeps_targeting_the_primary_board(mcp, services, two_boards):
+    assert_ok(call(mcp, "set_schedule_mode", enabled=True), "set_schedule_mode")
+
+    assert two_boards.is_schedule_enabled("board-main") is True
+    assert two_boards.is_schedule_enabled("board-note") is False
+
+
+def test_set_schedule_mode_reports_an_unknown_board(mcp, services, two_boards):
+    result = call(mcp, "set_schedule_mode", enabled=True, board_id="no-such-board")
+
+    assert result.get("status") == "error", f"an unknown board_id was reported as success: {result}"
+    assert "no-such-board" in str(result.get("error", ""))
+    assert two_boards.is_schedule_enabled("board-main") is False
+    assert two_boards.is_schedule_enabled("board-note") is False
+
+
+def test_get_settings_summary_reports_boards_schedule_and_active_page(mcp, services, two_boards):
+    """The troubleshoot prompt walks schedule + active page; the boards list is
+    what lets a model target board 2 and pick correct dimensions (#1765)."""
+    page = assert_ok(
+        call(mcp, "create_page", name="Summary", template_lines=FLAGSHIP_TEMPLATE, device_type="flagship"),
+        "create_page",
+    )
+    assert_ok(call(mcp, "set_active_page", page_id=page["page_id"]), "set_active_page")
+    two_boards.set_schedule_enabled(True, board_id="board-note")
+
+    result = assert_ok(call(mcp, "get_settings_summary"), "get_settings_summary")
+
+    assert result.get("active_page_id") == page["page_id"]
+    assert result.get("schedule", {}).get("enabled") is False, "schedule reflects the primary board"
+
+    boards = {b["id"]: b for b in result.get("boards", [])}
+    assert set(boards) == {"board-main", "board-note"}
+
+    main = boards["board-main"]
+    assert main["name"] == "Living Room"
+    assert main["device_type"] == "flagship"
+    assert (main["rows"], main["cols"]) == (6, 22)
+    assert main["primary"] is True
+    assert main["active_page_id"] == page["page_id"]
+    assert "error" in main, "the #1813 per-board init error surface is part of the contract"
+
+    note = boards["board-note"]
+    assert note["device_type"] == "note"
+    assert (note["rows"], note["cols"]) == (3, 15)
+    assert note["primary"] is False
+    assert note["schedule_enabled"] is True
+    assert note["paused"] is False and note["enabled"] is True
+
+
+def test_get_settings_summary_boards_never_leak_credentials(mcp, services, two_boards):
+    two_boards.set_boards(
+        [
+            {
+                "id": "board-main",
+                "name": "Living Room",
+                "device_type": "flagship",
+                "host": "192.168.0.99",
+                "local_api_key": "test_secret_key",
+            },
+            {"id": "board-note", "name": "Kitchen", "device_type": "note"},
+        ]
+    )
+
+    result = assert_ok(call(mcp, "get_settings_summary"), "get_settings_summary")
+
+    flat = json.dumps(result.get("boards", []))
+    assert "test_secret_key" not in flat, "a board API key leaked through get_settings_summary"
+    assert "192.168.0.99" not in flat, "a board host leaked through get_settings_summary"

--- a/tests/test_op_parity.py
+++ b/tests/test_op_parity.py
@@ -283,8 +283,13 @@ def test_parity_update_plugin_rejects_builtins_identically(tmp_path, mcp):
         assert result["status"] == "error"
 
     def mcp_steps(env):
-        result = mcp_call(mcp, "update_plugin", plugin_id=PLUGIN_ID)
-        assert result["status"] == "error"
+        # #1765: the MCP surface converts the executor's error envelope into
+        # a raised ToolError (protocol isError). The *state* parity below is
+        # unchanged — both grammars refuse and touch nothing.
+        from mcp.server.mcpserver.exceptions import ToolError
+
+        with pytest.raises(ToolError):
+            mcp_call(mcp, "update_plugin", plugin_id=PLUGIN_ID)
 
     assert_parity(tmp_path, chat_steps, mcp_steps, with_plugins=True)
 

--- a/tests/test_ops_registry.py
+++ b/tests/test_ops_registry.py
@@ -52,6 +52,9 @@ EXPECTED_CANONICAL = {
     "update_plugin",
     "update_setting",
     "trigger_system_update",
+    # MCP-only server op since #1765 — the REST POST /send-message
+    # equivalent; the chat grammar has no spelling for it today.
+    "send_message",
     # client-side chat ops, registered so the registry is the whole grammar
     "apply_patch",
     "suggest_variables",


### PR DESCRIPTION
Closes #1765; part of #1849. **Track A's final PR** — full chain: #1855 → #1860 → #1863 → #1865 → #1869 → #1873 → this. The last logged issue of the backend rework.

## What

- **Multi-board parity**: `set_active_page` / `set_schedule_mode` gain `board_id` (omitted = byte-identical legacy primary behavior; unknown board is now an explicit error instead of a silent no-op-reported-as-success). `get_settings_summary` gains schedule state, active page, and a **boards roster** (ids, device types, real dimensions, per-board active page, #1813 init errors) — with an explicit field projection so board credentials never cross the MCP boundary.
- **Five new tools** (28 → 33): `get_active_page`, `get_board_content` (read-only, never a live send), `send_message` (mirrors every REST gate — silence #1788, pause #970, out-of-band mark #1794/#1831 — via a shared `render_message` core the REST handler now also calls), `preview_saved_page` (with `fits_board` compat), `validate_template`. Instructions gained a MULTI-BOARD section.
- **Protocol errors**: one wrapper converts domain errors to `ToolError` → `isError: true`; unexpected exceptions log the traceback server-side and send a concise class-name message — no leaked tracebacks. Pre-fix the wire literally said `{"isError": false, "structuredContent": {"status": "error", ...}}`.
- **Paginated registry**: `list_registry_plugins(page, page_size, fields)` — the 33KB unpaginated preview dump becomes a <8KB default page with opt-in field projection.
- **Faithful previews**: `render_page_preview` builds a real `BoardContext` and passes `line_metadata` (pre-fix a note-board preview rendered `'no-board'` where the width belonged).

## Zero-regression evidence

- **Fail-first observed for every behavior change** (TypeErrors for missing params, 18 failures against reverted src for the new tools, the `isError: false` wire capture, 7 pagination failures, the `'no-board'` fidelity repro).
- ~35 error-path tests deliberately re-pinned from the old stringified contract to protocol errors, each with in-place justification (the repo's contract-reversal precedent); state-effect ledger updated with the 5 new tools.
- Full suite: baseline `5713 passed / 1 failed` → `5750 passed / same 1 environmental failure`. Route-inventory + response goldens untouched (no REST routes changed). ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP