### PR TITLE
fix: Phase 2 Task 9 — four measured robustness regressions

### DIFF
--- a/nginx-dev.conf
+++ b/nginx-dev.conf
@@ -87,8 +87,16 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_connect_timeout 10s;
-            proxy_send_timeout 30s;
-            proxy_read_timeout 60s;
+            # Must stay ABOVE src/main.py::SEND_WAIT_TIMEOUT (240s): a
+            # wait=True send blocks for that long, and cloud boards pace
+            # frames 15s apart behind a transition capped at 120s, so
+            # minute-plus sends are routine, not pathological. At the stock
+            # 60s nginx returned 504 to the browser while the backend went on
+            # working for 4x longer (issue #1886). 300s leaves headroom; raise
+            # both numbers together — tests/test_nginx_api_timeouts.py fails
+            # the build if they ever drift apart again.
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
         }
 
         location /api/ {
@@ -101,8 +109,16 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_connect_timeout 10s;
-            proxy_send_timeout 30s;
-            proxy_read_timeout 60s;
+            # Must stay ABOVE src/main.py::SEND_WAIT_TIMEOUT (240s): a
+            # wait=True send blocks for that long, and cloud boards pace
+            # frames 15s apart behind a transition capped at 120s, so
+            # minute-plus sends are routine, not pathological. At the stock
+            # 60s nginx returned 504 to the browser while the backend went on
+            # working for 4x longer (issue #1886). 300s leaves headroom; raise
+            # both numbers together — tests/test_nginx_api_timeouts.py fails
+            # the build if they ever drift apart again.
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
         }
 
         location @api_starting {

--- a/nginx.conf
+++ b/nginx.conf
@@ -106,8 +106,16 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_connect_timeout 10s;
-            proxy_send_timeout 30s;
-            proxy_read_timeout 60s;
+            # Must stay ABOVE src/main.py::SEND_WAIT_TIMEOUT (240s): a
+            # wait=True send blocks for that long, and cloud boards pace
+            # frames 15s apart behind a transition capped at 120s, so
+            # minute-plus sends are routine, not pathological. At the stock
+            # 60s nginx returned 504 to the browser while the backend went on
+            # working for 4x longer (issue #1886). 300s leaves headroom; raise
+            # both numbers together — tests/test_nginx_api_timeouts.py fails
+            # the build if they ever drift apart again.
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
         }
 
         # All API traffic under /api/* → FastAPI backend (path stripped: /api/pages → /pages)
@@ -122,8 +130,16 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_connect_timeout 10s;
-            proxy_send_timeout 30s;
-            proxy_read_timeout 60s;
+            # Must stay ABOVE src/main.py::SEND_WAIT_TIMEOUT (240s): a
+            # wait=True send blocks for that long, and cloud boards pace
+            # frames 15s apart behind a transition capped at 120s, so
+            # minute-plus sends are routine, not pathological. At the stock
+            # 60s nginx returned 504 to the browser while the backend went on
+            # working for 4x longer (issue #1886). 300s leaves headroom; raise
+            # both numbers together — tests/test_nginx_api_timeouts.py fails
+            # the build if they ever drift apart again.
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
         }
 
         location @api_starting {

--- a/nginx.https.conf
+++ b/nginx.https.conf
@@ -95,8 +95,16 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_connect_timeout 10s;
-            proxy_send_timeout 30s;
-            proxy_read_timeout 60s;
+            # Must stay ABOVE src/main.py::SEND_WAIT_TIMEOUT (240s): a
+            # wait=True send blocks for that long, and cloud boards pace
+            # frames 15s apart behind a transition capped at 120s, so
+            # minute-plus sends are routine, not pathological. At the stock
+            # 60s nginx returned 504 to the browser while the backend went on
+            # working for 4x longer (issue #1886). 300s leaves headroom; raise
+            # both numbers together — tests/test_nginx_api_timeouts.py fails
+            # the build if they ever drift apart again.
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
         }
 
         location /api/ {
@@ -109,8 +117,16 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_connect_timeout 10s;
-            proxy_send_timeout 30s;
-            proxy_read_timeout 60s;
+            # Must stay ABOVE src/main.py::SEND_WAIT_TIMEOUT (240s): a
+            # wait=True send blocks for that long, and cloud boards pace
+            # frames 15s apart behind a transition capped at 120s, so
+            # minute-plus sends are routine, not pathological. At the stock
+            # 60s nginx returned 504 to the browser while the backend went on
+            # working for 4x longer (issue #1886). 300s leaves headroom; raise
+            # both numbers together — tests/test_nginx_api_timeouts.py fails
+            # the build if they ever drift apart again.
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
         }
 
         location @api_starting {

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -35,6 +35,7 @@ from .auth import is_auth_enabled  # noqa: E402
 from .auth.middleware import AuthMiddleware  # noqa: E402
 from .auth.routes import router as auth_router  # noqa: E402
 from .board_client import board_client_from_board_dict  # noqa: E402
+from .board_send_executor import run_board_send  # noqa: E402
 from .collections.models import is_collection_id  # noqa: E402
 from .collections.service import get_collection_service  # noqa: E402
 from .config import Config  # noqa: E402
@@ -779,6 +780,15 @@ async def lifespan(app: FastAPI):
         shutdown_plugin_fetch_executor()
     except Exception:
         logger.debug("Failed to stop plugin-fetch executor during shutdown", exc_info=True)
+
+    # Stop the dedicated board-send pool (issue #1878). wait=False for the
+    # same reason: a wedged board must not stall process shutdown.
+    try:
+        from .board_send_executor import shutdown_board_send_executor
+
+        shutdown_board_send_executor()
+    except Exception:
+        logger.debug("Failed to stop board-send executor during shutdown", exc_info=True)
 
 
 # Create FastAPI app
@@ -2208,7 +2218,7 @@ async def refresh_display(board_id: str | None = None, payload: dict | None = Bo
             # keep the event loop free (#1826); _send_with_status moves as one
             # call because its failure reason lives in a thread-local that is
             # set and read inside the same sync call.
-            sent, error = await asyncio.to_thread(
+            sent, error = await run_board_send(
                 _send_with_status, service, "check_and_send_active_page_with_status", "check_and_send_active_page"
             )
             if error:
@@ -2229,7 +2239,7 @@ async def refresh_display(board_id: str | None = None, payload: dict | None = Bo
         is_primary = board_id == get_settings_service().get_primary_board_id()
         # Board network I/O — off the event loop (#1826); _send_with_status
         # moves as one call (thread-local failure reason, see above).
-        sent, error = await asyncio.to_thread(
+        sent, error = await run_board_send(
             _send_with_status,
             service,
             "check_and_send_for_board_with_status",
@@ -5126,7 +5136,7 @@ async def restore_after_transition_test(request: dict | None = None):
         dims = resolve_dimensions(page.device_type, page.notes_wide, page.notes_tall)
     grid = _render_live_page_grid(active_page_id, dims.rows, dims.cols)
 
-    success, was_sent = await asyncio.to_thread(board_client.render, grid, strategy=None, force=True)
+    success, was_sent = await run_board_send(board_client.render, grid, strategy=None, force=True)
     if not success:
         raise HTTPException(status_code=502, detail="Board unreachable - restore failed")
 
@@ -5410,7 +5420,7 @@ async def set_active_page(request: dict):
                     logger.warning(f"Active page set but render unavailable, not sent: {render_page_id}")
         return sent_to_board, paused, send_error
 
-    sent_to_board, paused, send_error = await asyncio.to_thread(_work)
+    sent_to_board, paused, send_error = await run_board_send(_work)
 
     # status stays "success" (the page selection itself was persisted); a
     # render/send problem is reported via error + sent_to_board=False, the
@@ -7390,7 +7400,7 @@ async def render_template_live(request: dict):
                 if isinstance(live_strategy, str) and live_strategy.startswith(TRANSITION_PLUGIN_PREFIX):
                     live_strategy = None
                 try:
-                    success, was_sent = await asyncio.to_thread(
+                    success, was_sent = await run_board_send(
                         client.send_characters,
                         board_array,
                         strategy=live_strategy,
@@ -7473,7 +7483,7 @@ async def force_refresh():
         return _send_with_status(service, "check_and_send_active_page_with_status", "check_and_send_active_page")
 
     try:
-        sent, error = await asyncio.to_thread(_work)
+        sent, error = await run_board_send(_work)
         if error:
             raise HTTPException(status_code=500, detail=f"Failed to force refresh: {error}")
         return {

--- a/src/board_client.py
+++ b/src/board_client.py
@@ -81,10 +81,30 @@ NOTE_ARRAY_MIN_SEND_INTERVAL: float = 15.0
 CLOUD_MIN_SEND_INTERVAL: float = 15.0
 
 # Connection-level send retry policy: retry once after a short backoff, but
-# only for errors where the board never answered (connect failures, timeouts).
+# only for errors where the board never ACCEPTED the connection.
 # HTTP 4xx/5xx responses ARE the board answering and are never retried.
 SEND_MAX_ATTEMPTS: int = 2
 SEND_RETRY_BACKOFF_SECONDS: float = 0.5
+
+
+def _is_retryable_send_error(exc: BaseException) -> bool:
+    """True when the board never accepted the connection, so a retry is worth it.
+
+    A refused or reset connection, or a DNS failure, means the board is not
+    listening: the retry is cheap (the failure is immediate) and often wins —
+    a board mid-reboot, a transient LAN blip. ``ConnectTimeout`` subclasses
+    ``ConnectionError`` as well as ``Timeout`` and lands on this side for the
+    same reason: no connection was established.
+
+    A ``ReadTimeout`` is the opposite case. The board took the request and then
+    went quiet, so it is wedged, and the second attempt pays the identical read
+    timeout against the identical wedged board. #1754 retried both classes
+    alike; the Phase 2 audit measured what that costs — a send to a wedged
+    board went from 10.01s to 20.53s, doubling the stall for nothing while the
+    per-board send worker (and any waiter on it) blocked.
+    """
+    return isinstance(exc, requests.exceptions.ConnectionError)
+
 
 # (connect, read) timeouts per API type. LAN connects should fail fast (an
 # unreachable board otherwise burns the full timeout per attempt in the
@@ -531,14 +551,16 @@ class BoardClient(TransitionRenderMixin):
     def _post_with_retry(self, url: str, headers: dict[str, str], payload: Any) -> requests.Response:
         """POST with a single connection-level retry after a short backoff.
 
-        Retries (once) ONLY errors where the board never answered --
-        ``requests.exceptions.ConnectionError`` and timeouts.  An HTTP error
-        response is the board answering: it is returned to the caller (whose
-        ``raise_for_status`` surfaces it) and never retried.  The backoff
-        waits on the active cancel event rather than sleeping, so a
-        preempting render() / newer send job abandons the retry promptly.
-        Worst case: SEND_MAX_ATTEMPTS * (connect + read timeout) + backoff,
-        well under the send worker's wait bound.
+        Retries (once) ONLY errors where the board never ACCEPTED the
+        connection -- see :func:`_is_retryable_send_error`. A ``ReadTimeout``
+        is raised by a board that answered and then went quiet, and is not
+        retried: the second attempt would pay the same read timeout again.
+        An HTTP error response is the board answering: it is returned to the
+        caller (whose ``raise_for_status`` surfaces it) and never retried.
+        The backoff waits on the active cancel event rather than sleeping, so
+        a preempting render() / newer send job abandons the retry promptly.
+        Worst case: SEND_MAX_ATTEMPTS * connect timeout + read timeout +
+        backoff, well under the send worker's wait bound.
         """
         last_exc: requests.exceptions.RequestException | None = None
         for attempt in range(1, SEND_MAX_ATTEMPTS + 1):
@@ -546,7 +568,7 @@ class BoardClient(TransitionRenderMixin):
                 return requests.post(url, headers=headers, json=payload, timeout=self._request_timeout)
             except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
                 last_exc = exc
-                if attempt >= SEND_MAX_ATTEMPTS:
+                if attempt >= SEND_MAX_ATTEMPTS or not _is_retryable_send_error(exc):
                     break
                 logger.debug(
                     "Send attempt %d/%d failed with connection-level error (%s); retrying in %.1fs",

--- a/src/board_send_executor.py
+++ b/src/board_send_executor.py
@@ -1,0 +1,76 @@
+"""A bounded, dedicated thread pool for board-send endpoints (issue #1878).
+
+Every ``asyncio.to_thread`` call in the process — ~61 sites: plugin installs,
+Wi-Fi scans, system updates, page previews, snapshot restores — shares
+asyncio's *default* executor, whose size is ``min(32, cpu_count + 4)``. On a
+four-core Pi that is eight threads for the whole application.
+
+Board sends are the one family of blocking work that can hold a thread for
+minutes rather than seconds. A queued send occupies its worker while merely
+*blocked on the per-board send lock*, and a transition plugin can hold that
+lock for its full runtime (up to the 120s manifest cap). So a handful of
+concurrent sends can occupy every default-executor thread and starve unrelated
+work: a plugin install, a Wi-Fi scan, a live-editor preview. Measured in the
+Phase 2 audit: 40 concurrent 2s requests completed in exactly three waves of
+18 workers.
+
+Giving the send endpoints their own bounded pool decouples the two failure
+modes. Send saturation now degrades only sends; the shared pool stays free for
+everything else. The pool is deliberately SMALL: sends are serialized per board
+by the send worker anyway (#1755), so extra threads would only queue deeper.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import functools
+import threading
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, TypeVar
+
+# Concurrency ceiling for board sends. Sends are already serialized per board
+# by that board's send worker, so this only needs to cover a handful of boards
+# being driven at once plus the occasional out-of-band send.
+BOARD_SEND_MAX_WORKERS = 4
+
+_executor: ThreadPoolExecutor | None = None
+_executor_lock = threading.Lock()
+
+T = TypeVar("T")
+
+
+def get_board_send_executor() -> ThreadPoolExecutor:
+    """Lazily create (once) the shared board-send pool."""
+    global _executor
+    with _executor_lock:
+        if _executor is None:
+            _executor = ThreadPoolExecutor(max_workers=BOARD_SEND_MAX_WORKERS, thread_name_prefix="board-send")
+        return _executor
+
+
+def shutdown_board_send_executor() -> None:
+    """Shut down the board-send pool (process teardown and tests only).
+
+    Safe to call repeatedly; a later send lazily creates a fresh pool.
+    ``wait=False`` so a wedged board cannot stall shutdown.
+    """
+    global _executor
+    with _executor_lock:
+        if _executor is not None:
+            _executor.shutdown(wait=False, cancel_futures=True)
+            _executor = None
+
+
+async def run_board_send(func: Callable[..., T], /, *args: Any, **kwargs: Any) -> T:
+    """``asyncio.to_thread`` for board sends, on the dedicated bounded pool.
+
+    Same contract as ``asyncio.to_thread``, context propagation included: runs
+    *func* on a worker thread and awaits its result. Only the pool differs,
+    which is the entire point — saturating it cannot starve the default
+    executor every other blocking handler in the process depends on.
+    """
+    loop = asyncio.get_running_loop()
+    ctx = contextvars.copy_context()
+    return await loop.run_in_executor(get_board_send_executor(), functools.partial(ctx.run, func, *args, **kwargs))

--- a/src/main.py
+++ b/src/main.py
@@ -63,6 +63,13 @@ ADHOC_PAGE_ID = "__adhoc__"
 # exceeds it. interruptible:false transitions defeat enqueue-time preemption
 # entirely — see src/transitions/runner.py — which is why they are clamped to
 # the 120s cap and the executing job is budgeted at that full cap.)
+#
+# nginx must OUTWAIT this number: nginx.conf / nginx.https.conf /
+# nginx-dev.conf set proxy_read_timeout and proxy_send_timeout to 300s on both
+# /api location blocks. At the stock 60s any send that legitimately ran longer
+# than a minute returned 504 to the browser while this thread kept waiting 4x
+# longer (issue #1886). Raise both together;
+# tests/test_nginx_api_timeouts.py fails the build if they drift apart.
 SEND_WAIT_TIMEOUT = 240.0
 
 # Backoff schedule for re-attempting boards that failed to initialize

--- a/src/pages/routes.py
+++ b/src/pages/routes.py
@@ -629,4 +629,8 @@ async def send_page(
             "board_id": board_id,
         }
 
-    return await asyncio.to_thread(_work)
+    # Board network I/O goes on the dedicated bounded send pool, never the
+    # shared default executor (#1878) — see src/board_send_executor.py.
+    from src.board_send_executor import run_board_send
+
+    return await run_board_send(_work)

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -11,6 +11,7 @@ The PluginRegistry is the central point for:
 import logging
 import re
 import threading
+import time
 from collections.abc import Collection
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import wait as futures_wait
@@ -62,8 +63,48 @@ CONTEXT_BUILD_TIMEOUT_SECONDS = 15
 # that reset the registry singleton never accumulate pools.
 PLUGIN_FETCH_MAX_WORKERS = 8
 
+# Per-plugin fetch circuit breaker (issue #1884).
+#
+# The bounded pool above cannot leak threads, but it introduced a new failure
+# mode the audit measured: once PLUGIN_FETCH_MAX_WORKERS *distinct* referenced
+# plugins wedge, every worker is occupied forever and healthy plugins are
+# starved off the board permanently (8 wedged + 4 healthy: the healthy four
+# went from being served every tick to 4 fetches total and absent from the
+# final context). No API can kill a thread stuck in plugin code, so bounding
+# occupancy alone cannot be the whole answer.
+#
+# The breaker: a fetch that actually STARTED and is still running when the
+# context-build timeout expires records one consecutive timeout against its
+# plugin. After PLUGIN_FETCH_BREAKER_THRESHOLD of them the plugin is
+# quarantined for PLUGIN_FETCH_BREAKER_COOLDOWN_SECONDS — neither submitted
+# nor waited on. That has two effects: the plugin stops consuming pool
+# workers, and every render stops paying CONTEXT_BUILD_TIMEOUT_SECONDS (15s
+# in production) for a data source that is never going to answer.
+#
+# A fetch that never STARTED is not counted: it is a symptom of saturation
+# caused by other plugins, and penalising it would quarantine exactly the
+# healthy plugins the breaker exists to protect.
+PLUGIN_FETCH_BREAKER_THRESHOLD = 3
+PLUGIN_FETCH_BREAKER_COOLDOWN_SECONDS = 300.0
+
+# Reserved capacity, the other half of #1884. Quarantining a plugin stops the
+# *next* fetch; the one already running keeps its worker until the plugin
+# returns, which for a truly wedged data source is never. Those workers are
+# written off, and once half the pool has been written off the shared pool is
+# rotated: a fresh pool takes over and the old one keeps its stuck threads
+# until the process exits. So healthy plugins always have at least
+# PLUGIN_FETCH_MAX_WORKERS - PLUGIN_FETCH_LOST_WORKER_LIMIT workers available,
+# no matter how many data sources are wedged.
+#
+# Total stuck threads stay bounded: the in-flight dedupe holds each plugin to
+# one fetch per board key, and the breaker stops resubmitting it, so the
+# ceiling is the number of distinct wedged (plugin, board) pairs — never a
+# per-tick growth rate, which is what #1751 was about.
+PLUGIN_FETCH_LOST_WORKER_LIMIT = PLUGIN_FETCH_MAX_WORKERS // 2
+
 _fetch_executor: ThreadPoolExecutor | None = None
 _fetch_executor_lock = threading.Lock()
+_fetch_workers_lost = 0
 
 
 def _get_fetch_executor() -> ThreadPoolExecutor:
@@ -77,6 +118,39 @@ def _get_fetch_executor() -> ThreadPoolExecutor:
         return _fetch_executor
 
 
+def _write_off_fetch_workers(count: int) -> None:
+    """Account *count* pool workers as permanently lost to wedged fetches.
+
+    Rotates the shared pool once the written-off total reaches
+    PLUGIN_FETCH_LOST_WORKER_LIMIT. The count is applied in one batch (not one
+    call per worker) so a tick that quarantines eight plugins rotates once,
+    rather than rotating and then immediately discarding the fresh pool.
+
+    ``wait=False`` and no ``cancel_futures``: nothing is queued on the retired
+    pool — build_template_context cancels every future that had not started
+    before it gave up — so only genuinely running (wedged) fetches are left
+    behind, and they die with the process.
+    """
+    global _fetch_executor, _fetch_workers_lost
+    if count <= 0:
+        return
+    with _fetch_executor_lock:
+        _fetch_workers_lost += count
+        if _fetch_workers_lost < PLUGIN_FETCH_LOST_WORKER_LIMIT:
+            return
+        logger.warning(
+            "plugin-fetch pool rotated: %d of %d workers are permanently occupied by wedged "
+            "plugin fetches; a fresh pool restores capacity for healthy plugins",
+            _fetch_workers_lost,
+            PLUGIN_FETCH_MAX_WORKERS,
+        )
+        retired = _fetch_executor
+        _fetch_executor = None
+        _fetch_workers_lost = 0
+    if retired is not None:
+        retired.shutdown(wait=False)
+
+
 def shutdown_plugin_fetch_executor() -> None:
     """Shut down the shared plugin-fetch pool (process teardown only).
 
@@ -84,11 +158,12 @@ def shutdown_plugin_fetch_executor() -> None:
     ``wait=False`` so a wedged plugin cannot stall shutdown; its worker
     thread dies with the process.
     """
-    global _fetch_executor
+    global _fetch_executor, _fetch_workers_lost
     with _fetch_executor_lock:
         if _fetch_executor is not None:
             _fetch_executor.shutdown(wait=False, cancel_futures=True)
             _fetch_executor = None
+        _fetch_workers_lost = 0
 
 
 def _config_in_use(plugin_id: str, stored_configs: dict[str, dict[str, Any]]) -> bool:
@@ -153,6 +228,15 @@ class PluginRegistry:
         # key instead of one more per tick until the pool starves.
         self._inflight_fetches: dict[tuple, Any] = {}
         self._inflight_lock = threading.Lock()
+
+        # Per-plugin fetch circuit breaker (issue #1884), guarded by
+        # _inflight_lock alongside the in-flight registry it works with.
+        # _fetch_timeouts counts CONSECUTIVE context-build timeouts on
+        # fetches that actually started; _fetch_breaker_until holds the
+        # monotonic deadline until which a quarantined plugin is neither
+        # submitted nor waited on.
+        self._fetch_timeouts: dict[str, int] = {}
+        self._fetch_breaker_until: dict[str, float] = {}
 
         # Set once initialize() has loaded the plugin set. Guards against a
         # repeat call rebuilding every live plugin (issue #1753).
@@ -1810,6 +1894,25 @@ class PluginRegistry:
         if not to_fetch:
             return context
 
+        # Circuit-breaker gate (issue #1884): a quarantined plugin is dropped
+        # from this build entirely — not submitted, and crucially not WAITED
+        # on. Skipping the wait is what removes the per-render
+        # CONTEXT_BUILD_TIMEOUT_SECONDS stall a single wedged referenced
+        # plugin used to impose on every tick.
+        now = time.monotonic()
+        with self._inflight_lock:
+            quarantined = [pid for pid in to_fetch if self._fetch_breaker_until.get(pid, 0.0) > now]
+            if quarantined:
+                to_fetch = [pid for pid in to_fetch if self._fetch_breaker_until.get(pid, 0.0) <= now]
+        if quarantined:
+            logger.debug(
+                "Skipping %d quarantined plugin(s) this render (fetch circuit breaker open): %s",
+                len(quarantined),
+                quarantined,
+            )
+        if not to_fetch:
+            return context
+
         # One persistent bounded pool for every render (issue #1751); see the
         # module-level notes on PLUGIN_FETCH_MAX_WORKERS. The timeout below
         # still solely bounds how long a render waits — never how long a
@@ -1858,6 +1961,20 @@ class PluginRegistry:
                     f"({never_started}) — all {PLUGIN_FETCH_MAX_WORKERS} workers are occupied by "
                     f"slow or wedged plugin fetches"
                 )
+            # cancel() above already flipped the never-started futures to
+            # CANCELLED, so what is left is the set that genuinely started and
+            # is still running — the only set the breaker may hold against a
+            # plugin (issue #1884).
+            self._record_fetch_timeouts([f for f in not_done if not f.cancelled()], futures)
+
+        if done:
+            # A fetch that completed — with data, without data, or with an
+            # error — is answering, so its consecutive-timeout streak ends and
+            # any quarantine is lifted.
+            with self._inflight_lock:
+                for future in done:
+                    self._fetch_timeouts.pop(futures[future], None)
+                    self._fetch_breaker_until.pop(futures[future], None)
 
         for future in done:
             plugin_id = futures[future]
@@ -1869,6 +1986,63 @@ class PluginRegistry:
                 logger.exception(f"Plugin {plugin_id} raised an error during context build")
 
         return context
+
+    def _record_fetch_timeouts(self, running: list, futures: dict) -> None:
+        """Charge one consecutive timeout to each plugin in *running*.
+
+        Opens the circuit breaker for any plugin that reaches
+        PLUGIN_FETCH_BREAKER_THRESHOLD, and writes off the pool worker its
+        still-running fetch has taken hostage (once per future — a probe after
+        the cooldown re-opens the breaker on the SAME future and must not be
+        counted twice).
+        """
+        if not running:
+            return
+        opened: list[str] = []
+        lost = 0
+        deadline = time.monotonic() + PLUGIN_FETCH_BREAKER_COOLDOWN_SECONDS
+        with self._inflight_lock:
+            for future in running:
+                plugin_id = futures[future]
+                count = self._fetch_timeouts.get(plugin_id, 0) + 1
+                self._fetch_timeouts[plugin_id] = count
+                if count < PLUGIN_FETCH_BREAKER_THRESHOLD:
+                    continue
+                self._fetch_breaker_until[plugin_id] = deadline
+                opened.append(plugin_id)
+                if not getattr(future, "_fb_worker_written_off", False):
+                    future._fb_worker_written_off = True
+                    lost += 1
+        _write_off_fetch_workers(lost)
+        if opened:
+            logger.warning(
+                "plugin-fetch circuit breaker OPEN for %s after %d consecutive context-build "
+                "timeouts; skipping them for %.0fs so renders stop waiting on them",
+                sorted(set(opened)),
+                PLUGIN_FETCH_BREAKER_THRESHOLD,
+                PLUGIN_FETCH_BREAKER_COOLDOWN_SECONDS,
+            )
+
+    def get_fetch_breaker_status(self) -> dict[str, dict[str, Any]]:
+        """Report which plugins the fetch circuit breaker is holding back.
+
+        Maps plugin_id -> ``{"consecutive_timeouts": int, "quarantined": bool,
+        "cooldown_remaining_seconds": float}`` for every plugin with a live
+        timeout streak. Empty when every data source is answering.
+        """
+        now = time.monotonic()
+        with self._inflight_lock:
+            timeouts = dict(self._fetch_timeouts)
+            until = dict(self._fetch_breaker_until)
+        status: dict[str, dict[str, Any]] = {}
+        for plugin_id, count in timeouts.items():
+            remaining = max(0.0, until.get(plugin_id, 0.0) - now)
+            status[plugin_id] = {
+                "consecutive_timeouts": count,
+                "quarantined": remaining > 0.0,
+                "cooldown_remaining_seconds": round(remaining, 1),
+            }
+        return status
 
     def build_template_contexts_for(
         self,

--- a/tests/test_board_client_policy.py
+++ b/tests/test_board_client_policy.py
@@ -3,10 +3,13 @@
 Covers three behaviors added in issue #1754:
 
 1. **Connection-level retry with backoff** — a send that fails because the
-   board never answered (``requests.ConnectionError`` / timeouts) is retried
-   exactly once after a short backoff. HTTP error *responses* (4xx/5xx) are
-   the board answering and are never retried. The backoff waits on the
-   client's cancel event so a preempting render abandons the retry promptly.
+   board never ACCEPTED the connection (``requests.ConnectionError``, which
+   includes ``ConnectTimeout``) is retried exactly once after a short backoff.
+   A ``ReadTimeout`` is not: the board took the request and went quiet, so the
+   second attempt pays the same timeout again (Phase 2 audit: 10.01s → 20.53s
+   on a wedged board). HTTP error *responses* (4xx/5xx) are the board
+   answering and are never retried. The backoff waits on the client's cancel
+   event so a preempting render abandons the retry promptly.
 2. **Universal min-send-interval floor** — per client instance: RW Cloud
    sends are floored at one send per 15s (Vestaboard's documented limit,
    docs/setup/cloud-api.md); note arrays keep their existing 15s floor;
@@ -104,9 +107,30 @@ class TestConnectionRetry:
         cancel.wait.assert_called_once_with(SEND_RETRY_BACKOFF_SECONDS)
 
     @patch("src.board_client.requests.post")
-    def test_read_timeout_is_retried(self, mock_post, client):
+    def test_read_timeout_is_not_retried(self, mock_post, client):
+        """A read timeout means the board ACCEPTED the request and went quiet.
+
+        This test previously asserted the opposite (``test_read_timeout_is_retried``,
+        #1754). That contract was wrong and the Phase 2 audit measured the cost:
+        a send to a wedged board went from 10.01s to 20.53s because the second
+        attempt pays the identical read timeout against the identical wedged
+        board. Retrying is for errors where no connection was established.
+        """
+        cancel = _no_cancel(client)
+        mock_post.side_effect = requests.exceptions.ReadTimeout("wedged")
+
+        result = client.send_characters(_flagship_grid(1))
+
+        assert result == (False, False)
+        assert mock_post.call_count == 1
+        cancel.wait.assert_not_called()
+
+    @patch("src.board_client.requests.post")
+    def test_connect_timeout_is_retried(self, mock_post, client):
+        """No connection was established, so the retry costs nothing extra to be
+        wrong about — ConnectTimeout subclasses ConnectionError deliberately."""
         _no_cancel(client)
-        mock_post.side_effect = [requests.exceptions.ReadTimeout("slow"), _ok_response()]
+        mock_post.side_effect = [requests.exceptions.ConnectTimeout("no route"), _ok_response()]
 
         result = client.send_characters(_flagship_grid(1))
 

--- a/tests/test_board_send_executor.py
+++ b/tests/test_board_send_executor.py
@@ -1,0 +1,162 @@
+"""Board sends get their own bounded pool so they cannot starve the app (#1878).
+
+Every ``asyncio.to_thread`` site in the process shares asyncio's default
+executor — ``min(32, cpu_count + 4)``, i.e. eight threads on a four-core Pi.
+Board sends are the one blocking family that can hold a thread for minutes: a
+queued send occupies its worker while merely blocked on the per-board send
+lock, and a transition plugin can hold that lock for its full runtime (up to
+the 120s manifest cap). A handful of concurrent sends therefore takes the whole
+shared pool and stalls unrelated blocking work — plugin installs, Wi-Fi scans,
+page previews.
+
+The test shrinks the default executor to the Pi's size so the arithmetic is
+deterministic, saturates it with concurrent board sends, and then asks an
+unrelated ``asyncio.to_thread`` endpoint (``POST /pages/{id}/preview``) for an
+answer. It must arrive promptly.
+"""
+
+import asyncio
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+
+import src.board_send_executor as board_send_executor
+from src.api_server import app
+
+# Stand-in for the shared pool on a four-core Pi.
+_DEFAULT_EXECUTOR_WORKERS = 8
+# More concurrent sends than that pool has threads.
+_CONCURRENT_SENDS = 12
+# Safety valve on the blocking stub; the assertions resolve long before it.
+_BLOCK_SECONDS = 5.0
+# An unrelated to_thread endpoint answering "promptly" means it did not queue
+# behind a send. The gap being measured is 0.05s vs _BLOCK_SECONDS.
+_BUDGET_SECONDS = 1.0
+# How many sends must be provably blocking on a thread before the measurement.
+# Below both pool sizes so the wait means the same thing on both sides of the fix.
+_BLOCKED_SENDS_FLOOR = 3
+
+
+@pytest.fixture(autouse=True)
+def _fresh_send_pool():
+    board_send_executor.shutdown_board_send_executor()
+    yield
+    board_send_executor.shutdown_board_send_executor()
+
+
+def _preview_result_mock() -> Mock:
+    return Mock(available=True, formatted="HELLO", display_type="text", raw=None, error=None)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_board_sends_do_not_starve_unrelated_thread_work():
+    """N slow sends must not delay an unrelated ``to_thread`` endpoint."""
+    loop = asyncio.get_running_loop()
+    shared = ThreadPoolExecutor(max_workers=_DEFAULT_EXECUTOR_WORKERS, thread_name_prefix="shared-pool")
+    loop.set_default_executor(shared)
+
+    release = threading.Event()
+    entered = threading.Semaphore(0)
+
+    def _blocking_send(*_args, **_kwargs):
+        entered.release()
+        release.wait(_BLOCK_SECONDS)
+        return True, None
+
+    service = Mock()
+    service.check_and_send_active_page_with_status = _blocking_send
+    page_service = Mock()
+    page_service.preview_page.return_value = _preview_result_mock()
+    settings = Mock()
+    settings.get_active_page_id.return_value = None
+
+    transport = httpx.ASGITransport(app=app)
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as ac:
+            with (
+                patch("src.api_server.get_service", return_value=service),
+                patch("src.api_server.get_page_service", return_value=page_service),
+                patch("src.api_server.get_settings_service", return_value=settings),
+            ):
+                sends = [asyncio.create_task(ac.post("/refresh")) for _ in range(_CONCURRENT_SENDS)]
+
+                # Wait until sends are genuinely blocking on worker threads.
+                # The floor is below BOTH pool sizes so the wait means the same
+                # thing before and after the fix; the non-vacuity claim below
+                # rests on how many sends are OUTSTANDING, which is what would
+                # have consumed the shared pool.
+                deadline = time.monotonic() + 5.0
+                occupied = 0
+                while occupied < _BLOCKED_SENDS_FLOOR and time.monotonic() < deadline:
+                    if entered.acquire(blocking=False):
+                        occupied += 1
+                    else:
+                        await asyncio.sleep(0.01)
+                # Let the remaining sends reach the handler and queue.
+                await asyncio.sleep(0.2)
+
+                # Snapshotted BEFORE the measurement: if the preview queues
+                # behind the sends it necessarily outlives them, so counting
+                # afterwards would count the very starvation under test as
+                # evidence that no starvation was possible.
+                outstanding = sum(1 for t in sends if not t.done())
+
+                started = time.monotonic()
+                preview = await ac.post("/pages/p1/preview")
+                waited = time.monotonic() - started
+
+                release.set()
+                await asyncio.gather(*sends)
+    finally:
+        release.set()
+        shared.shutdown(wait=False)
+
+    # Non-vacuity: sends really were blocking on threads, and enough of them
+    # were outstanding to have taken every thread of the shared pool.
+    assert occupied >= _BLOCKED_SENDS_FLOOR, (
+        f"only {occupied} sends reached a worker thread; the saturation never happened"
+    )
+    assert outstanding >= _DEFAULT_EXECUTOR_WORKERS, (
+        f"only {outstanding} sends were still in flight when the preview ran; "
+        f"fewer than the {_DEFAULT_EXECUTOR_WORKERS}-thread shared pool, so nothing was proven"
+    )
+
+    assert preview.status_code == 200
+    assert waited < _BUDGET_SECONDS, (
+        f"an unrelated to_thread endpoint waited {waited:.2f}s behind {_CONCURRENT_SENDS} "
+        "board sends — the sends are on the shared default executor"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_board_send_uses_the_dedicated_pool_not_the_default_executor():
+    """The helper's contract, pinned directly rather than only through a route."""
+    loop = asyncio.get_running_loop()
+    shared = ThreadPoolExecutor(max_workers=2, thread_name_prefix="shared-pool")
+    loop.set_default_executor(shared)
+    try:
+        via_helper = await board_send_executor.run_board_send(threading.current_thread)
+        via_to_thread = await asyncio.to_thread(threading.current_thread)
+    finally:
+        shared.shutdown(wait=False)
+
+    assert via_helper.name.startswith("board-send")
+    assert via_to_thread.name.startswith("shared-pool")
+
+
+@pytest.mark.asyncio
+async def test_run_board_send_forwards_arguments_and_propagates_exceptions():
+    """Same call contract as ``asyncio.to_thread``, including the failure path."""
+
+    def _work(a, *, b):
+        if a == "boom":
+            raise ValueError(b)
+        return f"{a}-{b}"
+
+    assert await board_send_executor.run_board_send(_work, "x", b="y") == "x-y"
+    with pytest.raises(ValueError, match="detail"):
+        await board_send_executor.run_board_send(_work, "boom", b="detail")

--- a/tests/test_nginx_api_timeouts.py
+++ b/tests/test_nginx_api_timeouts.py
@@ -1,0 +1,72 @@
+"""nginx must outwait the backend on the API proxy (issue #1886).
+
+``src.main.SEND_WAIT_TIMEOUT`` is how long a ``wait=True`` send blocks for its
+board job — 240s, sized in #1868 for a 120s transition ahead of us in the queue
+plus 15s cloud frame pacing plus our own paced send. nginx's API proxy was
+still on the stock ``proxy_read_timeout 60s``, so every send that legitimately
+took longer than a minute returned 504 to the browser while the backend went on
+working for up to four times as long: the UI reported failure for a send that
+succeeded, and the "please wait, the service is starting" body replaced the
+real JSON.
+
+That drift is the bug, so this test pins the RELATIONSHIP rather than the
+numbers. Raising SEND_WAIT_TIMEOUT without raising nginx fails here.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from src.main import SEND_WAIT_TIMEOUT
+
+CONFIGS = ("nginx.conf", "nginx.https.conf", "nginx-dev.conf")
+API_LOCATIONS = ("/api/mcp", "/api/")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_DURATION = re.compile(r"^(\d+(?:\.\d+)?)(ms|s|m|h)?$")
+_UNIT_SECONDS = {None: 1.0, "ms": 0.001, "s": 1.0, "m": 60.0, "h": 3600.0}
+
+
+def _seconds(value: str) -> float:
+    """Parse an nginx time literal ("300s", "5m", "250ms") into seconds."""
+    match = _DURATION.match(value)
+    assert match, f"unparseable nginx duration: {value!r}"
+    return float(match.group(1)) * _UNIT_SECONDS[match.group(2)]
+
+
+def _location_body(text: str, location: str) -> str:
+    """The brace-matched body of ``location <location> { ... }``."""
+    opener = f"location {location} {{"
+    start = text.index(opener) + len(opener)
+    depth = 1
+    for index in range(start, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:index]
+    raise AssertionError(f"unbalanced braces in `location {location}`")
+
+
+def _directive(body: str, name: str) -> float:
+    match = re.search(rf"^\s*{name}\s+(\S+?);", body, re.MULTILINE)
+    assert match, f"`{name}` is not declared in this location block"
+    return _seconds(match.group(1))
+
+
+@pytest.mark.parametrize("config_name", CONFIGS)
+@pytest.mark.parametrize("location", API_LOCATIONS)
+@pytest.mark.parametrize("directive", ("proxy_read_timeout", "proxy_send_timeout"))
+def test_api_proxy_outwaits_the_backend_send_budget(config_name: str, location: str, directive: str) -> None:
+    body = _location_body((REPO_ROOT / config_name).read_text(encoding="utf-8"), location)
+    value = _directive(body, directive)
+
+    assert value > SEND_WAIT_TIMEOUT, (
+        f"{config_name} `location {location}` has {directive} {value:g}s but "
+        f"src.main.SEND_WAIT_TIMEOUT is {SEND_WAIT_TIMEOUT:g}s: a wait-mode send that runs "
+        f"longer than {value:g}s returns 504 to the browser while the backend is still working. "
+        "Raise the nginx timeout whenever SEND_WAIT_TIMEOUT rises."
+    )

--- a/tests/test_plugin_fetch_breaker.py
+++ b/tests/test_plugin_fetch_breaker.py
@@ -1,0 +1,166 @@
+"""Plugin-fetch circuit breaker and reserved pool capacity (issue #1884).
+
+The shared bounded pool (``PLUGIN_FETCH_MAX_WORKERS``) fixed the thread leak
+of #1751, but a wedged fetch OCCUPIES its worker until the plugin returns —
+which for a genuinely wedged data source is never. Once that many distinct
+referenced plugins wedge, every worker is gone and healthy plugins are starved
+off the board permanently.
+
+Two defects are pinned here:
+
+1. **Starvation.** The audit's repro — 12 referenced plugins, 8 of them
+   permanently wedged, 60 ticks. The four healthy plugins must be in the
+   context on every tick once the breaker has opened, and the wedged ones must
+   stop being submitted.
+2. **The 15s render stall.** A single wedged *referenced* plugin made every
+   render wait the full ``CONTEXT_BUILD_TIMEOUT_SECONDS`` — 15s in production —
+   forever. After the breaker opens the render must not wait for it at all.
+
+Timing here is only ever used to separate "waited for the timeout" from "did
+not wait at all"; the assertions on presence and submission counts are exact.
+"""
+
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import src.plugins.registry as registry_module
+from src.plugins.base import PluginBase, PluginResult
+from src.plugins.registry import PluginRegistry
+
+WEDGED = 8
+HEALTHY = 4
+TICKS = 60
+TIMEOUT = 0.05
+# Ticks allowed for the breaker to notice and quarantine the wedged plugins.
+# Deliberately expressed as a plain number rather than as the threshold
+# constant so this test measures BEHAVIOR on both sides of the fix.
+SETTLE_TICKS = 10
+
+
+def _make_registry() -> PluginRegistry:
+    loader = MagicMock()
+    loader.load_all_plugins.return_value = {}
+    loader.load_errors = {}
+    loader.get_manifest.return_value = None
+    with patch("src.plugins.registry.PluginLoader", return_value=loader):
+        return PluginRegistry(plugins_dir=Path("/fake/plugins"))
+
+
+def _install(registry: PluginRegistry, plugin_id: str, get_data=None):
+    plugin = MagicMock(spec=PluginBase)
+    plugin.plugin_id = plugin_id
+    plugin.supports_triggers = False
+    if get_data is not None:
+        plugin.get_data.side_effect = get_data
+    else:
+        plugin.get_data.return_value = PluginResult(available=True, data={"value": plugin_id.upper()})
+    registry._plugins[plugin_id] = plugin
+    registry._enabled[plugin_id] = True
+    return plugin
+
+
+@pytest.fixture
+def fresh_pool():
+    """Private shared-pool lifetime so occupancy is this test's alone."""
+    registry_module.shutdown_plugin_fetch_executor()
+    yield
+    registry_module.shutdown_plugin_fetch_executor()
+
+
+@pytest.fixture
+def registry(monkeypatch, fresh_pool):
+    reg = _make_registry()
+    monkeypatch.setattr("src.plugins.registry.get_plugin_registry", lambda: reg)
+    monkeypatch.setattr(registry_module, "CONTEXT_BUILD_TIMEOUT_SECONDS", TIMEOUT)
+    return reg
+
+
+@pytest.fixture
+def release():
+    """An event every wedged fetch waits on; set in teardown so no thread leaks."""
+    ev = threading.Event()
+    yield ev
+    ev.set()
+
+
+def _wedge(release: threading.Event):
+    def _hang(board=None):
+        release.wait(timeout=30)
+        return PluginResult(available=False, error="released")
+
+    return _hang
+
+
+class TestStarvationUnderWedgedPlugins:
+    def test_healthy_plugins_are_served_every_tick_despite_eight_wedged_ones(self, registry, release):
+        """The audit repro: 8 wedged + 4 healthy referenced plugins, 60 ticks.
+
+        Pre-fix the eight wedged fetches took all eight pool workers on tick 1
+        and never gave them back, so the healthy four never started again and
+        vanished from the context for the rest of the process's life.
+        """
+        wedged_ids = [f"wedged_{i}" for i in range(WEDGED)]
+        healthy_ids = [f"healthy_{i}" for i in range(HEALTHY)]
+        for pid in wedged_ids:  # installed first: they win the race for the workers
+            _install(registry, pid, get_data=_wedge(release))
+        for pid in healthy_ids:
+            _install(registry, pid)
+
+        referenced = wedged_ids + healthy_ids
+        contexts = [registry.build_template_context(plugin_ids=referenced) for _ in range(TICKS)]
+
+        # The breaker needs a few ticks to notice; after that every tick must
+        # carry all four healthy plugins.
+        for offset, context in enumerate(contexts[SETTLE_TICKS:]):
+            present = [pid for pid in healthy_ids if pid in context]
+            assert present == healthy_ids, (
+                f"tick {offset + SETTLE_TICKS}: only {present} of {healthy_ids} reached the context"
+            )
+
+        # Non-vacuity: the data really is the healthy plugins' own.
+        assert contexts[-1]["healthy_0"] == {"value": "HEALTHY_0"}
+
+        # The wedged plugins are submitted once each and then never again.
+        wedged_calls = {pid: registry._plugins[pid].get_data.call_count for pid in wedged_ids}
+        assert wedged_calls == dict.fromkeys(wedged_ids, 1), (
+            f"wedged plugins were resubmitted after the breaker opened: {wedged_calls}"
+        )
+
+    def test_breaker_status_names_the_quarantined_plugins(self, registry, release):
+        """The quarantine is reportable, not just a log line."""
+        _install(registry, "wedged", get_data=_wedge(release))
+        _install(registry, "healthy")
+
+        for _ in range(SETTLE_TICKS):
+            registry.build_template_context(plugin_ids=["wedged", "healthy"])
+
+        status = registry.get_fetch_breaker_status()
+        assert status["wedged"]["quarantined"] is True
+        assert status["wedged"]["consecutive_timeouts"] >= registry_module.PLUGIN_FETCH_BREAKER_THRESHOLD
+        assert status["wedged"]["cooldown_remaining_seconds"] > 0
+        assert "healthy" not in status, "a plugin that answers every tick must never be quarantined"
+
+
+class TestWedgedPluginRenderStall:
+    def test_a_wedged_referenced_plugin_stops_costing_every_render_the_timeout(self, registry, release):
+        """One wedged referenced plugin used to cost EVERY render the full
+        context-build timeout (15s in production) forever."""
+        _install(registry, "wedged", get_data=_wedge(release))
+
+        durations = []
+        for _ in range(SETTLE_TICKS + 5):
+            started = time.monotonic()
+            registry.build_template_context(plugin_ids=["wedged"])
+            durations.append(time.monotonic() - started)
+
+        # Non-vacuity: the first render really did pay the full timeout, so a
+        # green result cannot come from the wedge failing to wedge.
+        assert durations[0] >= TIMEOUT, f"the first render did not stall at all: {durations[0]:.3f}s"
+        after = durations[SETTLE_TICKS:]
+        assert all(d < TIMEOUT / 2 for d in after), (
+            f"renders still wait for the wedged plugin after the breaker opened: {after}"
+        )


### PR DESCRIPTION
Phase 2 Task 9 (`.superpowers/plans/2026-09-06-rework-phase2.md`), the parallel robustness track. Four fixes in disjoint files, one commit each, every one with a fail-first test whose pre-fix output is in its commit body.

**All four golden corpora are byte-identical** — `git diff origin/next-rebuild -- tests/golden/` is empty. These are robustness fixes, not behavior changes.

## 9a — plugin-fetch pool starvation (#1884)

`24c3f88` · `src/plugins/registry.py`

The audit's measurement: 12 referenced plugins, 8 wedged, 60 ticks. The four healthy plugins went from served-every-tick (240 fetches on the old code) to **4 fetches total and 0 of 4 present in the final context**.

**Design chosen: per-plugin circuit breaker + pool rotation.** Reserved capacity by admission control cannot work here, and it is worth saying why: at tick 1 no plugin is yet *known* to be slow, so the wedged ones win the race for the workers and hold them **forever** — no thread stuck in plugin code can be reclaimed by any later policy. So the fix attacks both halves:

- A fetch that actually **started** and is still running at the context-build timeout charges one consecutive timeout to its plugin. At 3 the plugin is quarantined for 300s — neither submitted **nor waited on**. A fetch that never started is *not* charged: that is a symptom of saturation caused by *other* plugins, and charging it would quarantine exactly the healthy plugins the breaker exists to protect.
- The worker a quarantined plugin still holds is written off (once per future, so a post-cooldown probe on the same future is not double-counted). Once half the pool is written off, the shared pool is rotated — a fresh pool takes over, the retired one keeps its stuck threads until the process exits. That is the reserved capacity: healthy plugins always have at least half the pool.

Total stuck threads stay bounded, which is what #1751 actually required: in-flight dedupe holds each plugin to one fetch per board key and the breaker stops resubmitting it, so the ceiling is the number of distinct wedged `(plugin, board)` pairs — never a per-tick growth rate.

**Also fixes the related unfixed defect** (present on old and new code alike): one wedged *referenced* plugin made every render pay the full `CONTEXT_BUILD_TIMEOUT_SECONDS` — 15s in production — forever. Skipping the wait removes that stall once the breaker opens. Covered by its own test.

`get_fetch_breaker_status()` reports the quarantine. Deliberately **not** wired into an HTTP response here: the plugins domain has response goldens that the Task 6 slice re-records, and this PR must leave all four corpora untouched.

Tests: `tests/test_plugin_fetch_breaker.py` (3).

## 9b — nginx vs SEND_WAIT_TIMEOUT (#1886)

`6fc97e7` · `nginx.conf`, `nginx.https.conf`, `nginx-dev.conf`, `src/main.py`

`SEND_WAIT_TIMEOUT = 240.0`; nginx's `/api` blocks were on the stock `proxy_read_timeout 60s` / `proxy_send_timeout 30s`. Any send over a minute returned 504 to the browser while the backend worked 4x longer — and because `/api` 504s hit the `@api_starting` fallback, the real JSON was replaced by "Service is starting up". Routine now that cloud frames pace 15s apart up to a 120s transition cap.

Raised both directives to 300s on both `/api` blocks in **all three** configs (the dev config proxies the same backend and had the same 60s), with a comment on each side naming the other number. The test pins the **relationship**, not the literals: raising `SEND_WAIT_TIMEOUT` without raising nginx now fails the build. Silent drift is exactly how this bug happened.

Tests: `tests/test_nginx_api_timeouts.py` (12, parameterized over config x location x directive).

## 9c — executor bounding (#1878)

`7f0627c` · new `src/board_send_executor.py`, `src/api_server.py`, `src/pages/routes.py`

~61 `asyncio.to_thread` sites share asyncio's default executor: 8 threads on a four-core Pi. The audit measured 40 concurrent 2s requests finishing in exactly three waves of 18 workers. Board sends are the one blocking family that can hold a thread for minutes — a queued send occupies its worker while merely *blocked on `_send_lock`*, and a transition plugin can hold that lock for its full runtime — so send saturation could starve plugin installs, Wi-Fi scans, live-editor previews.

`run_board_send()` is a drop-in for `asyncio.to_thread` (same call contract, contextvar propagation included) on a bounded 4-worker pool. Six call sites move onto it: `POST /refresh` (both branches), `POST /force-refresh`, `PUT /settings/active-page`, `POST /pages/{id}/send`, `POST /templates/render/live`, `POST /transitions/restore`. Four workers is deliberate — sends are already serialized per board by that board's send worker (#1755), so extra threads would only queue deeper. Torn down in the lifespan shutdown alongside the plugin-fetch pool.

The test shrinks the loop's default executor to the Pi's 8 threads for determinism, and snapshots its non-vacuity evidence **before** the measurement: a preview that queues behind the sends necessarily outlives them, so counting outstanding sends afterwards would read the starvation under test as proof that starvation was impossible.

Tests: `tests/test_board_send_executor.py` (3). `test_blocking_io_event_loop` (the #1826 watchdogs over the same handlers) stays green.

## 9d — doubled wedged-board send cost

`4a6dc52` · `src/board_client.py`

#1754 retried "the board never answered", lumping `ConnectionError` and `Timeout` together. Against a board that is *wedged* rather than *down* that doubled the wall clock: 10.01s → 20.53s, with the per-board send worker and every `wait=True` caller behind it blocked for the whole doubled stall.

Now conditional on error class:

- `ConnectionError` → **retry**. Board not listening (refused, reset, DNS). The failure is immediate so the retry is cheap, and it often wins. `ConnectTimeout` subclasses `ConnectionError` and stays on this side for the same reason — no connection was established.
- `ReadTimeout` → **do not retry**. The board accepted the request and went quiet. A second identical attempt is no likelier to succeed and doubles the stall.
- HTTP 4xx/5xx unchanged: the board answering, never retried.

#1754's tests stay green except one that encoded the now-wrong contract: `test_read_timeout_is_retried` → `test_read_timeout_is_not_retried`, justified in place in the test body. Added `test_connect_timeout_is_retried` to pin the boundary — it fails if the predicate is over-narrowed to "ConnectionError and not Timeout".

## Verification

- Named suites: `test_plugin_registry_locking`, `test_registry_lock_discipline`, `test_engine_equivalence`, `test_send_worker`, `test_board_client_policy`, `test_board_client`, `test_blocking_io_event_loop`, `test_out_of_band_throttle`, `test_demand_driven_fetch`, `test_tick_shared_context`, plus the three new files — **235 passed**.
- Full suite `-m "not integration" -n auto`: baseline on `origin/next-rebuild` was 5949 passed / 1 failed; this branch is **5968 passed / 1 failed** — the same known-environmental `test_check_image_formats.py::TestRepositoryIsClean` worktree failure, +19 new tests, no regressions.
- `ruff==0.16.5`: `ruff check src/ tests/` and `ruff format --check src/ tests/` both clean.
- `git diff origin/next-rebuild -- tests/golden/` — empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP