### PR TITLE
fix: close the silent-failure defects (Phase 2 Task 10) — status codes, settings persistence, backup rollback, board_id validation

### DIFF
--- a/docs/internal/reference/API_CONVENTIONS.md
+++ b/docs/internal/reference/API_CONVENTIONS.md
@@ -27,6 +27,24 @@ three response shapes, zero 201s, `response_model` on 19 of 179 endpoints,
 - **Failures are never 200.** A handler must not answer an error with
   `{"success": false}` and HTTP 200. Client errors are 4xx, server errors
   5xx.
+- **Probe endpoints: one narrow exception.** An endpoint whose declared job
+  is to *report a verdict about something else* — `POST /config/board/test`,
+  `POST /config/board/enable-local-api` — answers 200 when the probe ran, even
+  when the verdict is "the board refused this key". The verdict is the payload
+  the caller asked for, not a transport failure. Three conditions make that
+  legitimate, and all three are required:
+  1. the 200 body is a declared `response_model` (`BoardTestResponse`,
+     `EnableLocalApiResponse`), never an ad-hoc dict;
+  2. the failure originated **upstream** — the board, or the network to it;
+  3. anything the server rejected *before* probing (missing credential,
+     malformed host, an SSRF-guard refusal) is a real 4xx, and anything
+     unanticipated is a 5xx.
+
+  Without (1) a generic client cannot tell the verdict from a success, which
+  is exactly the masking bug this rule replaced (#1887). `POST
+  /debug/test-connection` deliberately does *not* qualify: it has no verdict
+  body — no error class, no troubleshooting steps — so an unreachable board
+  there is a 503 and an unexpected error is a 500.
 - Missing resource → **404**; conflict (duplicate id, env-pinned resource) →
   **409**; feature unavailable / dependency down → **503**.
 

--- a/docs/internal/reference/API_CONVENTIONS.md
+++ b/docs/internal/reference/API_CONVENTIONS.md
@@ -92,6 +92,41 @@ contract through a deprecation window:
   (`updates`, `registry`, `install`, ...). Each router owns its reserved
   list next to its routes.
 
+### `board_id` validation: writes 404, reads fall back
+
+Decided 2026-09 with #1888. The asymmetry is deliberate and it is the
+inconsistency-of-record, so read it before "fixing" either half.
+
+- **Writes 404.** Any handler that persists something scoped to a board
+  calls `_require_board(board_id)` (`src/api_server.py`) — the single place
+  the "unknown board" verdict is made. Writing state bound to a board that
+  does not exist is invisible until something else trips over it: the four
+  schedule write endpoints used to store a phantom default page, a no-op
+  that reported `{"status": "success"}`, and schedules parented to
+  nonexistent boards.
+- **Reads fall back.** `GET /schedules` answers `[]`, `GET /schedules/enabled`
+  answers `false`, `GET /schedules/default-page` answers the global default,
+  and their siblings behave the same way. This is not an oversight:
+  1. a read cannot corrupt anything, so the worst case is a caller shown the
+     safe empty answer;
+  2. board-scoped polling legitimately races board deletion — one tab
+     removes a board while another is mid-poll for it — and 404ing there
+     turns a benign race into an error toast for the user;
+  3. the fallback answer ("no schedules", "not enabled") is *correct* for a
+     board that does not exist, whereas a write's fallback ("saved!") is a
+     lie.
+
+  `board_id=*` on `GET /schedules` stays a documented wildcard, not an id.
+
+If reads are ever made strict, they must all change together and the
+polling clients must be updated in the same PR.
+
+Two `SettingsService` setters — `set_paused` and `set_active_page_id` —
+also raise `ValueError` on an unknown board. Both are **unreachable with an
+unknown board over HTTP today** (every route reaching them validates first
+or 404s on its own path parameter); the raise is defense in depth so a
+future caller cannot recreate the phantom write.
+
 ## Zero-regression mechanics (how a conventions pass lands)
 
 1. Record the domain's **response-shape golden** from current behavior

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -8134,10 +8134,15 @@ async def import_backup(
     manually if needed.  In-memory service singletons are reloaded so the
     change takes effect without restarting the container.
     """
-    from .backup import BackupError, get_backup_service
+    from .backup import BackupError, BackupRestoreAborted, get_backup_service
 
     try:
         result = get_backup_service().import_from_dict(payload, reinstall_plugins=reinstall_plugins)
+    except BackupRestoreAborted as exc:
+        # The environment failed, not the uploaded file — a 400 would blame
+        # the operator's backup for a full disk (Phase 2 Task 10d).
+        logger.error("Backup restore aborted: %s", exc)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
     except BackupError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception:

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -2225,9 +2225,7 @@ async def refresh_display(board_id: str | None = None, payload: dict | None = Bo
                 "sent": sent,
             }
 
-        board = _find_board(board_id)
-        if board is None:
-            raise HTTPException(status_code=404, detail=f"Board not found: {board_id}")
+        board = _require_board(board_id)
         rt = service.get_runtime(board_id)
         if rt is None:
             raise HTTPException(status_code=503, detail=f"Board client not initialized: {board_id}")
@@ -2384,9 +2382,7 @@ async def get_board_current_message(force: bool = False, board_id: str | None = 
         raise HTTPException(status_code=503, detail="Board client not initialized")
 
     if board_id is not None:
-        board = _find_board(board_id)
-        if board is None:
-            raise HTTPException(status_code=404, detail=f"Board not found: {board_id}")
+        board = _require_board(board_id)
         if board_id != get_settings_service().get_primary_board_id():
             # Secondary board: serve from its runtime cache. No live read —
             # the poll thread only tracks the primary board (issue #1243).
@@ -3620,8 +3616,8 @@ async def update_silence_schedule(request: SilenceScheduleRequest):
     config_manager = get_config_manager()
 
     board_id = request.board_id
-    if board_id is not None and _find_board(board_id) is None:
-        raise HTTPException(status_code=404, detail=f"Board not found: {board_id}")
+    if board_id is not None:
+        _require_board(board_id)
 
     # Validate mode and page_id together
     mode = request.mode if request.mode in ("indicator", "freeze", "page") else "freeze"
@@ -4963,9 +4959,7 @@ def _resolve_live_board_client(board_id: str | None) -> tuple[dict | None, Any]:
     if board_id is not None:
         if not service:
             raise HTTPException(status_code=503, detail="Service not initialized")
-        board = _find_board(board_id)
-        if board is None:
-            raise HTTPException(status_code=404, detail=f"Board not found: {board_id}")
+        board = _require_board(board_id)
         client = service.get_board_client(board_id)
         if client is None:
             raise HTTPException(status_code=503, detail=f"Board client not initialized: {board_id}")
@@ -5317,9 +5311,7 @@ async def set_active_page(request: dict):
     board_id = request.get("board_id")
     board = None
     if board_id is not None:
-        board = _find_board(board_id)
-        if board is None:
-            raise HTTPException(status_code=404, detail=f"Board not found: {board_id}")
+        board = _require_board(board_id)
     collection_service = get_collection_service()
 
     # Validate page or collection exists if not clearing
@@ -5823,10 +5815,8 @@ async def set_board_paused(board_id: str, request: dict):
         raise HTTPException(status_code=400, detail="paused is required")
     if not isinstance(request["paused"], bool):
         raise HTTPException(status_code=400, detail="paused must be a boolean")
+    _require_board(board_id)
     settings_service = get_settings_service()
-    boards = settings_service.get_board_settings().boards or []
-    if not any(b.get("id") == board_id for b in boards):
-        raise HTTPException(status_code=404, detail=f"Board {board_id} not found")
     paused = settings_service.set_paused(request["paused"], board_id=board_id)
     return {
         "status": "success",
@@ -6455,6 +6445,25 @@ def _find_board(board_id: str) -> dict | None:
         if isinstance(board, dict) and board.get("id") == board_id:
             return board
     return None
+
+
+def _require_board(board_id: str) -> dict:
+    """Return the ``settings.boards`` entry for *board_id*, or raise 404.
+
+    The single place the "unknown board" verdict is made. The pattern was
+    open-coded in nine handlers and simply missing from four schedule write
+    endpoints, which persisted state bound to a board that does not exist and
+    reported success (#1888).
+
+    Use this on any path that *writes* something scoped to a board. Board-
+    scoped **reads** deliberately fall back to their safe default instead —
+    see the "board_id validation" note in
+    ``docs/internal/reference/API_CONVENTIONS.md``.
+    """
+    board = _find_board(board_id)
+    if board is None:
+        raise HTTPException(status_code=404, detail=f"Board not found: {board_id}")
+    return board
 
 
 def _board_dims(board: dict):
@@ -7384,12 +7393,7 @@ async def render_template_live(request: dict):
 
     target_board = None
     if board_id:
-        for b in boards:
-            if b.get("id") == board_id:
-                target_board = b
-                break
-        if not target_board:
-            raise HTTPException(status_code=404, detail=f"Board not found: {board_id}")
+        target_board = _require_board(board_id)
     elif boards:
         target_board = boards[0]
 

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -1077,8 +1077,13 @@ async def get_mqtt_status():
             "connected": client.is_connected(),
             "running": client.is_running(),
         }
-    except Exception:
-        return {"enabled": False, "connected": False, "running": False}
+    except Exception as e:
+        # ``enabled: False`` is a real answer ("MQTT is switched off"), so it
+        # must never double as "we could not tell" — the two were identical
+        # before #1887 and an operator debugging a broken broker saw the
+        # same body as one who had simply not enabled MQTT.
+        logger.error(f"Failed to read MQTT status: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to read MQTT status.") from e
 
 
 @app.post("/mqtt/republish-discovery")
@@ -2988,6 +2993,25 @@ async def validate_config():
     return {"valid": is_valid, "is_first_run": is_first_run, "errors": errors, "missing_fields": missing_fields}
 
 
+class BoardTestResponse(BaseModel):
+    """Declared verdict of a board connection probe.
+
+    ``POST /config/board/test`` is a *probe*: reporting "the board refused
+    this key" is the answer the caller asked for, not a transport failure,
+    so an upstream verdict stays HTTP 200 with ``success=False``. That is
+    only legitimate because the shape is declared here — an ad-hoc dict at
+    200 is indistinguishable from a success to any generic client (#1887).
+    Preconditions the server rejects before probing (missing credential,
+    malformed/unsafe host) are 4xx; unanticipated errors are 5xx.
+    """
+
+    success: bool
+    message: str
+    api_mode: str | None = None
+    error: str | None = None
+    troubleshooting: list[str] | None = None
+
+
 class BoardTestRequest(BaseModel):
     """Request model for testing board connection."""
 
@@ -2999,7 +3023,12 @@ class BoardTestRequest(BaseModel):
     port: int | None = None
 
 
-@app.post("/config/board/test")
+@app.post(
+    "/config/board/test",
+    response_model=BoardTestResponse,
+    response_model_exclude_none=True,
+    responses={400: {"description": "Missing credential, or a host the server refuses to probe"}},
+)
 async def test_board_connection(request: BoardTestRequest):
     """
     Test board connection with provided credentials without saving.
@@ -3023,6 +3052,12 @@ async def test_board_connection(request: BoardTestRequest):
         success: Whether the connection test passed
         message: Human-readable status message
         error: Detailed error message if failed
+
+    Status codes:
+        200: the probe ran and this is its verdict (``success`` may be False)
+        400: the probe could not be attempted — a credential is missing or
+             the host is not one this server will connect to
+        500: an unanticipated server-side error
     """
     from .board_client import BoardClient, is_successful_board_read_response
 
@@ -3031,34 +3066,22 @@ async def test_board_connection(request: BoardTestRequest):
     # Validate required fields based on mode
     if api_mode == "cloud":
         if not request.cloud_key:
-            return {"success": False, "message": "Cloud API key is required", "error": "Missing cloud_key parameter"}
+            raise HTTPException(status_code=400, detail="Cloud API key is required")
         api_key = request.cloud_key
         use_cloud = True
         host = None
     else:  # local mode
         if not request.local_api_key:
-            return {
-                "success": False,
-                "message": "Local API key is required",
-                "error": "Missing local_api_key parameter",
-            }
+            raise HTTPException(status_code=400, detail="Local API key is required")
         if not request.host:
-            return {
-                "success": False,
-                "message": "Board host/IP is required for Local API",
-                "error": "Missing host parameter",
-            }
+            raise HTTPException(status_code=400, detail="Board host/IP is required for Local API")
         api_key = request.local_api_key
         use_cloud = False
         host = request.host
-        try:
-            _validate_board_host(host)
-        except HTTPException as _exc:
-            return {
-                "success": False,
-                "message": "Invalid board host",
-                "error": _exc.detail,
-            }
+        # The host guard is the reason this endpoint cannot be pointed at an
+        # arbitrary URL. Its 400 propagates unchanged: swallowing it into a
+        # 200 body made a refused request look like a failed probe (#1887).
+        _validate_board_host(host)
 
     try:
         # Create temporary client with provided credentials
@@ -3158,14 +3181,11 @@ async def test_board_connection(request: BoardTestRequest):
                 ],
             }
 
-    except ValueError:
-        # Invalid configuration (missing required fields)
+    except ValueError as e:
+        # BoardClient rejected the credentials/host combination outright, so
+        # no probe happened: a precondition failure, not a board verdict.
         logger.warning("Board connection test failed - invalid config", exc_info=True)
-        return {
-            "success": False,
-            "message": "Board connection configuration is invalid.",
-            "error": "Configuration error",
-        }
+        raise HTTPException(status_code=400, detail="Board connection configuration is invalid.") from e
     except requests.exceptions.ConnectionError as e:
         logger.error(f"Board connection test error: {e}")
         if use_cloud:
@@ -3215,18 +3235,27 @@ async def test_board_connection(request: BoardTestRequest):
                     "Try using the board's IP address instead of a hostname.",
                 ],
             }
+    except HTTPException:
+        raise
     except Exception as e:
+        # Not a board verdict — the probe itself broke. Detail stays generic;
+        # the exception is in the log, not in the response (#1887).
         logger.error(f"Board connection test error: {e}", exc_info=True)
-        return {
-            "success": False,
-            "message": "Connection failed",
-            "error": "Unexpected error",
-            "troubleshooting": [
-                "Make sure the Vestaboard is powered on and connected to your network.",
-                "Try restarting FiestaBoard and the Vestaboard.",
-                "Visit the Network Diagnostics page for a detailed connection check.",
-            ],
-        }
+        raise HTTPException(status_code=500, detail="Board connection test failed unexpectedly.") from e
+
+
+class EnableLocalApiResponse(BaseModel):
+    """Declared verdict of a Local API enablement exchange.
+
+    Same contract as :class:`BoardTestResponse` (see its docstring): the
+    board's answer — including "that token is not valid" — is data at 200;
+    preconditions are 4xx; unanticipated errors are 5xx.
+    """
+
+    success: bool
+    message: str
+    api_key: str | None = None
+    error: str | None = None
 
 
 class EnablementTokenRequest(BaseModel):
@@ -3242,7 +3271,12 @@ class BoardScanRequest(BaseModel):
     timeout: float | None = 4.0
 
 
-@app.post("/config/board/enable-local-api")
+@app.post(
+    "/config/board/enable-local-api",
+    response_model=EnableLocalApiResponse,
+    response_model_exclude_none=True,
+    responses={400: {"description": "Missing field, or a host the server refuses to contact"}},
+)
 async def enable_local_api(request: EnablementTokenRequest):
     """
     Exchange a Local API Enablement Token for a Local API Key.
@@ -3260,30 +3294,28 @@ async def enable_local_api(request: EnablementTokenRequest):
         success: Whether the exchange was successful
         api_key: The local API key (if successful)
         message: Human-readable status message
+
+    Status codes:
+        200: the exchange was attempted and this is the board's answer
+        400: the exchange could not be attempted — a field is missing or the
+             host is not one this server will contact
+        500: an unanticipated server-side error
     """
     import requests as http_requests
 
     if not request.host:
-        return {"success": False, "message": "Board IP address is required", "error": "Missing host parameter"}
+        raise HTTPException(status_code=400, detail="Board IP address is required")
 
     if not request.enablement_token:
-        return {
-            "success": False,
-            "message": "Enablement token is required",
-            "error": "Missing enablement_token parameter",
-        }
+        raise HTTPException(status_code=400, detail="Enablement token is required")
 
     # Validate the host before composing the URL so an attacker can't
-    # redirect this request away from the local board (SSRF).
-    try:
-        _validate_board_host(request.host)
-        _validate_board_host_is_local_network(request.host)
-    except HTTPException as exc:
-        return {
-            "success": False,
-            "message": "Invalid board host",
-            "error": exc.detail,
-        }
+    # redirect this request away from the local board (SSRF). These 400s
+    # propagate unchanged — downgrading them to a 200 body meant a blocked
+    # SSRF attempt and a board that rejected the token were the same
+    # response to every client (#1887).
+    _validate_board_host(request.host)
+    _validate_board_host_is_local_network(request.host)
 
     # Resolve the host to a concrete IPv4 address and ensure it is a private/
     # loopback/link-local address.  Using the ``ipaddress`` module's
@@ -3300,27 +3332,15 @@ async def enable_local_api(request: EnablementTokenRequest):
             _addrinfo = _socket_mod.getaddrinfo(
                 request.host, None, family=_socket_mod.AF_INET, type=_socket_mod.SOCK_STREAM
             )
-        except _socket_mod.gaierror:
-            return {
-                "success": False,
-                "message": "Invalid board host",
-                "error": "host could not be resolved",
-            }
+        except _socket_mod.gaierror as exc:
+            raise HTTPException(status_code=400, detail="host could not be resolved") from exc
         _resolved = [info[4][0] for info in _addrinfo if info and len(info) >= 5 and info[4]]
         if not _resolved:
-            return {
-                "success": False,
-                "message": "Invalid board host",
-                "error": "host did not resolve to an IPv4 address",
-            }
+            raise HTTPException(status_code=400, detail="host did not resolve to an IPv4 address") from None
         _ip_obj = _ipaddress_mod.IPv4Address(_resolved[0])
 
     if not (_ip_obj.is_private or _ip_obj.is_loopback or _ip_obj.is_link_local):
-        return {
-            "success": False,
-            "message": "Invalid board host",
-            "error": "host must be on a private network",
-        }
+        raise HTTPException(status_code=400, detail="host must be on a private network")
     _safe_host = _ip_obj.compressed
     # Build the URL for the local enablement endpoint
     url = f"http://{_safe_host}:7000/local-api/enablement"
@@ -3377,13 +3397,11 @@ async def enable_local_api(request: EnablementTokenRequest):
             "message": "Connection timed out. Please check the IP address and try again.",
             "error": "Timeout",
         }
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Local API enablement error: {e}", exc_info=True)
-        return {
-            "success": False,
-            "message": "Failed to enable local API",
-            "error": "Unexpected error",
-        }
+        raise HTTPException(status_code=500, detail="Failed to enable local API.") from e
 
 
 @app.post("/config/board/scan")
@@ -4622,10 +4640,18 @@ async def validate_traffic_route(request: dict):
         data = await asyncio.to_thread(traffic_source.fetch_traffic_data)
 
         if not data:
-            return {
-                "valid": False,
-                "error": "Failed to validate route. This could be due to: 1) Invalid addresses, 2) Google Routes API not enabled, 3) API key issues. Check the API logs for details.",
-            }
+            # No verdict was produced: the upstream Routes API returned
+            # nothing, which is not the same as "this route is invalid".
+            # Reporting it as ``valid: false`` at 200 hid every outage,
+            # quota block and disabled-API misconfiguration (#1887).
+            raise HTTPException(
+                status_code=502,
+                detail=(
+                    "Could not validate the route: the Google Routes API returned no data. "
+                    "This is usually an invalid address, the Routes API not being enabled, "
+                    "or an API key problem."
+                ),
+            )
 
         # Extract coordinates if available
         origin_coords = None
@@ -4642,9 +4668,11 @@ async def validate_traffic_route(request: dict):
             "destination_coords": destination_coords,
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error validating traffic route: {e}", exc_info=True)
-        return {"valid": False, "error": "Failed to validate route"}
+        raise HTTPException(status_code=500, detail="Failed to validate route.") from e
 
 
 # =============================================================================
@@ -6679,11 +6707,16 @@ async def debug_test_connection():
                 "connected": True,
                 "latency_ms": latency,
             }
-        else:
-            return {"status": "error", "message": "Connection failed", "connected": False, "latency_ms": None}
+        # Unlike /config/board/test this endpoint has no declared verdict
+        # body — no error class, no troubleshooting — so a 200 carrying
+        # ``status: "error"`` was indistinguishable from a success to any
+        # client that only checks the status code (#1887).
+        raise HTTPException(status_code=503, detail="Could not reach the board.")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error testing connection: {e}", exc_info=True)
-        return {"status": "error", "message": "Connection test failed", "connected": False, "latency_ms": None}
+        raise HTTPException(status_code=500, detail="Connection test failed.") from e
 
 
 @app.post("/debug/clear-cache")

--- a/src/backup/__init__.py
+++ b/src/backup/__init__.py
@@ -9,6 +9,7 @@ restore it on a new instance.
 from .service import (
     BACKUP_SCHEMA_VERSION,
     BackupError,
+    BackupRestoreAborted,
     BackupService,
     get_backup_service,
 )
@@ -16,6 +17,7 @@ from .service import (
 __all__ = [
     "BACKUP_SCHEMA_VERSION",
     "BackupError",
+    "BackupRestoreAborted",
     "BackupService",
     "get_backup_service",
 ]

--- a/src/backup/service.py
+++ b/src/backup/service.py
@@ -69,6 +69,16 @@ class BackupError(Exception):
     """Raised when a backup cannot be produced or restored."""
 
 
+class BackupRestoreAborted(BackupError):
+    """A restore stopped because the environment, not the backup, failed.
+
+    Distinguished from a plain :class:`BackupError` — which means "this file
+    is not a usable backup", a client error — so a full disk or an
+    unwritable ``data/`` is reported as the server-side failure it is
+    instead of blaming the uploaded file.
+    """
+
+
 class BackupService:
     """Export and import FiestaBoard user data."""
 
@@ -127,7 +137,17 @@ class BackupService:
         The current ``data/`` directory is *not* deleted — instead each
         file we are about to overwrite is copied to
         ``data/<name>.json.pre-restore-<timestamp>`` so the user can roll
-        back manually if something goes wrong.
+        back manually if something goes wrong. A file whose copy cannot be
+        written is not overwritten at all; the restore aborts with
+        :class:`BackupError` instead.
+
+        .. warning::
+           The restore is **not transactional across files**. A hard failure
+           while restoring file N leaves files 1..N-1 restored and N..end at
+           their original contents, with a ``.pre-restore-<timestamp>`` copy
+           beside each of 1..N-1. The suffix is reported so the operator can
+           finish the rollback by hand. Making the whole set atomic (stage
+           every file, then rename them all) is a separate change.
 
         Args:
             backup: Parsed backup document.
@@ -150,6 +170,10 @@ class BackupService:
             timestamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
             restored: list[str] = []
             skipped: list[str] = []
+            # Only files whose pre-restore copy actually landed. The suffix
+            # used to be advertised unconditionally, pointing users at
+            # rollback copies that may never have been written (Task 10d).
+            backed_up: list[str] = []
 
             data_section = backup.get("data") or {}
 
@@ -163,14 +187,16 @@ class BackupService:
                     legacy = data_section.get("carousels")
                     if legacy is not None:
                         # No live store owns carousels.json — plain write.
-                        self._write_json_with_backup(self.data_dir / "carousels.json", legacy, timestamp)
+                        if self._write_json_with_backup(self.data_dir / "carousels.json", legacy, timestamp):
+                            backed_up.append("carousels.json")
                         restored.append("carousels.json (legacy)")
                         continue
                 if payload is None:
                     skipped.append(filename)
                     continue
                 with self._owning_lock(filename):
-                    self._write_json_with_backup(self.data_dir / filename, payload, timestamp)
+                    if self._write_json_with_backup(self.data_dir / filename, payload, timestamp):
+                        backed_up.append(filename)
                 restored.append(filename)
 
         plugin_results: dict[str, Any] = {
@@ -192,7 +218,10 @@ class BackupService:
             "status": "success",
             "restored_files": restored,
             "skipped_files": skipped,
-            "pre_restore_backup_suffix": f".pre-restore-{timestamp}",
+            # Empty when nothing was overwritten, so a caller can no longer
+            # be told to roll back to copies that were never made (Task 10d).
+            "pre_restore_backup_suffix": f".pre-restore-{timestamp}" if backed_up else "",
+            "pre_restore_backup_files": backed_up,
             "plugins": plugin_results,
             "reload_errors": reload_errors,
         }
@@ -272,27 +301,50 @@ class BackupService:
         return contextlib.nullcontext()
 
     @staticmethod
-    def _write_json_with_backup(path: Path, payload: Any, timestamp: str) -> None:
+    def _write_json_with_backup(path: Path, payload: Any, timestamp: str) -> bool:
         """Write *payload* to *path*, preserving any existing file.
 
-        The old file (if any) is moved to ``<path>.pre-restore-<timestamp>``
-        before the new content is written.  Writes go through
+        The old file (if any) is copied to ``<path>.pre-restore-<timestamp>``
+        **before** the new content is written. Writes go through
         :func:`src.atomic_io.write_json_atomic` (unique per-call staging file
         + ``os.replace``) so a crash mid-restore can never leave a partially
         written JSON file in place and no concurrent writer can collide on
         the staging name. Callers restoring a file owned by a live store must
         additionally hold that store's lock (see :meth:`_owning_lock`).
+
+        Returns:
+            True when a pre-restore copy was written, False when *path* did
+            not exist and there was therefore nothing to preserve.
+
+        Raises:
+            BackupRestoreAborted: the pre-restore copy failed. The live file is left
+                untouched — the copy is the user's only way back out of a
+                bad restore, so overwriting without one (which is what this
+                did before Phase 2 Task 10d) destroys the escape hatch and
+                then reports success.
         """
         path.parent.mkdir(parents=True, exist_ok=True)
-        if path.exists():
-            backup_path = path.with_suffix(path.suffix + f".pre-restore-{timestamp}")
-            try:
-                shutil.copy2(path, backup_path)
-                logger.info("Saved pre-restore backup to %s", backup_path)
-            except OSError as exc:
-                logger.warning("Could not write pre-restore backup %s: %s", backup_path, exc)
+        if not path.exists():
+            write_json_atomic(path, payload)
+            return False
+
+        backup_path = path.with_suffix(path.suffix + f".pre-restore-{timestamp}")
+        try:
+            shutil.copy2(path, backup_path)
+        except OSError as exc:
+            # A half-written copy is worse than none: it looks usable. Drop
+            # it, then abort before touching the live file.
+            with contextlib.suppress(OSError):
+                backup_path.unlink(missing_ok=True)
+            logger.error("Could not write pre-restore backup %s: %s", backup_path, exc)
+            raise BackupRestoreAborted(
+                f"Could not preserve the existing {path.name} before restoring it ({exc}). "
+                f"{path.name} was not overwritten."
+            ) from exc
+        logger.info("Saved pre-restore backup to %s", backup_path)
 
         write_json_atomic(path, payload)
+        return True
 
     @staticmethod
     def _validate_backup(backup: Any) -> None:

--- a/src/pages/routes.py
+++ b/src/pages/routes.py
@@ -490,7 +490,7 @@ async def send_page(
     from src.api_server import (  # patched-in-tests seam — see module docstring (#1756)
         _board_dims,
         _board_is_paused,
-        _find_board,
+        _require_board,
         _silence_active,
         get_page_service,
         get_service,
@@ -516,9 +516,7 @@ async def send_page(
     if board_id is not None:
         if not service:
             raise HTTPException(status_code=503, detail="Service not initialized")
-        board = _find_board(board_id)
-        if board is None:
-            raise HTTPException(status_code=404, detail=f"Board not found: {board_id}")
+        board = _require_board(board_id)
         board_client = service.get_board_client(board_id)
         if board_client is None:
             raise HTTPException(status_code=503, detail=f"Board client not initialized: {board_id}")

--- a/src/schedules/routes.py
+++ b/src/schedules/routes.py
@@ -18,6 +18,28 @@ from .models import ScheduleCreate, ScheduleUpdate
 router = APIRouter(tags=["schedules"])
 
 
+def _validate_board(board_id: str | None) -> None:
+    """404 when *board_id* names a board that does not exist.
+
+    ``None`` and ``""`` mean "the default/primary board" (``DEFAULT_BOARD_ID``
+    is ``""``) and are passed through untouched.
+
+    Every schedule *write* runs this. Before #1888 all four write endpoints
+    took a free-form board id: ``PUT /schedules/default-page`` stored a
+    phantom default, ``PUT /schedules/enabled`` was a logged no-op that
+    reported success, and ``POST``/``PUT /schedules/{id}`` persisted a
+    schedule parented to a nonexistent board because
+    ``check_ref_board_compatibility`` passes silently on an unknown board.
+    Board-scoped *reads* deliberately still fall back — see
+    ``docs/internal/reference/API_CONVENTIONS.md``.
+    """
+    if not board_id:
+        return
+    from src.api_server import _require_board  # patched-in-tests seam — see module docstring (#1756)
+
+    _require_board(board_id)
+
+
 def _enrich_schedule_with_sun_times(schedule_dict: dict) -> dict:
     """Add resolved_start_time / resolved_end_time to a schedule dict.
 
@@ -122,6 +144,8 @@ async def create_schedule(schedule_data: ScheduleCreate):
     """
     from src.api_server import get_schedule_service  # patched-in-tests seam — see module docstring (#1756)
 
+    _validate_board(schedule_data.board_id)
+
     schedule_service = get_schedule_service()
 
     try:
@@ -219,6 +243,7 @@ async def set_default_page(request: dict):
         raise HTTPException(status_code=400, detail="page_id parameter required")
     page_id = request["page_id"]
     board_id = request.get("board_id")
+    _validate_board(board_id)
     if page_id is not None:
         if is_collection_id(page_id):
             collection_service = get_collection_service()
@@ -253,6 +278,7 @@ async def set_schedule_enabled(request: dict):
     if not isinstance(enabled, bool):
         raise HTTPException(status_code=400, detail="enabled must be boolean")
     board_id = request.get("board_id")
+    _validate_board(board_id)
     settings_service = get_settings_service()
     settings_service.set_schedule_enabled(enabled, board_id=board_id)
     return {
@@ -298,6 +324,8 @@ async def update_schedule(schedule_id: str, schedule_data: ScheduleUpdate):
         Updated schedule entry
     """
     from src.api_server import get_schedule_service  # patched-in-tests seam — see module docstring (#1756)
+
+    _validate_board(schedule_data.board_id)
 
     schedule_service = get_schedule_service()
 

--- a/src/settings/service.py
+++ b/src/settings/service.py
@@ -1328,6 +1328,13 @@ class SettingsService:
 
         Returns:
             Updated ActivePageSettings
+
+        Raises:
+            ValueError: ``board_id`` names a board that does not exist.
+                Defense in depth (#1888): unreachable over HTTP today, but
+                the write is otherwise unconditional, so an unknown id used
+                to add a phantom ``by_board`` entry that nothing ever reads
+                and nothing reports.
         """
         # Mutate+save under the stopgap lock (#1848 is the real fix): two
         # worker-thread PUTs would otherwise race the asdict() walk in
@@ -1335,6 +1342,9 @@ class SettingsService:
         with self._per_board_write_lock:
             primary_id = self.get_primary_board_id()
             bid = board_id if board_id is not None else primary_id
+
+            if board_id and not any(b.get("id") == board_id for b in self._board.boards):
+                raise ValueError(f"Board not found: {board_id}")
 
             if bid is not None:
                 if page_id:
@@ -1675,8 +1685,11 @@ class SettingsService:
                     self._save_to_file()
                     logger.info(f"Board {board_id} {'paused' if paused else 'resumed'}")
                     return paused
-            logger.warning(f"Board {board_id} not found for set_paused")
-            return False
+            # Defense in depth (#1888): unreachable over HTTP today — every
+            # route that gets here validates the board first, or 404s on its
+            # own path parameter — but returning False for an unknown board
+            # is indistinguishable from "resumed successfully".
+            raise ValueError(f"Board not found: {board_id}")
         if self._board.boards:
             self._board.boards[0]["paused"] = paused
             self._save_to_file()

--- a/src/settings/service.py
+++ b/src/settings/service.py
@@ -912,7 +912,16 @@ class SettingsService:
         self._temporary_override: TemporaryOverride | None = self._load_temporary_override()
 
         if getattr(self, "_needs_seed_save", False):
-            self._save_to_file()
+            try:
+                self._save_to_file()
+            except OSError as e:
+                # Boot path, not a request path: refusing to construct the
+                # service would take the whole process down over a seed
+                # write. Running with in-memory defaults and an unwritable
+                # data dir is strictly better, and the next setter call —
+                # which *is* a request — will surface the same OSError to
+                # the caller as a 5xx.
+                logger.error(f"Could not persist seeded settings at startup: {e}")
             self._needs_seed_save = False
 
         logger.info(f"SettingsService initialized (file: {self.settings_file})")
@@ -1014,7 +1023,18 @@ class SettingsService:
 
     @_locked
     def _save_to_file(self) -> None:
-        """Save current settings to JSON file."""
+        """Save current settings to JSON file.
+
+        Write errors **propagate**, matching every other store in the
+        codebase (pages, collections, schedules, panels, config_manager all
+        log and re-raise). This used to log and return, so a full disk or a
+        read-only ``data/`` produced ~20 endpoints that answered HTTP 200
+        having persisted nothing and reverted on the next restart.
+
+        The two callers that must survive a failed write — the boot-time
+        seed save and the override expiry GC — catch ``OSError`` at their
+        own call site, each with a comment saying why.
+        """
         try:
             data = {
                 "schema_version": CURRENT_SETTINGS_SCHEMA_VERSION,
@@ -1035,6 +1055,7 @@ class SettingsService:
             logger.debug("Settings saved to file")
         except OSError as e:
             logger.error(f"Failed to save settings file: {e}")
+            raise
 
     def _load_transition_settings(self) -> TransitionSettings:
         """Load transition settings from file or env."""
@@ -1836,7 +1857,15 @@ class SettingsService:
             return None
         if self._temporary_override.is_expired():
             self._temporary_override = None
-            self._save_to_file()
+            try:
+                self._save_to_file()
+            except OSError as e:
+                # Background GC on a read path (the display loop calls this
+                # every tick). The override is already expired in memory, so
+                # the caller's answer is correct either way; failing the read
+                # would stall the loop over a write that will be retried on
+                # the next expiry.
+                logger.error(f"Could not persist temporary-override expiry: {e}")
             return None
         return self._temporary_override
 
@@ -1854,7 +1883,13 @@ class SettingsService:
             return None
         if raw.is_expired():
             self._temporary_override = None
-            self._save_to_file()
+            try:
+                self._save_to_file()
+            except OSError as e:
+                # Same background-GC reasoning as get_temporary_override:
+                # the display loop must still receive the expired override
+                # so it can apply revert_mode.
+                logger.error(f"Could not persist temporary-override expiry: {e}")
         return raw
 
     @_locked

--- a/src/system/routes.py
+++ b/src/system/routes.py
@@ -299,7 +299,7 @@ async def system_update_rollback(req: RollbackRequest):
                 detail={"status": "error", "error": f"Could not read snapshot: {e}"},
             ) from e
         try:
-            from src.backup.service import BackupError, get_backup_service
+            from src.backup.service import BackupError, BackupRestoreAborted, get_backup_service
         except Exception as e:  # pragma: no cover - import error is exceptional
             logger.exception("BackupService unavailable")
             raise HTTPException(status_code=500, detail={"status": "error", "error": str(e)}) from e
@@ -309,6 +309,14 @@ async def system_update_rollback(req: RollbackRequest):
             # Don't reinstall plugins from a settings-only snapshot: the user is
             # rolling back configuration, not reshaping their plugin set.
             result = await asyncio.to_thread(service.import_from_json, raw, reinstall_plugins=False)
+        except BackupRestoreAborted as e:
+            # Environment failure (unwritable data dir, full disk), not a bad
+            # snapshot — see Phase 2 Task 10d.
+            logger.error("Settings rollback aborted: %s", e)
+            raise HTTPException(
+                status_code=500,
+                detail={"status": "error", "error": str(e)},
+            ) from e
         except BackupError as e:
             raise HTTPException(
                 status_code=400,

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -930,11 +930,10 @@ class TestMQTTStatus:
             assert data["running"] is True
 
     def test_mqtt_status_exception(self, client):
-        """Exception returns disabled."""
+        """An error is a 500 — never a body that reads as "MQTT is off"."""
         with patch("src.mqtt.get_mqtt_client", side_effect=Exception("boom")):
             response = client.get("/mqtt/status")
-            data = response.json()
-            assert data["enabled"] is False
+            assert response.status_code == 500
 
 
 class TestMQTTRepublishDiscovery:
@@ -1704,28 +1703,25 @@ class TestDebugTestConnectionErrorPaths:
     """Additional tests for POST /debug/test-connection."""
 
     def test_connection_failed(self, client):
-        """Connection test returns disconnected."""
+        """An unreachable board is a 503, not a 200 carrying status=error."""
         with patch("src.api_server._get_board_client") as mock_bc:
             bc = Mock()
             bc.test_connection.return_value = False
             mock_bc.return_value = bc
             response = client.post("/debug/test-connection")
-            data = response.json()
-            assert data["connected"] is False
-            assert data["status"] == "error"
+            assert response.status_code == 503
+            assert response.json()["detail"]
 
     def test_connection_exception(self, client):
-        """Exception during connection test."""
+        """Exception during connection test surfaces as a 500."""
         with patch("src.api_server._get_board_client") as mock_bc:
             bc = Mock()
             bc.test_connection.side_effect = RuntimeError("timeout")
             mock_bc.return_value = bc
             response = client.post("/debug/test-connection")
-            data = response.json()
-            assert data["connected"] is False
-            # Generic message — exception details are logged, not leaked.
-            assert data["status"] == "error"
-            assert data["message"]
+            assert response.status_code == 500
+            # Generic detail — exception details are logged, not leaked.
+            assert "timeout" not in response.json()["detail"]
 
 
 class TestDebugClearCacheErrorPaths:

--- a/tests/test_api_coverage_extended.py
+++ b/tests/test_api_coverage_extended.py
@@ -428,8 +428,10 @@ class TestTrafficEndpoints:
             patch("src.utils.traffic.TrafficSource", return_value=mock_ts),
         ):
             resp = client.post("/traffic/routes/validate", json={"origin": "a", "destination": "b"})
-        assert resp.status_code == 200
-        assert resp.json()["valid"] is False
+        # The upstream Routes API produced no verdict; that is a 502, not a
+        # 200 saying the route is invalid (Phase 2 Task 10a, #1887).
+        assert resp.status_code == 502
+        assert "Routes API" in resp.json()["detail"]
 
     def test_validate_route_exception(self, client):
         with (
@@ -440,8 +442,8 @@ class TestTrafficEndpoints:
             patch("src.utils.traffic.TrafficSource", side_effect=Exception("boom")),
         ):
             resp = client.post("/traffic/routes/validate", json={"origin": "a", "destination": "b"})
-        assert resp.status_code == 200
-        assert resp.json()["valid"] is False
+        # An unanticipated error is a 500, not a 200 "valid: false" (#1887).
+        assert resp.status_code == 500
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -444,6 +444,7 @@ class TestConfigEndpoints:
 
 class TestBoardConnectionTest:
     def test_test_board_local_missing_key(self, client):
+        """A missing credential is a precondition failure: 400 (#1887)."""
         response = client.post(
             "/config/board/test",
             json={
@@ -451,10 +452,8 @@ class TestBoardConnectionTest:
                 "host": "192.168.1.100",
             },
         )
-        assert response.status_code == 200
-        data = response.json()
-        assert data["success"] is False
-        assert "API key is required" in data["message"]
+        assert response.status_code == 400
+        assert "API key is required" in response.json()["detail"]
 
     def test_test_board_local_missing_host(self, client):
         response = client.post(
@@ -464,10 +463,8 @@ class TestBoardConnectionTest:
                 "local_api_key": "test_key_123",
             },
         )
-        assert response.status_code == 200
-        data = response.json()
-        assert data["success"] is False
-        assert "host" in data["message"].lower()
+        assert response.status_code == 400
+        assert "host" in response.json()["detail"].lower()
 
     def test_test_board_cloud_missing_key(self, client):
         response = client.post(
@@ -476,8 +473,7 @@ class TestBoardConnectionTest:
                 "api_mode": "cloud",
             },
         )
-        assert response.status_code == 200
-        assert response.json()["success"] is False
+        assert response.status_code == 400
 
 
 # ============================================================
@@ -1826,8 +1822,7 @@ class TestEnableLocalAPI:
                 "enablement_token": "test_token_xyz",
             },
         )
-        assert response.status_code == 200
-        assert response.json()["success"] is False
+        assert response.status_code == 400
 
     def test_missing_token(self, client):
         response = client.post(
@@ -1837,8 +1832,7 @@ class TestEnableLocalAPI:
                 "enablement_token": "",
             },
         )
-        assert response.status_code == 200
-        assert response.json()["success"] is False
+        assert response.status_code == 400
 
     def test_success(self, client):
         mock_resp = Mock()
@@ -1939,8 +1933,7 @@ class TestEnableLocalAPI:
                     "enablement_token": "test_token_xyz",
                 },
             )
-        assert response.status_code == 200
-        assert response.json()["success"] is False
+        assert response.status_code == 500
 
     def test_rejects_public_ip(self, client):
         """SSRF guard: a public IP must be rejected before any HTTP request."""
@@ -1952,10 +1945,10 @@ class TestEnableLocalAPI:
                     "enablement_token": "test_token_xyz",
                 },
             )
-        # Returns 200 with success=False (this endpoint reports validation as a body field).
-        assert response.status_code == 200
-        body = response.json()
-        assert body["success"] is False
+        # The SSRF guard's 400 reaches the client as a 400 (#1887); it used
+        # to be downgraded to a 200 body indistinguishable from a board that
+        # simply rejected the token.
+        assert response.status_code == 400
         # No outbound HTTP request should have been issued.
         mock_post.assert_not_called()
 

--- a/tests/test_backup_restore_rollback.py
+++ b/tests/test_backup_restore_rollback.py
@@ -1,0 +1,131 @@
+"""A restore must not overwrite a file it could not back up (Phase 2, Task 10d).
+
+``_write_json_with_backup`` copied the live file aside, and when that copy
+raised ``OSError`` it logged a warning and **fell through to overwrite the
+live file anyway**. ``import_from_dict`` then returned
+``{"status": "success", "pre_restore_backup_suffix": ...}`` — advertising a
+rollback copy that might not exist, or exist truncated. The user's only
+escape hatch from a bad restore was reported as present when it was not.
+
+Two defects, both pinned here:
+  (a) the copy failure is not propagated — the overwrite happens regardless;
+  (b) the suffix is emitted unconditionally rather than derived from copies
+      that actually succeeded.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.backup.service import BACKUP_FILE_MARKER, BACKUP_SCHEMA_VERSION, BackupError, BackupService
+
+
+def _backup_doc(data: dict) -> dict:
+    return {
+        BACKUP_FILE_MARKER: True,
+        "schema_version": BACKUP_SCHEMA_VERSION,
+        "data": data,
+    }
+
+
+class TestBackupCopyFailureAbortsTheRestore:
+    def test_live_file_is_not_overwritten_when_its_backup_copy_fails(self, tmp_path: Path):
+        (tmp_path / "config.json").write_text(json.dumps({"marker": "OLD"}))
+        service = BackupService(data_dir=tmp_path)
+
+        with (
+            patch("src.backup.service._reload_services", return_value=[]),
+            patch("src.backup.service.shutil.copy2", side_effect=OSError(28, "No space left on device")),
+            pytest.raises(BackupError),
+        ):
+            service.import_from_dict(_backup_doc({"config": {"marker": "NEW"}}), reinstall_plugins=False)
+
+        assert json.loads((tmp_path / "config.json").read_text()) == {"marker": "OLD"}
+
+    def test_a_partial_backup_copy_is_removed_rather_than_left_behind(self, tmp_path: Path):
+        """A truncated rollback copy is worse than none: it looks usable."""
+        (tmp_path / "config.json").write_text(json.dumps({"marker": "OLD"}))
+        service = BackupService(data_dir=tmp_path)
+
+        def half_copy(src, dst, *args, **kwargs):
+            Path(dst).write_text('{"marker": "OL')  # truncated
+            raise OSError(28, "No space left on device")
+
+        with (
+            patch("src.backup.service._reload_services", return_value=[]),
+            patch("src.backup.service.shutil.copy2", side_effect=half_copy),
+            pytest.raises(BackupError),
+        ):
+            service.import_from_dict(_backup_doc({"config": {"marker": "NEW"}}), reinstall_plugins=False)
+
+        assert list(tmp_path.glob("config.json.pre-restore-*")) == []
+
+
+class TestSuffixReflectsRealCopies:
+    def test_no_suffix_is_advertised_when_nothing_was_backed_up(self, tmp_path: Path):
+        """A restore into an empty data dir overwrites nothing, so there is no
+        rollback copy to point the user at."""
+        service = BackupService(data_dir=tmp_path)
+
+        with patch("src.backup.service._reload_services", return_value=[]):
+            result = service.import_from_dict(_backup_doc({"config": {"marker": "NEW"}}), reinstall_plugins=False)
+
+        assert result["restored_files"] == ["config.json"]
+        assert result["pre_restore_backup_suffix"] == ""
+        assert result["pre_restore_backup_files"] == []
+
+    def test_suffix_and_file_list_name_only_files_actually_copied(self, tmp_path: Path):
+        (tmp_path / "config.json").write_text(json.dumps({"marker": "OLD"}))
+        service = BackupService(data_dir=tmp_path)
+
+        with patch("src.backup.service._reload_services", return_value=[]):
+            result = service.import_from_dict(
+                _backup_doc({"config": {"marker": "NEW"}, "pages": {"pages": []}}),
+                reinstall_plugins=False,
+            )
+
+        # pages.json did not exist, so it has no rollback copy; config.json does.
+        assert result["pre_restore_backup_files"] == ["config.json"]
+        suffix = result["pre_restore_backup_suffix"]
+        assert (tmp_path / f"config.json{suffix}").exists()
+        assert not (tmp_path / f"pages.json{suffix}").exists()
+
+
+class TestEndpointMapping:
+    """A refused write is a server failure, not a bad backup file."""
+
+    def test_import_endpoint_reports_5xx_when_the_pre_restore_copy_fails(self, tmp_path: Path):
+        from fastapi.testclient import TestClient
+
+        from src.api_server import app
+
+        (tmp_path / "config.json").write_text(json.dumps({"marker": "OLD"}))
+        service = BackupService(data_dir=tmp_path)
+
+        with (
+            patch("src.backup.get_backup_service", return_value=service),
+            patch("src.backup.service._reload_services", return_value=[]),
+            patch("src.backup.service.shutil.copy2", side_effect=OSError(28, "No space left on device")),
+        ):
+            response = TestClient(app).post(
+                "/backup/import",
+                params={"reinstall_plugins": "false"},
+                json=_backup_doc({"config": {"marker": "NEW"}}),
+            )
+
+        # 400 would blame the operator's backup file for a full disk.
+        assert response.status_code == 500
+        assert "not overwritten" in response.json()["detail"]
+        assert json.loads((tmp_path / "config.json").read_text()) == {"marker": "OLD"}
+
+    def test_a_genuinely_bad_backup_file_is_still_a_400(self, tmp_path: Path):
+        from fastapi.testclient import TestClient
+
+        from src.api_server import app
+
+        with patch("src.backup.get_backup_service", return_value=BackupService(data_dir=tmp_path)):
+            response = TestClient(app).post("/backup/import", json={"not": "a backup"})
+
+        assert response.status_code == 400

--- a/tests/test_board_connection_test.py
+++ b/tests/test_board_connection_test.py
@@ -583,9 +583,9 @@ class TestBoardTestGeneralError:
             },
         )
 
-        data = response.json()
-        assert data["success"] is False
-        assert "troubleshooting" in data
+        # An unanticipated failure is not a probe verdict (Phase 2 Task 10a).
+        assert response.status_code == 500
+        assert "unexpected error" not in response.json()["detail"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_board_id_validation.py
+++ b/tests/test_board_id_validation.py
@@ -1,0 +1,185 @@
+"""An unknown board_id must be a 404 on every write path (Phase 2, Task 10c; #1888).
+
+Four live endpoints accepted a free-form ``board_id`` and reported success:
+
+* ``PUT /schedules/default-page`` wrote a phantom entry via
+  ``ScheduleStorage.set_default_page_id``;
+* ``PUT /schedules/enabled`` reached ``SettingsService.set_schedule_enabled``,
+  which logged "Board not found" and returned the settings unchanged, while
+  the route answered ``{"status": "success", "enabled": true}``;
+* ``POST /schedules`` and ``PUT /schedules/{id}`` persisted a schedule bound
+  to a board that does not exist, because ``check_ref_board_compatibility``
+  passes silently on an unknown board.
+
+The 404 pattern already existed inline in nine other handlers; this pins the
+shared ``_require_board`` helper they now all share.
+
+**Reads deliberately keep falling back** — see the "board_id validation" note
+in ``docs/internal/reference/API_CONVENTIONS.md``. The read pins at the
+bottom of this module exist so that decision cannot be reversed by accident.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api_server import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def one_board():
+    """Patch the boards list to a single known board, ``board-1``."""
+    board_settings = Mock()
+    board_settings.boards = [{"id": "board-1", "name": "Flagship", "device_type": "flagship"}]
+    settings = Mock()
+    settings.get_board_settings.return_value = board_settings
+    settings.get_primary_board_id.return_value = "board-1"
+    settings.is_schedule_enabled.return_value = False
+    with patch("src.api_server.get_settings_service", return_value=settings):
+        yield settings
+
+
+class TestScheduleWritesRejectUnknownBoards:
+    def test_set_default_page_404s_and_writes_nothing(self, client, one_board):
+        schedule_service = Mock()
+        page_service = Mock()
+        page_service.get_page.return_value = Mock(id="page-1")
+        with (
+            patch("src.api_server.get_schedule_service", return_value=schedule_service),
+            patch("src.api_server.get_page_service", return_value=page_service),
+        ):
+            response = client.put(
+                "/schedules/default-page",
+                json={"page_id": "page-1", "board_id": "ghost-board"},
+            )
+        assert response.status_code == 404
+        assert "ghost-board" in response.json()["detail"]
+        schedule_service.set_default_page.assert_not_called()
+
+    def test_set_schedule_enabled_404s_and_writes_nothing(self, client, one_board):
+        response = client.put("/schedules/enabled", json={"enabled": True, "board_id": "ghost-board"})
+        assert response.status_code == 404
+        one_board.set_schedule_enabled.assert_not_called()
+
+    def test_create_schedule_404s_and_persists_nothing(self, client, one_board):
+        schedule_service = Mock()
+        with patch("src.api_server.get_schedule_service", return_value=schedule_service):
+            response = client.post(
+                "/schedules",
+                json={
+                    "board_id": "ghost-board",
+                    "page_id": "page-1",
+                    "start_time": "09:00",
+                    "end_time": "17:00",
+                },
+            )
+        assert response.status_code == 404
+        schedule_service.create_schedule.assert_not_called()
+
+    def test_update_schedule_404s_and_does_not_reparent(self, client, one_board):
+        schedule_service = Mock()
+        with patch("src.api_server.get_schedule_service", return_value=schedule_service):
+            response = client.put("/schedules/sched-1", json={"board_id": "ghost-board"})
+        assert response.status_code == 404
+        schedule_service.update_schedule.assert_not_called()
+
+
+class TestKnownAndOmittedBoardIdsStillWork:
+    """The guard must reject only genuinely unknown ids."""
+
+    def test_known_board_id_is_accepted(self, client, one_board):
+        schedule_service = Mock()
+        with patch("src.api_server.get_schedule_service", return_value=schedule_service):
+            response = client.put("/schedules/enabled", json={"enabled": True, "board_id": "board-1"})
+        assert response.status_code == 200
+        one_board.set_schedule_enabled.assert_called_once()
+
+    def test_omitted_board_id_still_means_the_primary_board(self, client, one_board):
+        response = client.put("/schedules/enabled", json={"enabled": True})
+        assert response.status_code == 200
+        one_board.set_schedule_enabled.assert_called_once()
+
+    def test_empty_board_id_still_means_the_default_board(self, client, one_board):
+        """``ScheduleCreate.board_id`` defaults to "" = default/first board."""
+        schedule_service = Mock()
+        created = Mock()
+        created.model_dump.return_value = {
+            "id": "s1",
+            "board_id": "",
+            "page_id": "page-1",
+            "start_time": "09:00",
+            "end_time": "17:00",
+            "start_type": "fixed",
+            "end_type": "fixed",
+        }
+        created.page_id = "page-1"
+        created.board_id = ""
+        schedule_service.create_schedule.return_value = created
+        compat = Mock(ok=True, warnings=[])
+        with (
+            patch("src.api_server.get_schedule_service", return_value=schedule_service),
+            patch("src.api_server.check_ref_board_compatibility", return_value=compat),
+        ):
+            response = client.post(
+                "/schedules",
+                json={"page_id": "page-1", "start_time": "09:00", "end_time": "17:00"},
+            )
+        assert response.status_code == 200
+
+
+class TestServiceLevelDefenceInDepth:
+    """`set_paused` / `set_active_page_id` are NOT reachable with an unknown
+    board over HTTP today — every route that reaches them validates first, or
+    404s on its own path parameter. These are belt-and-braces so a future
+    caller cannot recreate the phantom write."""
+
+    def test_set_paused_rejects_an_unknown_board(self, tmp_path):
+        from src.settings.service import SettingsService
+
+        service = SettingsService(str(tmp_path / "settings.json"))
+        service.get_board_settings().boards = [{"id": "board-1"}]
+        with pytest.raises(ValueError, match="ghost-board"):
+            service.set_paused(True, board_id="ghost-board")
+
+    def test_set_active_page_id_rejects_an_unknown_board(self, tmp_path):
+        from src.settings.service import SettingsService
+
+        service = SettingsService(str(tmp_path / "settings.json"))
+        service.get_board_settings().boards = [{"id": "board-1"}]
+        with pytest.raises(ValueError, match="ghost-board"):
+            service.set_active_page_id("page-1", board_id="ghost-board")
+
+    def test_set_active_page_id_does_not_write_a_phantom_entry(self, tmp_path):
+        from src.settings.service import SettingsService
+
+        service = SettingsService(str(tmp_path / "settings.json"))
+        service.get_board_settings().boards = [{"id": "board-1"}]
+        with pytest.raises(ValueError):
+            service.set_active_page_id("page-1", board_id="ghost-board")
+        assert "ghost-board" not in service.get_active_page_settings().by_board
+
+
+class TestReadsDeliberatelyFallBack:
+    """Documented asymmetry: reads answer with the safe default rather than
+    404, because a board-scoped poll racing a board deletion is normal and
+    a read cannot corrupt anything. Changing this is a decision, not a fix."""
+
+    def test_list_schedules_returns_empty_for_an_unknown_board(self, client, one_board):
+        schedule_service = Mock()
+        schedule_service.list_schedules.return_value = []
+        schedule_service.get_default_page.return_value = None
+        with patch("src.api_server.get_schedule_service", return_value=schedule_service):
+            response = client.get("/schedules", params={"board_id": "ghost-board"})
+        assert response.status_code == 200
+        assert response.json()["schedules"] == []
+
+    def test_get_schedule_enabled_returns_false_for_an_unknown_board(self, client, one_board):
+        response = client.get("/schedules/enabled", params={"board_id": "ghost-board"})
+        assert response.status_code == 200
+        assert response.json()["enabled"] is False

--- a/tests/test_debug_endpoints.py
+++ b/tests/test_debug_endpoints.py
@@ -263,14 +263,12 @@ class TestDebugTestConnection:
         assert isinstance(data["latency_ms"], int)
 
     def test_connection_failure(self, client, mock_board_client):
-        """Test failed connection test."""
+        """A board that cannot be reached is a 503 (Phase 2 Task 10a, #1887)."""
         mock_board_client.test_connection.return_value = False
 
         response = client.post("/debug/test-connection")
-        assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "error"
-        assert data["connected"] is False
+        assert response.status_code == 503
+        assert response.json()["detail"]
 
     def test_connection_no_client(self, client):
         """Test connection test when client not configured."""

--- a/tests/test_settings_per_board.py
+++ b/tests/test_settings_per_board.py
@@ -357,6 +357,9 @@ def test_concurrent_set_active_page_serializes_mutate_and_save(settings_file, mo
     must be serialized (stopgap lock until the real fix in #1848)."""
     import threading
 
+    # Both boards must exist: since #1888 set_active_page_id rejects an
+    # unknown board_id rather than writing a phantom by_board entry.
+    _write_raw(settings_file, _two_board_raw())
     svc = SettingsService(settings_file=settings_file)
 
     first_save = threading.Event()

--- a/tests/test_settings_save_propagates.py
+++ b/tests/test_settings_save_propagates.py
@@ -1,0 +1,94 @@
+"""A settings write the OS refuses must not report success (Phase 2, Task 10b).
+
+``SettingsService._save_to_file`` was the only log-without-raise persistence
+path in the codebase — every other store (pages, collections, schedules,
+panels, config_manager) logs *and* re-raises. 24 setter call sites and ~20
+endpoints therefore answered HTTP 200 having persisted nothing: on a full
+disk or a read-only ``data/`` the UI showed the new value, the in-memory
+object held it, and the next restart silently reverted it.
+
+Background paths (boot-time seed save, the expiry GC in
+``get_temporary_override`` / ``consume_temporary_override``) are the
+deliberate exception: they run outside a request, so they log and continue
+rather than take the process down. Those exceptions are pinned here too, so
+"it is swallowed" can never quietly come back for the request paths.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api_server import app
+from src.settings.service import SettingsService, TemporaryOverride
+
+
+@pytest.fixture
+def client():
+    # raise_server_exceptions=False so we observe the 500 the ASGI server
+    # would send rather than having the exception re-raised into the test.
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _service(tmp_path) -> SettingsService:
+    return SettingsService(str(tmp_path / "settings.json"))
+
+
+def _make_undirectory(tmp_path):
+    """Return a path whose parent is a regular file.
+
+    Writing there fails with ``NotADirectoryError`` (an ``OSError``) for
+    every user including root, so this stands in for a read-only or full
+    data directory without depending on permission bits the test container
+    ignores.
+    """
+    blocker = tmp_path / "data-dir-gone"
+    blocker.write_text("this is a file, not a directory")
+    return blocker / "settings.json"
+
+
+class TestServiceLevel:
+    def test_a_refused_write_propagates_out_of_a_setter(self, tmp_path):
+        service = _service(tmp_path)
+        service.set_polling_interval(30)  # sanity: the happy path works
+
+        service._store._path = _make_undirectory(tmp_path)
+
+        with pytest.raises(OSError):
+            service.set_polling_interval(45)
+
+    def test_boot_seed_save_failure_does_not_kill_the_service(self, tmp_path):
+        """Startup must survive an unwritable data dir — read-only settings
+        are still better than a process that will not boot."""
+        with patch.object(SettingsService, "_save_to_file", side_effect=OSError(28, "No space left on device")):
+            service = _service(tmp_path)
+        assert service.get_polling_settings() is not None
+
+    def test_get_override_gc_failure_does_not_break_the_read(self, tmp_path):
+        """The display loop reads the override every tick; a failed GC write
+        must not turn a read into an exception."""
+        service = _service(tmp_path)
+        service.set_temporary_override(TemporaryOverride(page_id="p1", expires_at="2000-01-01T00:00:00+00:00"))
+        service._store._path = _make_undirectory(tmp_path)
+
+        assert service.get_temporary_override() is None
+
+    def test_consume_override_gc_failure_does_not_break_the_read(self, tmp_path):
+        service = _service(tmp_path)
+        service.set_temporary_override(TemporaryOverride(page_id="p1", expires_at="2000-01-01T00:00:00+00:00"))
+        service._store._path = _make_undirectory(tmp_path)
+
+        # Returns the expired override so the display loop can apply its
+        # revert mode, even though the clearing write could not be saved.
+        assert service.consume_temporary_override() is not None
+
+
+class TestEndpointLevel:
+    def test_settings_put_returns_5xx_when_the_write_fails(self, client):
+        """The defect in one line: this used to be a 200 having saved nothing."""
+        with patch(
+            "src.storage.json_store.write_json_atomic",
+            side_effect=OSError(28, "No space left on device"),
+        ):
+            response = client.put("/settings/polling", json={"interval_seconds": 45})
+        assert response.status_code >= 500

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -311,9 +311,14 @@ class TestSettingsServiceInit:
         assert "output" in data
         assert "board" in data
 
-    def test_save_to_file_handles_io_error(self, settings_service):
-        with patch("builtins.open", side_effect=OSError("write error")):
-            settings_service._save_to_file()  # Should not raise
+    def test_save_to_file_propagates_io_error(self, settings_service):
+        """A refused write must reach the caller (Phase 2 Task 10b).
+
+        This asserted "should not raise" until #1887: swallowing it made ~20
+        endpoints answer HTTP 200 having persisted nothing.
+        """
+        with patch("builtins.open", side_effect=OSError("write error")), pytest.raises(OSError):
+            settings_service._save_to_file()
 
     def test_save_to_file_is_atomic_on_mid_write_crash(self, settings_service, settings_file, monkeypatch):
         """Regression for #1313 (mirrors #1304): a crash inside _save_to_file()
@@ -332,7 +337,10 @@ class TestSettingsServiceInit:
             raise OSError("Simulated crash mid-write")
 
         monkeypatch.setattr(service_module.json, "dump", crashing_dump)
-        settings_service._save_to_file()  # swallows OSError; must not corrupt file
+        # The OSError now propagates (Phase 2 Task 10b); the point of this
+        # test is unchanged — the live file must survive the failed write.
+        with pytest.raises(OSError):
+            settings_service._save_to_file()
         monkeypatch.setattr(service_module.json, "dump", real_dump)
 
         assert Path(settings_file).read_bytes() == original_bytes

--- a/tests/test_status_code_correctness.py
+++ b/tests/test_status_code_correctness.py
@@ -1,0 +1,265 @@
+"""Failures must reach the client as failures (Phase 2, Task 10a).
+
+Six handlers used to answer HTTP 200 for outcomes that were not successes,
+so every client — the wizard, the settings page, curl, the MCP server —
+saw "OK" for a request that did not do what it said. This module pins the
+line drawn in ``docs/internal/reference/API_CONVENTIONS.md``:
+
+* a **precondition** failure (missing field, malformed host, SSRF reject) is
+  a real 4xx;
+* an **upstream** result from a probe endpoint whose declared job is to
+  report a verdict (``/config/board/test``,
+  ``/config/board/enable-local-api``) may stay 200 — but only through a
+  declared ``response_model``, never an ad-hoc dict;
+* anything the server did not anticipate is a 5xx.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+from fastapi.testclient import TestClient
+
+from src.api_server import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _local_client_mock():
+    mock_client = Mock()
+    mock_client.base_url = "http://192.168.1.10:7000/local-api/message"
+    mock_client.headers = {}
+    return mock_client
+
+
+# ---------------------------------------------------------------------------
+# POST /config/board/test — preconditions are 4xx
+# ---------------------------------------------------------------------------
+
+
+class TestBoardTestPreconditions:
+    def test_missing_local_api_key_is_400(self, client):
+        response = client.post("/config/board/test", json={"api_mode": "local", "host": "192.168.1.10"})
+        assert response.status_code == 400
+        assert "API key" in response.json()["detail"]
+
+    def test_missing_host_is_400(self, client):
+        response = client.post("/config/board/test", json={"api_mode": "local", "local_api_key": "key"})
+        assert response.status_code == 400
+        assert "host" in response.json()["detail"].lower()
+
+    def test_missing_cloud_key_is_400(self, client):
+        response = client.post("/config/board/test", json={"api_mode": "cloud"})
+        assert response.status_code == 400
+
+    def test_host_validation_rejection_propagates_as_400(self, client):
+        """The host guard's 400 must not be downgraded to a 200 (#1887).
+
+        ``_validate_board_host`` is the guard that stops a caller pointing
+        this endpoint at an arbitrary URL. Catching its HTTPException and
+        answering 200 made a rejected request indistinguishable from a
+        board that merely refused the key.
+        """
+        with patch("src.api_server.requests.get") as mock_get:
+            response = client.post(
+                "/config/board/test",
+                json={"api_mode": "local", "local_api_key": "key", "host": "evil.example.com/@10.0.0.1"},
+            )
+        assert response.status_code == 400
+        mock_get.assert_not_called()
+
+
+class TestBoardTestUpstreamVerdictsStay200:
+    """The declared contract: an upstream board result is data, not an error."""
+
+    @patch("src.api_server.requests.get")
+    @patch("src.board_client.BoardClient")
+    def test_board_rejects_key_stays_200_with_typed_body(self, mock_client_cls, mock_get, client):
+        mock_client_cls.return_value = _local_client_mock()
+        mock_get.return_value = Mock(status_code=401)
+
+        response = client.post(
+            "/config/board/test",
+            json={"api_mode": "local", "local_api_key": "key", "host": "192.168.1.10"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is False
+        assert isinstance(body["troubleshooting"], list)
+
+    @patch("src.api_server.requests.get")
+    @patch("src.board_client.BoardClient")
+    def test_board_unreachable_stays_200(self, mock_client_cls, mock_get, client):
+        mock_client_cls.return_value = _local_client_mock()
+        mock_get.side_effect = requests.exceptions.ConnectionError("refused")
+
+        response = client.post(
+            "/config/board/test",
+            json={"api_mode": "local", "local_api_key": "key", "host": "192.168.1.10"},
+        )
+        assert response.status_code == 200
+        assert response.json()["success"] is False
+
+    def test_declares_a_response_model(self):
+        route = next(r for r in app.routes if getattr(r, "path", None) == "/config/board/test")
+        assert route.response_model is not None
+
+
+class TestBoardTestUnexpectedErrors:
+    @patch("src.api_server.requests.get")
+    @patch("src.board_client.BoardClient")
+    def test_unexpected_exception_is_500(self, mock_client_cls, mock_get, client):
+        mock_client_cls.return_value = _local_client_mock()
+        mock_get.side_effect = RuntimeError("unexpected error")
+
+        response = client.post(
+            "/config/board/test",
+            json={"api_mode": "local", "local_api_key": "key", "host": "192.168.1.10"},
+            # TestClient re-raises by default; we want the handled response.
+        )
+        assert response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# POST /config/board/enable-local-api
+# ---------------------------------------------------------------------------
+
+
+class TestEnableLocalApiPreconditions:
+    def test_missing_host_is_400(self, client):
+        response = client.post("/config/board/enable-local-api", json={"host": "", "enablement_token": "test_token"})
+        assert response.status_code == 400
+
+    def test_missing_token_is_400(self, client):
+        response = client.post("/config/board/enable-local-api", json={"host": "192.168.1.100", "enablement_token": ""})
+        assert response.status_code == 400
+
+    def test_public_ip_is_400_and_issues_no_request(self, client):
+        """SSRF guard (#1887): the 400 must reach the client as a 400."""
+        with patch("src.api_server.requests.post") as mock_post:
+            response = client.post(
+                "/config/board/enable-local-api",
+                json={"host": "8.8.8.8", "enablement_token": "test_token"},
+            )
+        assert response.status_code == 400
+        mock_post.assert_not_called()
+
+    def test_unresolvable_host_is_400(self, client):
+        import socket as socket_mod
+
+        with (
+            patch("src.api_server._validate_board_host_is_local_network"),
+            patch("socket.getaddrinfo", side_effect=socket_mod.gaierror("no such host")),
+            patch("src.api_server.requests.post") as mock_post,
+        ):
+            response = client.post(
+                "/config/board/enable-local-api",
+                json={"host": "board.invalid", "enablement_token": "test_token"},
+            )
+        assert response.status_code == 400
+        mock_post.assert_not_called()
+
+
+class TestEnableLocalApiUpstreamVerdictsStay200:
+    def test_invalid_enablement_token_stays_200(self, client):
+        with patch("src.api_server.requests.post", return_value=Mock(status_code=401)):
+            response = client.post(
+                "/config/board/enable-local-api",
+                json={"host": "192.168.1.100", "enablement_token": "bad"},
+            )
+        assert response.status_code == 200
+        assert response.json()["success"] is False
+
+    def test_declares_a_response_model(self):
+        route = next(r for r in app.routes if getattr(r, "path", None) == "/config/board/enable-local-api")
+        assert route.response_model is not None
+
+
+class TestEnableLocalApiUnexpectedErrors:
+    def test_unexpected_exception_is_500(self, client):
+        with patch("src.api_server.requests.post", side_effect=RuntimeError("unexpected")):
+            response = client.post(
+                "/config/board/enable-local-api",
+                json={"host": "192.168.1.100", "enablement_token": "test_token"},
+            )
+        assert response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# POST /traffic/routes/validate
+# ---------------------------------------------------------------------------
+
+
+class TestValidateTrafficRoute:
+    @staticmethod
+    def _config_manager():
+        cm = Mock()
+        cm.get_plugin_config.return_value = {"api_key": "test_key"}
+        return cm
+
+    def test_upstream_returning_no_data_is_502(self, client):
+        source = Mock()
+        source.fetch_traffic_data.return_value = None
+        with (
+            patch("src.api_server.get_config_manager", return_value=self._config_manager()),
+            patch("src.utils.traffic.TrafficSource", return_value=source),
+        ):
+            response = client.post(
+                "/traffic/routes/validate",
+                json={"origin": "40.7128,-74.0060", "destination": "40.7580,-73.9855"},
+            )
+        assert response.status_code == 502
+
+    def test_unexpected_exception_is_500(self, client):
+        with (
+            patch("src.api_server.get_config_manager", return_value=self._config_manager()),
+            patch("src.utils.traffic.TrafficSource", side_effect=RuntimeError("boom")),
+        ):
+            response = client.post(
+                "/traffic/routes/validate",
+                json={"origin": "40.7128,-74.0060", "destination": "40.7580,-73.9855"},
+            )
+        assert response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# POST /debug/test-connection
+# ---------------------------------------------------------------------------
+
+
+class TestDebugTestConnectionStatuses:
+    def test_unreachable_board_is_503(self, client):
+        board = Mock()
+        board.test_connection.return_value = False
+        with patch("src.api_server._get_board_client", return_value=board):
+            response = client.post("/debug/test-connection")
+        assert response.status_code == 503
+
+    def test_unexpected_exception_is_500(self, client):
+        board = Mock()
+        board.test_connection.side_effect = RuntimeError("timeout")
+        with patch("src.api_server._get_board_client", return_value=board):
+            response = client.post("/debug/test-connection")
+        assert response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# GET /mqtt/status
+# ---------------------------------------------------------------------------
+
+
+class TestMqttStatusMasking:
+    def test_error_is_not_reported_as_mqtt_being_off(self, client):
+        """`{"enabled": false}` must mean "MQTT is off", never "we crashed"."""
+        with patch("src.mqtt.get_mqtt_client", side_effect=RuntimeError("boom")):
+            response = client.get("/mqtt/status")
+        assert response.status_code == 500
+
+    def test_no_client_still_reports_disabled_at_200(self, client):
+        with patch("src.mqtt.get_mqtt_client", return_value=None):
+            response = client.get("/mqtt/status")
+        assert response.status_code == 200
+        assert response.json() == {"enabled": False, "connected": False, "running": False}

--- a/web/tests/api.spec.ts
+++ b/web/tests/api.spec.ts
@@ -283,8 +283,10 @@ test.describe("API – Debug", () => {
     const res = await fetch(`${API()}/debug/test-connection`, {
       method: "POST",
     });
-    // Connection may or may not succeed depending on board config state
-    expect([200, 400]).toContain(res.status);
+    // Connection may or may not succeed depending on board config state.
+    // 503 = board configured but unreachable (#1887 made that a real status
+    // instead of a 200 carrying { status: "error" }).
+    expect([200, 400, 503]).toContain(res.status);
     if (res.ok) {
       const data = await res.json();
       expect(data).toHaveProperty("connected");

--- a/web/tests/board-discovery-offline.spec.ts
+++ b/web/tests/board-discovery-offline.spec.ts
@@ -137,9 +137,11 @@ test.describe("Board Connection Test — Offline Detection", () => {
         host: BOARD_HOST,
       }),
     });
-    expect(res.ok).toBe(true);
+    // A missing credential is a precondition failure, not a probe verdict:
+    // the endpoint answers 400 rather than a 200 { success: false } (#1887).
+    expect(res.status).toBe(400);
     const data = await res.json();
-    expect(data.success).toBe(false);
+    expect(data.detail).toContain("API key");
   });
 });
 


### PR DESCRIPTION
Phase 2, Task 10 — the silent-failure track. Four commits, deliberately separate: they have very different blast radii and each carries its own fail-first evidence.

Ground truth is the completed enumeration in `.superpowers/plans/2026-09-06-rework-phase2.md` Task 10: **6 handlers / 34 sites** strict. Nothing was re-enumerated.

## 🔒 Security-adjacent — read this first (#1887)

`test_board_connection` (`POST /config/board/test`) and `enable_local_api` (`POST /config/board/enable-local-api`) each caught `HTTPException` from the host validators and **downgraded their 400 into a 200** `{"success": false}`.

Those validators — `_validate_board_host`, `_validate_board_host_is_local_network`, and the `ipaddress` private/loopback/link-local check — are the SSRF guard on the only two endpoints that take a caller-supplied host and open a connection to it. A blocked SSRF attempt and a board that merely rejected the API key produced **the same 200 response**, so nothing downstream — logs, proxies, rate limiters, tests — could tell a refusal from a failed probe. Both now propagate the 400 unchanged, and the test asserts no outbound request is issued.

## Commit 1 — status-code correctness (34 sites, 6 handlers)

The design line, now written into `docs/internal/reference/API_CONVENTIONS.md` as a narrow **three-condition** exception to "failures are never 200":

| outcome | status |
|---|---|
| the probe **ran**; this is its verdict (board refused the key, unreachable, 5xx, timeout) | **200**, but only through a declared `response_model` |
| the probe **could not be attempted** (missing credential, malformed host, SSRF refusal, `BoardClient` rejecting the config) | **4xx** |
| **unanticipated** (`except Exception`) | **5xx**, generic detail, exception in the log only |

Two new models, `BoardTestResponse` and `EnableLocalApiResponse`, both with `response_model_exclude_none=True` so the emitted bodies are byte-identical to before. The declared shape is what makes the 200 legitimate; an ad-hoc dict at 200 is indistinguishable from a success to a generic client, which is what made this a bug rather than a contract.

`POST /debug/test-connection` deliberately does **not** qualify for the carve-out — it has no verdict body at all (no error class, no troubleshooting), so its 200 `{"status": "error"}` was unreadable to any client checking the status code. Unreachable board → 503, unexpected → 500.

Per handler: `test_board_connection` 16 sites, `enable_local_api` 12, `validate_traffic_route` 2 (upstream Routes API returning no data → **502**; it is not a verdict that the route is invalid, and reporting it as `valid: false` hid every outage, quota block and disabled-API misconfiguration), `debug_test_connection` 2, `get_mqtt_status` 1 (its `except` returned `{"enabled": false, "connected": false}` — byte-identical to "MQTT is switched off").

Untouched as instructed and verified: `set_hdmi_kiosk` (its `except` wraps only `resp.json()` after the sidecar already returned 200/202) and `get_plugin_options_endpoint` (documented deliberate 200s).

**Web:** no component change needed — all five callers of `testBoardConnection`/`enableLocalApi` already `try/catch` and surface `error.message`, which `fetchApi` fills from `detail`, so the 400s reach the same toast the 200 `message` fed. The TS interfaces already match the new Pydantic models field for field. Two Playwright specs asserted the old statuses and were updated.

**Fail-first:** `17 failed, 4 passed`. The 4 pre-existing passes are the deliberate pins on what must *not* change (upstream 401 stays 200, unreachable board stays 200, `/mqtt/status` with no client stays 200 `enabled: false`).

## Commit 2 — the single swallow site (done alone)

`SettingsService._save_to_file` was the **only** log-without-raise persistence path in the codebase — pages, collections, schedules, panels and config_manager all log *and* re-raise (all five verified). 24 setter call sites and ~20 endpoints answered HTTP 200 having persisted nothing: on a full disk or a read-only `data/`, the UI showed the new value and the next restart silently reverted it.

Fallout decided per call site. **Propagate** on every request path — a 5xx on a refused write is the point. **Log and continue**, each with the reason inline, on the two background paths: the boot-time seed save (refusing to construct the service would take the process down over a seed write) and the expiry GC in `get_temporary_override`/`consume_temporary_override` (a *read* path the display loop hits every tick; `consume` still returns the expired object so `revert_mode` applies). `_run_migrations` needed nothing — it calls `_atomic_write_json` directly and already had its own handler.

Every other caller traced: `main.py` sits inside `check_and_send_for_board`'s `except Exception`, `mqtt/commands.py` inside `handle()`'s, `pages/service.py` is on the `DELETE /pages/{id}` request path where propagating is desired.

**Fail-first:** `2 failed, 3 passed` — `DID NOT RAISE OSError`, and `assert 200 >= 500` for the endpoint. The read-only data dir is simulated by pointing the store at a path whose parent is a regular file, so `mkdir` fails with a real `OSError` for every user including root (permission bits do nothing in the test container).

## Commit 3 — backup restore rollback (highest severity)

`_write_json_with_backup` logged a warning on a failed pre-restore copy and **fell through to overwrite the live file anyway**, then `import_from_dict` returned `{"status": "success", "pre_restore_backup_suffix": ...}` — advertising a rollback copy that might not exist or exist truncated. The user's only way out of a bad restore was reported present exactly when it was gone.

(a) The copy failure now aborts before touching the live file, and a partially written copy is unlinked first (a truncated rollback file is worse than none — it looks usable). (b) `pre_restore_backup_suffix` is derived from copies that actually landed (`""` otherwise, so the key's type is unchanged for existing consumers), plus a new `pre_restore_backup_files` naming exactly which files have one.

New `BackupRestoreAborted(BackupError)` so a full disk is a 500 rather than a 400 blaming the operator's backup file; a genuinely malformed backup is still a 400.

**Noted, not fixed:** the restore is **not transactional across files** — a hard failure on file N leaves 1..N-1 restored and N..end original. Now a `.. warning::` on `import_from_dict` naming the exact state. Making it atomic means staging all six files and renaming them under six owning locks at once — a different change with its own deadlock analysis.

**Fail-first:** `4 failed` — two `DID NOT RAISE BackupError`, `assert '.pre-restore-...' == ''`, and `KeyError: 'pre_restore_backup_files'`. The first also asserts the live file still reads `OLD` after the abort; pre-fix it read `NEW`. The two endpoint-mapping tests were written after the code and are mutation-proven (deleting the `except BackupRestoreAborted` clause gives `assert 400 == 500`).

## Commit 4 — board_id validation (#1888)

Four write endpoints persisted state bound to a nonexistent board and reported success: `PUT /schedules/default-page` (phantom default), `PUT /schedules/enabled` (logged no-op reporting success), `POST /schedules` and `PUT /schedules/{id}` (schedule parented / re-parented onto a nonexistent board, because `check_ref_board_compatibility` passes silently on an unknown board).

`_require_board(board_id)` **consolidates** the nine handlers that already open-coded the 404 — including `POST /settings/board/{board_id}/pause`, whose hand-rolled `"Board {id} not found"` now matches the `"Board not found: {id}"` everyone else emits. The five `_find_board` sites that deliberately tolerate a missing board (panel `board_missing` flags, compat checks) are untouched.

**The read-path decision, written down.** Writes 404; board-scoped reads keep falling back (`GET /schedules` → `[]`, `GET /schedules/enabled` → `false`, …). Recorded in `API_CONVENTIONS.md` so it reads as a decision, not an oversight: (1) a read cannot corrupt anything; (2) board-scoped polling legitimately races board deletion, and 404ing turns a benign race into an error toast; (3) "no schedules" is a *correct* answer for a board that does not exist, whereas a write's "saved!" is a lie. Two tests pin the fallback, and the doc says that if reads go strict they must all change together with their polling clients.

`SettingsService.set_paused` and `set_active_page_id` now raise `ValueError` instead of returning `False` / writing a phantom `by_board` entry. **Both are unreachable with an unknown board over HTTP today** — their routes validate first — so this is defense in depth, not a live bug; the tests say so in their class docstring.

**Fail-first:** `7 failed, 5 passed`. The 5 passes pin what must not change: a known id, an omitted one (= primary), an empty one (= default board, `DEFAULT_BOARD_ID` is `""`), and the two read fallbacks. Each write test also asserts the service call was never made, so a 404 that still wrote would fail.

## Verification

- Baseline on `origin/next-rebuild`: `1 failed, 5949 passed, 1 skipped` — the failure is the known worktree-environmental `test_check_image_formats.py::TestRepositoryIsClean`.
- Head: `1 failed, 5993 passed, 1 skipped` — same single environmental failure. +44 tests.
- **All four golden corpora unchanged** (`git diff origin/next-rebuild..HEAD -- tests/golden/` is empty). No route added, removed or renamed, so the route inventory is untouched; no response-shape golden covers any endpoint whose status changed, and `response_model_exclude_none=True` keeps the 200 bodies byte-identical regardless.
- 11 existing tests encoded the masked contracts and were updated in the commit that changed each one, with the reason inline.
- ruff 0.16.5 `check` + `format --check` clean. markdownlint, cspell and the docs-contract check clean. prettier clean on the two touched `web/tests/` files. No `web/src/` change, so the web unit suite is untouched.

## Not fixed, deliberately

- Backup restore cross-file atomicity (documented above).
- `validate_traffic_route` still takes `request: dict` and returns an ad-hoc dict on success — converting it to a declared contract is its domain slice's job (Task 8), and this PR only stops it serving failures as 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP
