### PR TITLE
feat(collections): Phase 2 slice 1 — conventions, seam retirement, web lockstep

### DIFF
--- a/src/api_errors.py
+++ b/src/api_errors.py
@@ -1,0 +1,50 @@
+"""Shared error-response declarations for the domain routers.
+
+Phase 2, spec §2: every converted domain serves **one** error contract —
+FastAPI's ``{"detail": <string>}`` — and *declares* the failure codes it can
+return so they appear in the OpenAPI schema and in the CI conventions ratchet
+(``tests/test_api_conventions_ratchet.py``).
+
+Usage in a router::
+
+    from src.api_errors import errors
+
+    @router.get("/things/{thing_id}", response_model=ThingResponse, responses=errors(404))
+    async def get_thing(thing_id: str): ...
+
+Declare only the codes a route can actually return. A route with no failure
+path declares nothing and carries a checked-in exception in
+``tests/conventions_manifest.json`` saying why.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class ErrorResponse(BaseModel):
+    """The single error body the API serves."""
+
+    detail: str
+
+
+#: Canonical description per status code, so sibling endpoints across domains
+#: document the same failure the same way.
+_DESCRIPTIONS: dict[int, str] = {
+    400: "Invalid request — the payload references something that does not exist or violates a rule.",
+    403: "Forbidden.",
+    404: "Resource not found.",
+    409: "Conflict — duplicate id, or a resource pinned by the environment.",
+    422: "Request body failed validation.",
+    503: "A required dependency is unavailable.",
+}
+
+
+def errors(*status_codes: int) -> dict[int | str, dict[str, Any]]:
+    """Build the ``responses=`` block for the given failure codes."""
+    unknown = [code for code in status_codes if code not in _DESCRIPTIONS]
+    if unknown:
+        raise ValueError(f"No canonical description for status code(s) {unknown}; add one to src/api_errors.py")
+    return {code: {"model": ErrorResponse, "description": _DESCRIPTIONS[code]} for code in status_codes}

--- a/src/collections/models.py
+++ b/src/collections/models.py
@@ -226,3 +226,32 @@ class CollectionUpdate(BaseModel):
     time: TimeModeConfig | None = None
     variable: VariableModeConfig | None = None
     random: RandomModeConfig | None = None
+
+
+# --- Response models -----------------------------------------------------
+#
+# Phase 2 conventions (spec §2): every route declares a ``response_model``.
+# Collections have no derived, masked, or computed wire fields, so the stored
+# model *is* the response model — ``CollectionResponse`` is an alias rather
+# than a copy, and the routes name the contract instead of the store.
+
+#: The wire shape of a single collection.
+CollectionResponse = Collection
+
+
+class CollectionListResponse(BaseModel):
+    """Body of ``GET /collections``."""
+
+    collections: list[Collection]
+    total: int
+
+
+class CollectionDeleteResponse(BaseModel):
+    """Body of ``DELETE /collections/{collection_id}``.
+
+    Per ``docs/internal/reference/API_CONVENTIONS.md`` a delete answers 200
+    with the deleted resource id (this domain's choice) — not a
+    ``{"status": "success"}`` envelope.
+    """
+
+    id: str

--- a/src/collections/routes.py
+++ b/src/collections/routes.py
@@ -1,19 +1,35 @@
 """FastAPI router for the collection endpoints.
 
-Handlers moved verbatim from ``src/api_server.py`` (issue #1756, pure move).
-Names that still live in ``api_server`` — the service getters and the
-template engine accessor — are imported *inside* each handler so they
-resolve through the api_server module at call time. The test-suite patches
-them as ``src.api_server.<name>``; a module-level import would both create
-an import cycle (api_server imports this router) and detach the moved
-handlers from those patches.
+Handlers were moved here verbatim from ``src/api_server.py`` (issue #1756);
+Phase 2 slice 1 then applied ``docs/internal/reference/API_CONVENTIONS.md`` to
+them and retired the call-time ``from src.api_server import ...`` seams the
+move left behind.
+
+Collaborators now resolve from their canonical homes at **module import
+time**, so this module never loads ``src.api_server``
+(``tests/test_collections_decoupled.py`` asserts that in a fresh
+interpreter). Tests that need to stub a collaborator patch it where this
+module binds it — ``src.collections.routes.<name>`` — not
+``src.api_server.<name>``.
 """
 
 from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException
 
-from .models import CollectionCreate, CollectionUpdate
+from src.api_errors import errors
+from src.pages.service import get_page_service
+from src.templates.engine import get_template_engine
+from src.templates.expressions import validate_expression
+
+from .models import (
+    CollectionCreate,
+    CollectionDeleteResponse,
+    CollectionListResponse,
+    CollectionResponse,
+    CollectionUpdate,
+)
+from .service import get_collection_service
 
 router = APIRouter(tags=["collections"])
 
@@ -30,8 +46,6 @@ def _validate_collection_payload(
     page, and statically validates variable-mode rule expressions against the
     known plugin sources before we let them hit storage.
     """
-    from src.api_server import get_template_engine  # patched-in-tests seam — see module docstring (#1756)
-
     page_ids = getattr(data, "page_ids", None)
     if page_ids is None and require_pages:
         return  # let Pydantic surface the missing field
@@ -57,10 +71,8 @@ def _validate_collection_payload(
                     detail=f"Variable rule {idx} page_id not in page_ids",
                 )
 
-    from src.templates.expressions import validate_expression
-
     template_engine = get_template_engine()
-    known_sources = template_engine._get_all_known_sources()
+    known_sources = template_engine.get_all_known_sources()
     for idx, rule in enumerate(variable.rules):
         issues = validate_expression(rule.expression, known_sources=known_sources)
         if issues:
@@ -71,59 +83,54 @@ def _validate_collection_payload(
             )
 
 
-@router.get("/collections")
+@router.get("/collections", response_model=CollectionListResponse)
 async def list_collections():
     """List all collections."""
-    from src.api_server import get_collection_service  # patched-in-tests seam — see module docstring (#1756)
-
     collection_service = get_collection_service()
     collections = collection_service.list_collections()
-    return {
-        "collections": [c.model_dump() for c in collections],
-        "total": len(collections),
-    }
+    return CollectionListResponse(collections=collections, total=len(collections))
 
 
-@router.post("/collections")
+@router.post(
+    "/collections",
+    response_model=CollectionResponse,
+    status_code=201,
+    responses=errors(400),
+)
 async def create_collection(data: CollectionCreate):
     """Create a new collection."""
-    from src.api_server import (  # patched-in-tests seam — see module docstring (#1756)
-        get_collection_service,
-        get_page_service,
-    )
-
     collection_service = get_collection_service()
     page_service = get_page_service()
 
     _validate_collection_payload(data, page_service)
 
     try:
-        collection = collection_service.create_collection(data)
-        return {"status": "success", "collection": collection.model_dump()}
+        return collection_service.create_collection(data)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
 
-@router.get("/collections/{collection_id}")
+@router.get(
+    "/collections/{collection_id}",
+    response_model=CollectionResponse,
+    responses=errors(404),
+)
 async def get_collection(collection_id: str):
     """Get a collection by ID."""
-    from src.api_server import get_collection_service  # patched-in-tests seam — see module docstring (#1756)
-
     collection_service = get_collection_service()
     collection = collection_service.get_collection(collection_id)
     if not collection:
         raise HTTPException(status_code=404, detail=f"Collection not found: {collection_id}")
-    return collection.model_dump()
+    return collection
 
 
-@router.put("/collections/{collection_id}")
+@router.put(
+    "/collections/{collection_id}",
+    response_model=CollectionResponse,
+    responses=errors(400, 404),
+)
 async def update_collection(collection_id: str, data: CollectionUpdate):
     """Update an existing collection."""
-    from src.api_server import (  # patched-in-tests seam — see module docstring (#1756)
-        get_collection_service,
-        get_page_service,
-    )
-
     collection_service = get_collection_service()
     page_service = get_page_service()
 
@@ -131,20 +138,22 @@ async def update_collection(collection_id: str, data: CollectionUpdate):
 
     try:
         collection = collection_service.update_collection(collection_id, data)
-        if not collection:
-            raise HTTPException(status_code=404, detail=f"Collection not found: {collection_id}")
-        return {"status": "success", "collection": collection.model_dump()}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
+    if not collection:
+        raise HTTPException(status_code=404, detail=f"Collection not found: {collection_id}")
+    return collection
 
 
-@router.delete("/collections/{collection_id}")
+@router.delete(
+    "/collections/{collection_id}",
+    response_model=CollectionDeleteResponse,
+    responses=errors(404),
+)
 async def delete_collection(collection_id: str):
     """Delete a collection."""
-    from src.api_server import get_collection_service  # patched-in-tests seam — see module docstring (#1756)
-
     collection_service = get_collection_service()
     deleted = collection_service.delete_collection(collection_id)
     if not deleted:
         raise HTTPException(status_code=404, detail=f"Collection not found: {collection_id}")
-    return {"status": "success", "message": f"Collection {collection_id} deleted"}
+    return CollectionDeleteResponse(id=collection_id)

--- a/src/templates/engine.py
+++ b/src/templates/engine.py
@@ -1464,7 +1464,7 @@ class TemplateEngine:
         lines = template.split("\n")
 
         # Get available sources based on system mode
-        available_sources = self._get_all_known_sources()
+        available_sources = self.get_all_known_sources()
 
         for line_num, line in enumerate(lines, 1):
             # Check for unclosed variable braces
@@ -1517,15 +1517,23 @@ class TemplateEngine:
 
         return errors
 
-    def _get_all_known_sources(self) -> set:
+    def get_all_known_sources(self) -> set:
         """Get all known plugin IDs (for validation).
 
         Includes all plugins, not just enabled ones, so templates
         can be validated even if not all plugins are enabled.
+
+        Public because routers validate payloads against it — reaching into
+        another object's ``_private`` members from a route is exactly what
+        ``docs/internal/reference/API_CONVENTIONS.md`` bans.
         """
         if not self._plugin_registry:
             return set()
         return set(self._plugin_registry.plugins.keys())
+
+    def _get_all_known_sources(self) -> set:
+        """Back-compat alias for :meth:`get_all_known_sources`."""
+        return self.get_all_known_sources()
 
     def _calculate_max_line_length(self, line: str, cols: int = 22) -> int:
         """Calculate maximum possible rendered length of a template line.

--- a/tests/golden/responses/collections.json
+++ b/tests/golden/responses/collections.json
@@ -15,25 +15,22 @@
       "label": "create_collection_ok",
       "method": "POST",
       "path_template": "/collections",
-      "status": 200,
+      "status": 201,
       "shape": {
-        "collection": {
-          "created_at": "str",
-          "id": "str",
-          "name": "str",
-          "page_ids": [
-            "str",
-            "str"
-          ],
-          "random": "null",
-          "selection_mode": "str",
-          "time": {
-            "interval_seconds": "int"
-          },
-          "updated_at": "null",
-          "variable": "null"
+        "created_at": "str",
+        "id": "str",
+        "name": "str",
+        "page_ids": [
+          "str",
+          "str"
+        ],
+        "random": "null",
+        "selection_mode": "str",
+        "time": {
+          "interval_seconds": "int"
         },
-        "status": "str"
+        "updated_at": "null",
+        "variable": "null"
       }
     },
     {
@@ -130,23 +127,20 @@
       "path_template": "/collections/{collection_id}",
       "status": 200,
       "shape": {
-        "collection": {
-          "created_at": "str",
-          "id": "str",
-          "name": "str",
-          "page_ids": [
-            "str",
-            "str"
-          ],
-          "random": "null",
-          "selection_mode": "str",
-          "time": {
-            "interval_seconds": "int"
-          },
-          "updated_at": "str",
-          "variable": "null"
+        "created_at": "str",
+        "id": "str",
+        "name": "str",
+        "page_ids": [
+          "str",
+          "str"
+        ],
+        "random": "null",
+        "selection_mode": "str",
+        "time": {
+          "interval_seconds": "int"
         },
-        "status": "str"
+        "updated_at": "str",
+        "variable": "null"
       }
     },
     {
@@ -173,8 +167,7 @@
       "path_template": "/collections/{collection_id}",
       "status": 200,
       "shape": {
-        "message": "str",
-        "status": "str"
+        "id": "str"
       }
     },
     {

--- a/tests/test_api_coverage_extended.py
+++ b/tests/test_api_coverage_extended.py
@@ -933,14 +933,23 @@ class TestGenericDataTestFetch:
 
 
 class TestCollectionErrors:
+    """Patch targets live on ``src.collections.routes`` (Phase 2 slice 1).
+
+    The collections router used to re-import its collaborators from
+    ``src.api_server`` at call time purely so these patches kept working. That
+    seam is gone: the router binds ``get_collection_service`` /
+    ``get_page_service`` at import time from their canonical modules, so a stub
+    goes where the router looks the name up.
+    """
+
     def test_create_collection_value_error(self, client):
         mock_cs = Mock()
         mock_cs.create_collection.side_effect = ValueError("Duplicate name")
         mock_ps = Mock()
         mock_ps.get_page.return_value = Mock()
         with (
-            patch("src.api_server.get_collection_service", return_value=mock_cs),
-            patch("src.api_server.get_page_service", return_value=mock_ps),
+            patch("src.collections.routes.get_collection_service", return_value=mock_cs),
+            patch("src.collections.routes.get_page_service", return_value=mock_ps),
         ):
             resp = client.post("/collections", json={"name": "Test", "page_ids": ["p1"]})
         assert resp.status_code == 400
@@ -952,8 +961,8 @@ class TestCollectionErrors:
         mock_ps = Mock()
         mock_ps.get_page.return_value = Mock()
         with (
-            patch("src.api_server.get_collection_service", return_value=mock_cs),
-            patch("src.api_server.get_page_service", return_value=mock_ps),
+            patch("src.collections.routes.get_collection_service", return_value=mock_cs),
+            patch("src.collections.routes.get_page_service", return_value=mock_ps),
         ):
             resp = client.put("/collections/c1", json={"name": "Updated", "page_ids": ["p1"]})
         assert resp.status_code == 400

--- a/tests/test_collections_contract.py
+++ b/tests/test_collections_contract.py
@@ -6,11 +6,24 @@ it cannot see a wrong id, a reordered ``page_ids`` list, or an error string that
 stopped naming the missing resource — the class of regression Phase 1's masking
 bug proved shape goldens miss.
 
-Every assertion below is a promise this domain makes to the web client. The
-conversion in this PR is allowed to change the *envelope* (create returns the
-bare resource at 201 instead of ``{"status": "success", "collection": ...}``),
-and those specific lines are re-pinned in the same commit with a comment naming
-the change. Nothing else may move.
+Every assertion below is a promise this domain makes to the web client.
+
+Re-pinned by the conventions pass in this same PR. What deliberately changed,
+and nothing else:
+
+* ``POST /collections`` answers **201** (was 200) with the **bare** collection
+  (was ``{"status": "success", "collection": {...}}``) — conventions doc,
+  "Status codes" and "Bare bodies".
+* ``PUT /collections/{id}`` answers 200 with the **bare** collection (was the
+  same ``status``/``collection`` envelope).
+* ``DELETE /collections/{id}`` answers 200 with ``{"id": <deleted id>}`` (was
+  ``{"status": "success", "message": "Collection <id> deleted"}``) — the
+  conventions doc lets a domain pick "200 with the deleted resource id" or
+  "204 with no body"; collections picks the former.
+
+Every value assertion — ids, ``page_ids`` ordering, list ordering and total,
+error strings, status codes on the failure paths — is unchanged from the
+pre-conversion recording. None was weakened.
 """
 
 from __future__ import annotations
@@ -59,8 +72,8 @@ def _create(client: TestClient, **body) -> dict:
     is a one-line change instead of a sweep.
     """
     response = client.post("/collections", json=body)
-    assert response.status_code == 200, response.text
-    return response.json()["collection"]
+    assert response.status_code == 201, response.text
+    return response.json()
 
 
 # ── create ──────────────────────────────────────────────────────────────────
@@ -71,10 +84,9 @@ def test_create_returns_the_created_collection_with_its_values(client, pages):
 
     response = client.post("/collections", json={"name": "Morning", "page_ids": [page_a, page_b]})
 
-    assert response.status_code == 200, response.text
-    body = response.json()
-    assert body["status"] == "success"
-    collection = body["collection"]
+    # RE-PINNED: 201 + bare resource (was 200 + {"status", "collection"}).
+    assert response.status_code == 201, response.text
+    collection = response.json()
     assert collection["name"] == "Morning"
     assert collection["page_ids"] == [page_a, page_b]
     assert collection["selection_mode"] == "time"
@@ -182,10 +194,9 @@ def test_update_returns_the_updated_collection_and_keeps_its_id(client, pages):
 
     response = client.put(f"/collections/{created['id']}", json={"name": "After", "page_ids": [page_b, page_a]})
 
+    # RE-PINNED: bare resource (was {"status", "collection"}); status stays 200.
     assert response.status_code == 200, response.text
-    body = response.json()
-    assert body["status"] == "success"
-    updated = body["collection"]
+    updated = response.json()
     assert updated["id"] == created["id"]
     assert updated["name"] == "After"
     assert updated["page_ids"] == [page_b, page_a]
@@ -200,7 +211,7 @@ def test_update_leaves_unsent_fields_alone(client, pages):
     response = client.put(f"/collections/{created['id']}", json={"name": "Renamed Only"})
 
     assert response.status_code == 200, response.text
-    updated = response.json()["collection"]
+    updated = response.json()  # RE-PINNED: bare resource
     assert updated["name"] == "Renamed Only"
     assert updated["page_ids"] == [page_a, page_b]
 
@@ -232,10 +243,8 @@ def test_delete_removes_the_collection_and_reports_it(client, pages):
     response = client.delete(f"/collections/{created['id']}")
 
     assert response.status_code == 200, response.text
-    assert response.json() == {
-        "status": "success",
-        "message": f"Collection {created['id']} deleted",
-    }
+    # RE-PINNED: the deleted resource id (was {"status": "success", "message": ...}).
+    assert response.json() == {"id": created["id"]}
     assert client.get(f"/collections/{created['id']}").status_code == 404
     assert client.get("/collections").json() == {"collections": [], "total": 0}
 

--- a/tests/test_collections_contract.py
+++ b/tests/test_collections_contract.py
@@ -1,0 +1,247 @@
+"""Value-level contract goldens for the /collections API (Phase 2 §2, slice 1).
+
+These are deliberately *values*, not shapes. The shape corpus in
+``tests/golden/responses/collections.json`` records key sets and type names, so
+it cannot see a wrong id, a reordered ``page_ids`` list, or an error string that
+stopped naming the missing resource — the class of regression Phase 1's masking
+bug proved shape goldens miss.
+
+Every assertion below is a promise this domain makes to the web client. The
+conversion in this PR is allowed to change the *envelope* (create returns the
+bare resource at 201 instead of ``{"status": "success", "collection": ...}``),
+and those specific lines are re-pinned in the same commit with a comment naming
+the change. Nothing else may move.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+MISSING_ID = "collection:00000000-dead-beef-0000-000000000000"
+
+
+@pytest.fixture
+def client(_isolated_data_dir):
+    """A TestClient whose services all resolve into this test's temp data dir."""
+    from src.api_server import app
+
+    return TestClient(app)
+
+
+def _seed_page(client: TestClient, name: str, first_line: str) -> str:
+    response = client.post(
+        "/pages",
+        json={
+            "name": name,
+            "type": "template",
+            "device_type": "flagship",
+            "template": [first_line, "", "", "", "", ""],
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["page"]["id"]
+
+
+@pytest.fixture
+def pages(client) -> tuple[str, str]:
+    """Two real pages, so collection membership validation passes."""
+    return (
+        _seed_page(client, "Contract Page A", "AAA"),
+        _seed_page(client, "Contract Page B", "BBB"),
+    )
+
+
+def _create(client: TestClient, **body) -> dict:
+    """POST /collections and return the created collection as a dict.
+
+    The one place that knows the create envelope, so re-pinning the envelope
+    is a one-line change instead of a sweep.
+    """
+    response = client.post("/collections", json=body)
+    assert response.status_code == 200, response.text
+    return response.json()["collection"]
+
+
+# ── create ──────────────────────────────────────────────────────────────────
+
+
+def test_create_returns_the_created_collection_with_its_values(client, pages):
+    page_a, page_b = pages
+
+    response = client.post("/collections", json={"name": "Morning", "page_ids": [page_a, page_b]})
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "success"
+    collection = body["collection"]
+    assert collection["name"] == "Morning"
+    assert collection["page_ids"] == [page_a, page_b]
+    assert collection["selection_mode"] == "time"
+    assert collection["time"] == {"interval_seconds": 30}
+    assert collection["variable"] is None
+    assert collection["random"] is None
+    assert collection["updated_at"] is None
+
+
+def test_create_mints_a_prefixed_collection_id(client, pages):
+    page_a, _ = pages
+
+    collection = _create(client, name="Prefixed", page_ids=[page_a])
+
+    assert collection["id"].startswith("collection:")
+    assert len(collection["id"]) > len("collection:")
+
+
+def test_create_preserves_page_ids_order_verbatim(client, pages):
+    """``page_ids`` is an ordered playlist, not a set — reversal is a bug."""
+    page_a, page_b = pages
+
+    forwards = _create(client, name="Forwards", page_ids=[page_a, page_b])
+    backwards = _create(client, name="Backwards", page_ids=[page_b, page_a])
+
+    assert forwards["page_ids"] == [page_a, page_b]
+    assert backwards["page_ids"] == [page_b, page_a]
+
+
+def test_create_rejects_an_unknown_page_with_400_naming_the_page(client, pages):
+    page_a, _ = pages
+
+    response = client.post("/collections", json={"name": "Bad", "page_ids": [page_a, "no-such-page"]})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Page not found: no-such-page"}
+
+
+def test_create_rejects_a_missing_page_ids_field_with_422(client):
+    response = client.post("/collections", json={"name": "No Pages"})
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert isinstance(detail, list)
+    assert [d["loc"] for d in detail] == [["body", "page_ids"]]
+    assert detail[0]["type"] == "missing"
+
+
+def test_create_rejects_an_empty_page_ids_list_with_422(client):
+    response = client.post("/collections", json={"name": "Empty", "page_ids": []})
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert [d["loc"] for d in detail] == [["body", "page_ids"]]
+    assert detail[0]["type"] == "too_short"
+
+
+# ── read ────────────────────────────────────────────────────────────────────
+
+
+def test_get_round_trips_the_created_collection_by_id(client, pages):
+    page_a, page_b = pages
+    created = _create(client, name="Round Trip", page_ids=[page_a, page_b])
+
+    response = client.get(f"/collections/{created['id']}")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == created
+
+
+def test_get_unknown_collection_returns_404_naming_the_id(client):
+    response = client.get(f"/collections/{MISSING_ID}")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": f"Collection not found: {MISSING_ID}"}
+
+
+def test_list_is_empty_before_anything_is_created(client):
+    response = client.get("/collections")
+
+    assert response.status_code == 200
+    assert response.json() == {"collections": [], "total": 0}
+
+
+def test_list_returns_every_collection_sorted_by_name_with_a_total(client, pages):
+    page_a, page_b = pages
+    _create(client, name="Zulu", page_ids=[page_a])
+    _create(client, name="Alpha", page_ids=[page_b])
+
+    response = client.get("/collections")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [c["name"] for c in body["collections"]] == ["Alpha", "Zulu"]
+    assert [c["page_ids"] for c in body["collections"]] == [[page_b], [page_a]]
+    assert body["total"] == 2
+
+
+# ── update ──────────────────────────────────────────────────────────────────
+
+
+def test_update_returns_the_updated_collection_and_keeps_its_id(client, pages):
+    page_a, page_b = pages
+    created = _create(client, name="Before", page_ids=[page_a])
+
+    response = client.put(f"/collections/{created['id']}", json={"name": "After", "page_ids": [page_b, page_a]})
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "success"
+    updated = body["collection"]
+    assert updated["id"] == created["id"]
+    assert updated["name"] == "After"
+    assert updated["page_ids"] == [page_b, page_a]
+    assert updated["created_at"] == created["created_at"]
+    assert updated["updated_at"] is not None
+
+
+def test_update_leaves_unsent_fields_alone(client, pages):
+    page_a, page_b = pages
+    created = _create(client, name="Keep Pages", page_ids=[page_a, page_b])
+
+    response = client.put(f"/collections/{created['id']}", json={"name": "Renamed Only"})
+
+    assert response.status_code == 200, response.text
+    updated = response.json()["collection"]
+    assert updated["name"] == "Renamed Only"
+    assert updated["page_ids"] == [page_a, page_b]
+
+
+def test_update_rejects_an_unknown_page_with_400_naming_the_page(client, pages):
+    page_a, _ = pages
+    created = _create(client, name="Guarded", page_ids=[page_a])
+
+    response = client.put(f"/collections/{created['id']}", json={"page_ids": ["no-such-page"]})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Page not found: no-such-page"}
+
+
+def test_update_unknown_collection_returns_404_naming_the_id(client):
+    response = client.put(f"/collections/{MISSING_ID}", json={"name": "Nobody"})
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": f"Collection not found: {MISSING_ID}"}
+
+
+# ── delete ──────────────────────────────────────────────────────────────────
+
+
+def test_delete_removes_the_collection_and_reports_it(client, pages):
+    page_a, _ = pages
+    created = _create(client, name="Doomed", page_ids=[page_a])
+
+    response = client.delete(f"/collections/{created['id']}")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "status": "success",
+        "message": f"Collection {created['id']} deleted",
+    }
+    assert client.get(f"/collections/{created['id']}").status_code == 404
+    assert client.get("/collections").json() == {"collections": [], "total": 0}
+
+
+def test_delete_unknown_collection_returns_404_naming_the_id(client):
+    response = client.delete(f"/collections/{MISSING_ID}")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": f"Collection not found: {MISSING_ID}"}

--- a/tests/test_collections_decoupled.py
+++ b/tests/test_collections_decoupled.py
@@ -1,0 +1,123 @@
+"""The collections router must not depend on ``src.api_server`` (Phase 2 §2.3).
+
+The #1756 extraction moved the five collection handlers out of the 10k-line
+``src/api_server.py`` but left six call-time ``from src.api_server import ...``
+statements behind, purely so the suite's ``patch("src.api_server.<name>")``
+targets kept resolving. That is not an extraction: importing the router was
+clean, but *serving a request* pulled the whole module — its route table, its
+background tasks, its MCP mount — back in, and the 2026-09 audit counted those
+seams going up 4.2x across Phase 1.
+
+This test pins the fix the honest way. In a fresh interpreter it imports the
+router, drives all five handlers end to end against patched canonical seams
+(``src.collections.routes.<name>``), asserts the stubs really were driven — so
+a handler that silently no-op'd could not pass — and then asserts
+``src.api_server`` never entered ``sys.modules``.
+
+Importing the module alone would be a much weaker claim: the seams were call
+time, so a module-level import check passes even with every one of them still
+in place.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SCRIPT = r"""
+import asyncio
+import sys
+from unittest.mock import MagicMock, patch
+
+import src.collections.routes as routes
+from src.collections.models import Collection, CollectionCreate, CollectionUpdate
+
+assert "src.api_server" not in sys.modules, "importing the collections router must not import api_server"
+
+
+def call(coro):
+    return asyncio.run(coro)
+
+
+sample = Collection(id="collection:abc", name="Decoupled", page_ids=["p1"])
+
+collection_service = MagicMock()
+collection_service.list_collections.return_value = [sample]
+collection_service.get_collection.return_value = sample
+collection_service.create_collection.return_value = sample
+collection_service.update_collection.return_value = sample
+collection_service.delete_collection.return_value = True
+
+page_service = MagicMock()
+page_service.get_page.return_value = object()
+
+with (
+    patch("src.collections.routes.get_collection_service", return_value=collection_service),
+    patch("src.collections.routes.get_page_service", return_value=page_service),
+):
+    listed = call(routes.list_collections())
+    assert listed.total == 1, listed
+    assert listed.collections[0].name == "Decoupled"
+
+    created = call(routes.create_collection(CollectionCreate(name="Decoupled", page_ids=["p1"])))
+    assert created.id == "collection:abc", created
+
+    fetched = call(routes.get_collection("collection:abc"))
+    assert fetched.id == "collection:abc", fetched
+
+    updated = call(routes.update_collection("collection:abc", CollectionUpdate(name="Renamed")))
+    assert updated.id == "collection:abc", updated
+
+    deleted = call(routes.delete_collection("collection:abc"))
+    assert deleted.id == "collection:abc", deleted
+
+# Not vacuous: the handlers really drove the service, and really validated the
+# page ids through the page service.
+collection_service.list_collections.assert_called_once()
+collection_service.create_collection.assert_called_once()
+collection_service.get_collection.assert_called_once_with("collection:abc")
+collection_service.update_collection.assert_called_once()
+collection_service.delete_collection.assert_called_once_with("collection:abc")
+page_service.get_page.assert_called_with("p1")
+
+assert "src.api_server" not in sys.modules, (
+    "a collections handler imported src.api_server — the call-time seam regrew"
+)
+print("DECOUPLED")
+"""
+
+
+def test_collections_router_serves_every_route_without_importing_api_server():
+    result = subprocess.run(
+        [sys.executable, "-c", SCRIPT],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    assert "DECOUPLED" in result.stdout
+
+
+def test_collections_router_source_declares_no_api_server_import():
+    """A static backstop over every branch, not just the exercised ones.
+
+    The subprocess test above can only catch a seam on a code path it drives.
+    This walks the module's AST, so an ``import api_server`` hidden inside a
+    rarely-taken ``except`` branch fails the build too.
+    """
+    import ast
+
+    tree = ast.parse((REPO_ROOT / "src" / "collections" / "routes.py").read_text())
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            offenders += [a.name for a in node.names if "api_server" in a.name]
+        elif isinstance(node, ast.ImportFrom) and "api_server" in (node.module or ""):
+            offenders.append(node.module)
+
+    assert offenders == [], f"src/collections/routes.py imports api_server: {offenders}"

--- a/tests/test_persistence_round_trip.py
+++ b/tests/test_persistence_round_trip.py
@@ -113,8 +113,9 @@ def _create_collection(client: TestClient, page_id: str) -> dict:
         "/collections",
         json={"name": "Mornings", "page_ids": [page_id]},
     )
-    assert response.status_code == 200, response.text
-    return response.json()["collection"]
+    # 201 + bare resource since the collections conventions pass (Phase 2 slice 1).
+    assert response.status_code == 201, response.text
+    return response.json()
 
 
 def _create_panel(client: TestClient, name: str = "Kitchen TV") -> dict:

--- a/tests/test_response_shape_goldens.py
+++ b/tests/test_response_shape_goldens.py
@@ -496,7 +496,7 @@ def test_collections_response_shapes():
         "/collections",
         json_body={"name": "Golden Collection", "page_ids": [page_a, page_b]},
     )
-    collection_id = body["collection"]["id"]
+    collection_id = body["id"]  # 201 + bare resource since the conventions pass
     rec.id_map[collection_id] = "<collection_id>"
     rec.hit(
         "create_collection_unknown_page",

--- a/web/src/lib/api/collections.ts
+++ b/web/src/lib/api/collections.ts
@@ -66,12 +66,20 @@ export interface CollectionsResponse {
   total: number;
 }
 
+/** Body of `DELETE /collections/{id}` — the id of the collection that was removed. */
+export interface CollectionDeleteResponse {
+  id: string;
+}
+
+// Create / update / delete return bare bodies, not `{status, collection}`
+// envelopes — see docs/internal/reference/API_CONVENTIONS.md. Create answers
+// 201; `fetchApi` already treats any 2xx as success.
 export const collectionsApi = {
   // Collection endpoints
   getCollections: () => fetchApi<CollectionsResponse>("/collections"),
 
   createCollection: (data: CollectionCreate) =>
-    fetchApi<{ status: string; collection: Collection }>("/collections", {
+    fetchApi<Collection>("/collections", {
       method: "POST",
       body: JSON.stringify(data),
     }),
@@ -79,13 +87,13 @@ export const collectionsApi = {
   getCollection: (collectionId: string) => fetchApi<Collection>(`/collections/${collectionId}`),
 
   updateCollection: (collectionId: string, data: CollectionUpdate) =>
-    fetchApi<{ status: string; collection: Collection }>(`/collections/${collectionId}`, {
+    fetchApi<Collection>(`/collections/${collectionId}`, {
       method: "PUT",
       body: JSON.stringify(data),
     }),
 
   deleteCollection: (collectionId: string) =>
-    fetchApi<{ status: string; message: string }>(`/collections/${collectionId}`, {
+    fetchApi<CollectionDeleteResponse>(`/collections/${collectionId}`, {
       method: "DELETE",
     }),
 };

--- a/web/tests/generate-screenshots.spec.ts
+++ b/web/tests/generate-screenshots.spec.ts
@@ -152,8 +152,9 @@ async function createCollection(name: string, pageIds: string[], intervalSeconds
     }),
   });
   if (!res.ok) throw new Error(`createCollection failed: ${res.status}`);
+  // 201 + bare resource since the collections conventions pass.
   const data = await res.json();
-  return data.collection.id;
+  return data.id;
 }
 
 async function deleteAllCollections() {

--- a/web/tests/helpers.ts
+++ b/web/tests/helpers.ts
@@ -416,8 +416,8 @@ export async function createCollection(
   if (!res.ok) {
     throw new Error(`createCollection failed: ${res.status} ${await res.text()}`);
   }
-  const data = await res.json();
-  return data.collection;
+  // 201 + bare resource since the collections conventions pass.
+  return await res.json();
 }
 
 /** Delete every collection via the API. */

--- a/web/tests/regression/collections.spec.ts
+++ b/web/tests/regression/collections.spec.ts
@@ -62,8 +62,8 @@ async function createCollectionApi(name: string, pageIds: string[], intervalSeco
   if (!res.ok) {
     throw new Error(`createCollectionApi failed: ${res.status} ${await res.text()}`);
   }
-  const data = (await res.json()) as { collection: CollectionApi };
-  return data.collection;
+  // 201 + bare resource since the collections conventions pass.
+  return (await res.json()) as CollectionApi;
 }
 
 /**


### PR DESCRIPTION
Phase 2 vertical slice **1 of 7** — the pilot that establishes the recipe the
other six domains copy. Spec: `.superpowers/specs/2026-09-06-rework-phase2-design.md` §2.
Plan: `.superpowers/plans/2026-09-06-rework-phase2.md` Task 3.

Base is `next-rebuild`, not `main`.

---

## The five parts

### 1. Value-level goldens first — recorded green *before* any change

`tests/test_collections_contract.py` (16 tests) pins the real **values** the
five routes return: the id round-trip, `page_ids` order preservation in both
directions, list ordering and total, and the exact error bodies for 404
(unknown id, three routes) and 400/422 (unknown page, missing `page_ids`,
empty `page_ids`). The existing shape corpus records key sets and type names,
so it cannot see a wrong id, a reordered playlist, or an error string that
stopped naming the missing resource.

Recorded on unmodified `next-rebuild`, commit `ed23054`, before a single
production line moved:

```
tests/test_collections_contract.py ................       [100%]
======================= 16 passed, 13 warnings in 0.55s ===============
```

### 2. Conventions applied

| Route | `response_model` | status | declared errors |
|---|---|---|---|
| `GET /collections` | `CollectionListResponse` | 200 | — (see exception below) |
| `POST /collections` | `CollectionResponse` | **201** | 400 |
| `GET /collections/{id}` | `CollectionResponse` | 200 | 404 |
| `PUT /collections/{id}` | `CollectionResponse` | 200 | 400, 404 |
| `DELETE /collections/{id}` | `CollectionDeleteResponse` | 200 | 404 |

- **Bare bodies.** Create and update return the collection itself, not
  `{"status": "success", "collection": {...}}`. Delete returns
  `{"id": "<deleted id>"}` — `API_CONVENTIONS.md` offers "200 with the deleted
  resource id" or "204 with no body"; this domain picks the former and its one
  delete route is consistent with itself.
- **`CollectionResponse` is an alias for `Collection`.** Collections have no
  derived, computed, or masked wire fields, so the stored model *is* the wire
  model. Domains where those diverge (plugins, settings) will need real
  classes; this one would only have gained a copy to keep in sync.
- **New `src/api_errors.py`** holds the one `ErrorResponse` model
  (`{"detail": str}`) and an `errors(*codes)` helper, so the six later slices
  declare failures identically instead of hand-rolling a dict each. Passing an
  unknown code raises rather than silently emitting an undocumented response.
- **Request bodies were already typed** (`CollectionCreate` /
  `CollectionUpdate`) — verified no route takes a bare `dict`.
- **One error contract**: every failure is
  `HTTPException(status_code=..., detail="<string>")`. There was no dict
  `detail` and no 200-on-failure in this domain to begin with.
- **No route reaches a private member.** `_validate_collection_payload` called
  `template_engine._get_all_known_sources()`; `TemplateEngine` now exposes
  `get_all_known_sources()`, with the underscore name kept as an alias for the
  two tests that call it directly.

### 3. Seams retired

`src/collections/routes.py` did **six** call-time `from src.api_server import
...` imports, existing purely so `patch("src.api_server.<name>")` kept
resolving. Importing the router was clean; *serving a request* dragged the
10k-line module back in. All six are gone — collaborators bind at import time
from `src.collections.service`, `src.pages.service`, `src.templates.engine`,
`src.templates.expressions`.

**Test patches repointed** (`tests/test_api_coverage_extended.py`,
`TestCollectionErrors`, the only two tests that depended on the seam):

```python
patch("src.api_server.get_collection_service", ...)   # before
patch("src.collections.routes.get_collection_service", ...)   # after
```

The rule for the next slice: patch **where the router binds the name**. The
router does `from .service import get_collection_service`, so the live
reference is `src.collections.routes.get_collection_service`. Patches on
`src.api_server.get_collection_service` in *other* files (`test_pages.py`,
`test_temporary_override*.py`, `test_page_retarget.py`, …) were left alone —
they stub the collection service for **pages/schedules** handlers that still
live in `api_server` and resolve it there.

**`tests/test_collections_decoupled.py`** pins the result two ways:

1. A subprocess that imports the router, drives all five handlers end to end
   against patched canonical seams, asserts the stubs were **really driven**
   (so a silently no-op'ing handler cannot pass), then asserts
   `"src.api_server" not in sys.modules`. A module-import-only check would be
   far weaker — the seams were call-time, so it passes with all six still in
   place.
2. An AST walk of the module that fails on an `api_server` import anywhere,
   including inside a branch no test drives.

Both mutation-proven. Reinstating one call-time import in `list_collections`:

```
FAILED tests/test_collections_decoupled.py::test_collections_router_serves_every_route_without_importing_api_server
FAILED tests/test_collections_decoupled.py::test_collections_router_source_declares_no_api_server_import
E   AssertionError: src/collections/routes.py imports api_server: ['src.api_server']
============================== 2 failed in 0.69s ===============================
```

### 4. Web lockstep

`web/src/lib/api/collections.ts`: `createCollection` and `updateCollection`
now return `Collection`; `deleteCollection` returns a new
`CollectionDeleteResponse`. `fetchApi` already treats any 2xx as success, so
the 201 needed no plumbing change.

Consumers: the app's three call sites (`app/routes/collections.tsx` mutations,
`global-ai-chat-drawer.tsx` create/update) all discard the mutation result, so
only the three e2e helpers that read `data.collection` changed —
`tests/helpers.ts`, `tests/regression/collections.spec.ts`,
`tests/generate-screenshots.spec.ts`. MSW handlers only mock `GET
/collections`, which is unchanged.

`tsc --noEmit` clean; vitest **1621 passed / 7 skipped** (146 files); prettier
and eslint clean on every changed file.

### 5. Shims — deliberately none

**These endpoints are internal-only.** Evidence checked:

- `grep -rn "/collections" docs/ README.md` → **no hits**. Nothing published
  documents them.
- The MCP tools (`src/mcp_server.py`) and the ops executors
  (`src/ops/executors.py`) call `CollectionService` **directly** — they never
  issue HTTP.
- `grep -rn '"/collections'` across `src/` finds only the route decorators
  themselves.
- In `web/`, the only callers are `collectionsApi` and three Playwright
  helpers, all in this repo, shipped in the same container at the same
  version.

No third party can plausibly be calling these, so per spec §2.5 there are no
`Deprecation`/`Sunset` shims.

---

## Goldens

`tests/golden/responses/collections.json` re-recorded — **28 insertions, 35
deletions, three intended changes and nothing else**:

| Record | Before | After |
|---|---|---|
| `create_collection_ok` | 200, `{collection: {...}, status}` | **201**, bare collection |
| `update_collection_ok` | 200, `{collection: {...}, status}` | 200, bare collection |
| `delete_collection_ok` | `{message, status}` | `{id}` |

No other domain's corpus moved. `tests/golden/api_routes.json` is
**unchanged**: it records path / methods / name / kind, none of which a
conventions pass touches. `tests/test_collections_contract.py` is re-pinned to
the new envelope with `RE-PINNED:` comments naming each change; every value
assertion is byte-identical to the pre-conversion recording — nothing was
weakened.

---

## Verification

| Check | Result |
|---|---|
| Full suite `-m "not integration" -n auto` | **5967 passed, 1 skipped, 1 failed** |
| Baseline, same tree, before any change | **5949 passed, 1 skipped, 1 failed** |
| Delta | +18 (16 contract + 2 decoupling); failure set is a strict subset (identical) |
| `tests/test_collections.py` | 100 passed |
| Web `tsc --noEmit` / vitest / prettier / eslint | clean / 1621 passed / clean / clean |
| `ruff check` + `ruff format --check` (0.16.5) | clean, 298 files |

The single failure is
`tests/test_check_image_formats.py::TestRepositoryIsClean` — the documented
worktree-environment failure (`git ls-files` exits 128 inside the mounted
container). It fails identically on the untouched baseline.

---

## ⚠️ Conventions-manifest entry is PENDING

The CI ratchet (`tests/test_api_conventions_ratchet.py` +
`tests/conventions_manifest.json`, plan Task 2) had **not** landed on
`origin/next-rebuild` when this branch was cut, so this PR does not touch the
manifest. **Someone must add the entry below once the ratchet merges** —
without it the pilot domain is invisible to the ratchet and the whole point of
the mechanism is lost.

```json
{
  "converted_domains": ["collections"],
  "exceptions": [
    {
      "route": "GET /collections",
      "rule": "declared_errors",
      "reason": "Listing has no failure path: an empty store answers 200 with {\"collections\": [], \"total\": 0}, and the route takes no id or body that could 4xx. Declaring a 404 here would document a response the handler cannot produce."
    }
  ]
}
```

This was verified, not guessed. Against a scratch merge of
`phase2/conventions-ratchet` into this branch:

- With `converted_domains: ["collections"]` and no exception →
  **1 failed, 20 passed**, the single failure being
  `GET /collections: declares no 4xx in responses=`.
- With the exception above → **21 passed**.

And the fail-first evidence, the same ratchet merged onto **unconverted**
`origin/next-rebuild` with `collections` in `converted_domains`:

```
E   Converted domains must declare response_model on every route ...
E       DELETE /collections/{collection_id}: no response_model= declared
E       GET /collections/{collection_id}: no response_model= declared
E       GET /collections: no response_model= declared
E       POST /collections: no response_model= declared
E       PUT /collections/{collection_id}: no response_model= declared
E   Converted domains must declare the errors they raise ...
E       DELETE /collections/{collection_id}: declares no 4xx in responses=
E       GET /collections/{collection_id}: declares no 4xx in responses=
E       GET /collections: declares no 4xx in responses=
E       POST /collections: declares no 4xx in responses=
E       PUT /collections/{collection_id}: declares no 4xx in responses=
```

Ten violations across two rules. `typed_body` and `no_200_on_failure` already
passed pre-conversion — collections was the domain with the least to fix,
which is exactly why it was chosen as the pilot.

---

## What will NOT generalise to plugins / settings

Reviewers of the later slices should not expect this to be representative:

1. **`CollectionResponse` as a plain alias.** Works only because nothing is
   masked or derived. `plugins` must not do this — the `"***"` masking
   round-trip needs a wire model distinct from the stored one, and that is the
   exact regression shape goldens missed in Phase 1.
2. **Only two tests patched the seam.** Collections had 6 call-time imports
   but a tiny test surface. `plugins` (25 routes) and `settings` (37) have
   patches spread across many files, and some of those patches are for
   handlers that legitimately still live in `api_server` — repointing
   indiscriminately will break them. The discriminator: patch where the
   *router* binds the name, leave patches serving `api_server`-resident
   handlers alone.
3. **Zero 200-on-failure and zero dict `detail` to fix.** `system` has 18 of
   20 `HTTPException`s using dict `detail`; `plugins/service.py` raises
   `fastapi.HTTPException` at 25 sites from the service layer. Those slices
   carry real behavior change; this one did not.
4. **Every web consumer discarded the mutation result.** `pages` and
   `schedules` read response bodies into UI state — their lockstep step is a
   genuine refactor, not three helper edits.
5. **The domain had no `responses=` conflicts and one honest exception.**
   Larger domains will need several, each needing its own argued reason.
6. **The full suite runs in ~17s** for this domain's blast radius. Do not read
   that as a signal about the bigger slices.

Also worth flagging for whoever writes the ratchet's route walker: FastAPI
≥ 0.130 wraps `include_router()` results in an internal `_IncludedRouter` node
with **no `path`** — a naive `for r in app.routes` scan silently sees zero
collection routes. `tests/test_route_inventory.py::_walk` already handles it
via `include_context`; anything else enumerating routes must too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP
