### PR TITLE
fix(tests): close the data/ isolation leak — set FIESTABOARD_DATA_DIR before collection

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -55,6 +55,7 @@ from .pages.service import (  # noqa: E402
 )
 from .panels.models import PanelCreate, PanelUpdate  # noqa: E402
 from .panels.service import get_panel_service  # noqa: E402
+from .paths import get_data_dir  # noqa: E402
 
 # Patch seam (issue #1756): no handler left in this module calls it, but the
 # extracted routers resolve it through `src.api_server` at call time so
@@ -69,11 +70,31 @@ from .virtual_board_client import release_virtual_board_state  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
-# Log file configuration
-LOG_DIR = Path("/app/data/logs")
-LOG_FILE = LOG_DIR / "app.log"
+# Log file configuration.
+#
+# ``LOG_DIR`` is a *test seam* in the same shape as ``SYSTEM_UPDATE_STATE_FILE``
+# further down: production leaves it ``None`` and ``_log_dir()`` resolves
+# ``<data>/logs`` lazily through ``src.paths.get_data_dir()`` (honoring
+# ``FIESTABOARD_DATA_DIR``, #1762). It was previously the hard-coded container
+# path ``/app/data/logs``, which bypassed the seam entirely and made the test
+# suite write ``data/logs/app.log`` into the checkout on every run (#1881).
+#
+# Resolve at call time, never at import time: import-time resolution is what
+# created this class of bug (#1894).
+LOG_DIR: Path | None = None
 LOG_MAX_BYTES = 5 * 1024 * 1024  # 5MB per file
 LOG_BACKUP_COUNT = 5  # Keep 5 backup files (25MB total max)
+
+
+def _log_dir() -> Path:
+    """Resolve the log directory, honoring the ``LOG_DIR`` test seam."""
+    return LOG_DIR if LOG_DIR is not None else get_data_dir() / "logs"
+
+
+def _log_file() -> Path:
+    """Resolve the current log file (``<data>/logs/app.log``)."""
+    return _log_dir() / "app.log"
+
 
 # Cache state for /muni/stops endpoint
 _muni_stops_cache: dict[str, Any] | None = None
@@ -341,18 +362,19 @@ def _setup_file_logging():
     """Set up file-based logging with rotation."""
     try:
         # Create logs directory if it doesn't exist
-        LOG_DIR.mkdir(parents=True, exist_ok=True)
+        log_file = _log_file()
+        log_file.parent.mkdir(parents=True, exist_ok=True)
 
         # Create JSON file handler with rotation
         file_handler = JSONFileHandler(
-            str(LOG_FILE), maxBytes=LOG_MAX_BYTES, backupCount=LOG_BACKUP_COUNT, encoding="utf-8"
+            str(log_file), maxBytes=LOG_MAX_BYTES, backupCount=LOG_BACKUP_COUNT, encoding="utf-8"
         )
         file_handler.setFormatter(logging.Formatter("%(message)s"))
         file_handler.setLevel(logging.INFO)
 
         # Add to root logger
         logging.getLogger().addHandler(file_handler)
-        logger.info(f"File logging initialized: {LOG_FILE}")
+        logger.info(f"File logging initialized: {log_file}")
     except Exception as e:
         logger.warning(f"Failed to set up file logging: {e}")
 
@@ -368,9 +390,10 @@ def _read_logs_from_files(
     all_logs = []
 
     # Read from current log file and backups
-    log_files = [LOG_FILE]
+    current_log = _log_file()
+    log_files = [current_log]
     for i in range(1, LOG_BACKUP_COUNT + 1):
-        backup_file = Path(f"{LOG_FILE}.{i}")
+        backup_file = Path(f"{current_log}.{i}")
         if backup_file.exists():
             log_files.append(backup_file)
 

--- a/src/system/https_certs.py
+++ b/src/system/https_certs.py
@@ -3,8 +3,8 @@
 This module supports the opt-in **HTTPS (Beta)** setting. When the user
 enables HTTPS we generate a long-lived self-signed certificate that nginx
 serves on port 3000 inside the container. The cert files live under
-``/app/data/certs`` so they persist across container rebuilds via the
-existing ``./data:/app/data`` bind mount.
+``<data>/certs`` (``/app/data/certs`` in the container) so they persist
+across container rebuilds via the existing ``./data:/app/data`` bind mount.
 
 Each FiestaBoard instance generates its own keypair and certificate; we
 never bake a shared private key into the image.
@@ -26,11 +26,10 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from src.paths import get_data_dir
+
 logger = logging.getLogger(__name__)
 
-# Directory holding the cert + key. Lives under /app/data so the bind
-# mount in docker-compose preserves it across container rebuilds.
-DEFAULT_CERT_DIR = Path("/app/data/certs")
 
 CERT_FILENAME = "fiestaboard.crt"
 KEY_FILENAME = "fiestaboard.key"
@@ -39,16 +38,32 @@ KEY_FILENAME = "fiestaboard.key"
 CERT_VALID_DAYS = 3650
 
 
+def default_cert_dir() -> Path:
+    """Resolve the default cert directory: ``<data>/certs``.
+
+    Goes through ``src.paths.get_data_dir()`` — the one seam every store's
+    default path resolves through — rather than the hard-coded container
+    path ``/app/data/certs`` it used to be. In the container that seam still
+    resolves to ``/app/data``, so the certs keep living on the
+    ``./data:/app/data`` bind mount and survive rebuilds; in tests it
+    resolves to a temp dir instead of the checkout (#1881/#1894).
+
+    Resolved at call time, never at import time: import-time resolution is
+    what created this class of bug.
+    """
+    return get_data_dir() / "certs"
+
+
 def _cert_dir() -> Path:
     """Resolve the cert directory.
 
     Honours the ``FIESTABOARD_CERT_DIR`` env var so tests can use a
-    temporary directory without writing to ``/app/data``.
+    temporary directory without writing to the data dir.
     """
     override = os.environ.get("FIESTABOARD_CERT_DIR")
     if override:
         return Path(override)
-    return DEFAULT_CERT_DIR
+    return default_cert_dir()
 
 
 def cert_paths() -> tuple[Path, Path]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,59 @@
 # tests/conftest.py
 
+import os
+import shutil
+import tempfile
 import threading
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+
+# Session-wide throwaway data dir, created in ``pytest_configure`` (below) and
+# removed in ``pytest_unconfigure``. Module-level so both hooks see it.
+_SESSION_DATA_ROOT: Path | None = None
+
+
+def pytest_configure(config):
+    """Point ``FIESTABOARD_DATA_DIR`` at a throwaway dir before collection (#1894).
+
+    The autouse ``_isolated_data_dir`` fixture below is *function*-scoped, so
+    it cannot cover the two windows where nothing is active:
+
+    1. **Collection time.** ``src/api_server.py`` resolves the data dir while
+       it is being imported (``is_auth_enabled()`` at module scope builds the
+       auth service, which resolves ``<data>/auth.json``). Four test modules
+       build a ``TestClient(app)`` at module scope, so every xdist worker
+       imports it before the first fixture runs.
+    2. **After a test's teardown.** ``monkeypatch`` restores the variable to
+       whatever it was *before* the test. Background threads a test started
+       (e.g. ``board-state-poll`` in ``src/main.py``) outlive it, and the next
+       thing they log re-enters ``ConfigManager()`` -> ``get_data_dir()``.
+
+    With the variable unset in either window ``get_data_dir()`` falls back to
+    ``<repo>/data`` and the suite writes the checkout — the intermittent
+    ``config.json`` / ``logs/app.log`` leak that fails innocent PRs on CI's
+    "Verify tests did not write data/" step.
+
+    Setting it here, before collection, closes both: the fallback every
+    ``monkeypatch`` teardown restores to is now a temp dir, not the repo. The
+    per-test fixture stays layered on top for per-test isolation.
+
+    The directory is keyed by ``PYTEST_XDIST_WORKER`` (pid when running
+    without xdist) so parallel workers never share one.
+    """
+    global _SESSION_DATA_ROOT
+    worker = os.environ.get("PYTEST_XDIST_WORKER") or f"pid{os.getpid()}"
+    _SESSION_DATA_ROOT = Path(tempfile.mkdtemp(prefix=f"fiestaboard-tests-{worker}-"))
+    os.environ["FIESTABOARD_DATA_DIR"] = str(_SESSION_DATA_ROOT / "data")
+
+
+def pytest_unconfigure(config):
+    """Remove the session data dir created in ``pytest_configure``."""
+    global _SESSION_DATA_ROOT
+    if _SESSION_DATA_ROOT is not None:
+        shutil.rmtree(_SESSION_DATA_ROOT, ignore_errors=True)
+        _SESSION_DATA_ROOT = None
 
 
 def _drop_all_singletons() -> None:
@@ -63,6 +113,11 @@ def _isolated_data_dir(tmp_path, monkeypatch):
     cannot see a store some earlier test built against its own tmp dir;
     after, so no singleton survives holding a path into this test's (now
     deleted) tmp dir.
+
+    This narrows isolation to one test. It does *not* establish it: the
+    session-wide override in ``pytest_configure`` above is what guarantees
+    the variable is never unset, including at collection time and after this
+    fixture's ``monkeypatch`` has been undone (#1894).
     """
     monkeypatch.setenv("FIESTABOARD_DATA_DIR", str(tmp_path / "data"))
     _drop_all_singletons()

--- a/tests/test_data_dir_isolation.py
+++ b/tests/test_data_dir_isolation.py
@@ -14,11 +14,19 @@ the repo. Before the seam existed this failed for every store.
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
-REPO_DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REPO_DATA_DIR = REPO_ROOT / "data"
+
+# Captured while this module is being *imported* — i.e. at collection time,
+# before any fixture has run. See TestSessionDataDirFloor below.
+ENV_AT_IMPORT_TIME = os.environ.get("FIESTABOARD_DATA_DIR")
 
 
 @pytest.fixture
@@ -95,3 +103,114 @@ def test_external_plugins_dir_default_is_isolated(isolated_env):
     from src.plugins.sources import get_external_plugins_dir
 
     _assert_isolated(get_external_plugins_dir(), isolated_env, "get_external_plugins_dir")
+
+
+class TestSessionDataDirFloor:
+    """``FIESTABOARD_DATA_DIR`` is set for the whole session, not just per test (#1894).
+
+    The autouse ``_isolated_data_dir`` fixture is function-scoped, so it leaves
+    two windows uncovered — collection time (``src/api_server.py`` resolves the
+    auth file while it is being imported) and the moment after a test's
+    ``monkeypatch`` teardown (background threads a test started keep logging,
+    and the log handler re-enters ``ConfigManager()``). In either window an
+    unset variable sent ``get_data_dir()`` at the checkout's ``data/``, writing
+    ``config.json`` and ``logs/app.log`` into the repo.
+
+    These assertions are the non-vacuous half of this file: they fail if the
+    ``pytest_configure`` hook in ``tests/conftest.py`` is removed, even though
+    the function-scoped fixture would still be in place.
+    """
+
+    def test_env_is_already_set_when_test_modules_are_imported(self):
+        assert ENV_AT_IMPORT_TIME, (
+            "FIESTABOARD_DATA_DIR was unset while this module was imported — "
+            "anything resolving the data dir at import/collection time writes the repo"
+        )
+        assert not Path(ENV_AT_IMPORT_TIME).resolve().is_relative_to(REPO_ROOT)
+
+    def test_a_floor_remains_when_no_function_fixture_is_active(self, tmp_path):
+        """The value ``monkeypatch`` restores to must be a temp dir, not "unset".
+
+        This is the window the function-scoped fixture cannot cover: a
+        background thread a test started keeps logging after that test's
+        teardown, re-enters ``ConfigManager()`` and resolves the data dir with
+        nothing patched. Measured for real — a nested pytest session runs one
+        test from this file with ``FIESTABOARD_DATA_DIR`` scrubbed from its
+        environment, and a ``-p`` plugin records the surviving value from
+        ``pytest_sessionfinish``, after every function fixture is finalized.
+        """
+        probe = tmp_path / "floor_probe.py"
+        out = tmp_path / "floor.txt"
+        probe.write_text(
+            "import os\n"
+            "\n"
+            "\n"
+            "def pytest_sessionfinish(session, exitstatus):\n"
+            "    out = os.environ['FLOOR_PROBE_OUT']\n"
+            "    with open(out, 'w') as fh:\n"
+            "        fh.write(os.environ.get('FIESTABOARD_DATA_DIR', ''))\n"
+        )
+        env = dict(os.environ)
+        env.pop("FIESTABOARD_DATA_DIR", None)
+        env.pop("PYTEST_XDIST_WORKER", None)
+        env["FLOOR_PROBE_OUT"] = str(out)
+        env["PYTHONPATH"] = os.pathsep.join([str(tmp_path), env.get("PYTHONPATH", "")]).rstrip(os.pathsep)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                f"{__file__}::TestSessionDataDirFloor::test_get_data_dir_never_resolves_inside_the_repository",
+                "-q",
+                "-p",
+                "floor_probe",
+                "-p",
+                "no:cacheprovider",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"nested session failed:\n{result.stdout}\n{result.stderr}"
+        floor = out.read_text().strip()
+        assert floor, "FIESTABOARD_DATA_DIR was left *unset* once the function fixtures were torn down"
+        assert not Path(floor).resolve().is_relative_to(REPO_ROOT), (
+            f"the surviving data dir points into the checkout: {floor}"
+        )
+
+    def test_data_dir_is_unique_per_xdist_worker(self):
+        worker = os.environ.get("PYTEST_XDIST_WORKER")
+        if not worker:
+            pytest.skip("not running under xdist")
+        assert worker in str(ENV_AT_IMPORT_TIME), (
+            f"session data dir {ENV_AT_IMPORT_TIME!r} is not keyed by worker {worker!r} — "
+            "parallel workers would share one directory"
+        )
+
+    def test_get_data_dir_never_resolves_inside_the_repository(self):
+        from src.paths import get_data_dir
+
+        assert not get_data_dir().resolve().is_relative_to(REPO_ROOT)
+
+
+class TestAbsoluteContainerPathsGoThroughTheSeam:
+    """Paths that used to be hard-coded ``/app/data/...`` now follow the seam (#1881)."""
+
+    def test_log_dir_follows_the_data_dir_seam(self):
+        from src import api_server
+        from src.paths import get_data_dir
+
+        assert api_server.LOG_DIR is None, "production must leave the LOG_DIR seam unset"
+        assert api_server._log_dir() == get_data_dir() / "logs"
+        assert api_server._log_file() == get_data_dir() / "logs" / "app.log"
+        assert not api_server._log_dir().resolve().is_relative_to(REPO_ROOT)
+
+    def test_cert_dir_follows_the_data_dir_seam(self, monkeypatch):
+        from src.paths import get_data_dir
+        from src.system import https_certs
+
+        monkeypatch.delenv("FIESTABOARD_CERT_DIR", raising=False)
+        assert https_certs._cert_dir() == get_data_dir() / "certs"
+        assert not https_certs._cert_dir().resolve().is_relative_to(REPO_ROOT)

--- a/tests/test_https_certs.py
+++ b/tests/test_https_certs.py
@@ -42,8 +42,14 @@ class TestCertPaths:
     def test_cert_paths_default_without_override(self, monkeypatch):
         monkeypatch.delenv("FIESTABOARD_CERT_DIR", raising=False)
         cert, key = https_certs.cert_paths()
-        assert cert == https_certs.DEFAULT_CERT_DIR / "fiestaboard.crt"
-        assert key == https_certs.DEFAULT_CERT_DIR / "fiestaboard.key"
+        assert cert == https_certs.default_cert_dir() / "fiestaboard.crt"
+        assert key == https_certs.default_cert_dir() / "fiestaboard.key"
+
+    def test_cert_default_dir_follows_the_data_dir_seam(self, monkeypatch, tmp_path):
+        """The default lands under ``<data>/certs``, not a hard-coded /app path (#1881)."""
+        monkeypatch.delenv("FIESTABOARD_CERT_DIR", raising=False)
+        monkeypatch.setenv("FIESTABOARD_DATA_DIR", str(tmp_path / "somewhere"))
+        assert https_certs.default_cert_dir() == tmp_path / "somewhere" / "certs"
 
     def test_cert_exists_false_initially(self, cert_dir):
         assert https_certs.cert_exists() is False

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -63,31 +63,32 @@ def mock_api_server(test_log_dir, sample_log_entries):
     """Create a test client with mocked log directory."""
     # Patch the log directory before importing
     with patch.dict(os.environ, {"PRODUCTION": "true"}):
+        # ``LOG_DIR`` is the test seam; ``_log_file()`` reads it back at call
+        # time, so patching the directory alone redirects both.
         with patch("src.api_server.LOG_DIR", test_log_dir):
-            with patch("src.api_server.LOG_FILE", test_log_dir / "app.log"):
-                # Create log file
-                log_file = test_log_dir / "app.log"
-                with open(log_file, "w") as f:
-                    for entry in sample_log_entries:
-                        f.write(json.dumps(entry) + "\n")
+            # Create log file
+            log_file = test_log_dir / "app.log"
+            with open(log_file, "w") as f:
+                for entry in sample_log_entries:
+                    f.write(json.dumps(entry) + "\n")
 
-                # Also populate the in-memory buffer
-                from src import api_server
+            # Also populate the in-memory buffer
+            from src import api_server
 
-                with api_server._log_lock:
-                    api_server._log_buffer.clear()
-                    for entry in sample_log_entries:
-                        api_server._log_buffer.append(entry)
+            with api_server._log_lock:
+                api_server._log_buffer.clear()
+                for entry in sample_log_entries:
+                    api_server._log_buffer.append(entry)
 
-                # Create test client
-                from src.api_server import app
+            # Create test client
+            from src.api_server import app
 
-                client = TestClient(app)
-                yield client
+            client = TestClient(app)
+            yield client
 
-                # Cleanup
-                with api_server._log_lock:
-                    api_server._log_buffer.clear()
+            # Cleanup
+            with api_server._log_lock:
+                api_server._log_buffer.clear()
 
 
 class TestLogsEndpoint:


### PR DESCRIPTION
Closes #1894. Closes #1881.

## The mechanism (confirmed, not assumed)

`tests/conftest.py`'s `_isolated_data_dir` is a **function-scoped** autouse fixture, so it cannot cover the two windows where no fixture is active. I instrumented `src.paths.get_data_dir()` to dump a stack whenever it resolved with `FIESTABOARD_DATA_DIR` unset and ran the full suite on unmodified `origin/next-rebuild` under `-n auto`, with `-v <tmp>:/app/data` so the image's `VOLUME /app/data` could not hide the writes. 15 such resolutions, in exactly two shapes:

**1. Collection time** — 14 of 15, one per xdist worker:

```
File "/app/src/api_server.py", line 880, in <module>
  if is_auth_enabled():
File "/app/src/auth/service.py", line 348, in _default_auth_file
  return get_data_dir() / "auth.json"
```

`src/api_server.py` resolves the data dir *while it is being imported*, and four test modules build a `TestClient(app)` at module scope — so every worker hits this before its first fixture runs.

**2. After a test's teardown** — the `config.json` write:

```
thread=board-state-poll
File "/app/src/main.py", line 926, in _board_poll_loop
  chars = rt.client.read_current_message()
File "/app/src/board_client.py", line 797, in read_current_message
  logger.error(f"Failed to read current message: {e}")
...
File "/app/src/api_server.py", line 290, in _create_log_entry
  time_service = get_time_service()
File "/app/src/config.py", line 227, in GENERAL_TIMEZONE
File "/app/src/config_manager.py", line 423, in __init__
  self._config_path = get_data_dir() / "config.json"
```

`monkeypatch` restores the variable to what it was *before* the test — unset — and a background thread that test started keeps logging. `ConfigManager` then writes its defaults into the checkout.

`logs/app.log` is a third, deterministic path: `LOG_DIR = Path("/app/data/logs")` bypassed the seam entirely (#1881).

### Fail-first, trunk (`origin/next-rebuild`, no PR content), 4 runs

```
run 1 leaked: logs/app.log
run 2 leaked: config.json  logs/app.log
run 3 leaked: logs/app.log
run 4 leaked: logs/app.log
```

## The fix

- **`tests/conftest.py`** — a `pytest_configure` hook points `FIESTABOARD_DATA_DIR` at a throwaway dir *before collection*, keyed by `PYTEST_XDIST_WORKER` (pid without xdist) so parallel workers never share one; `pytest_unconfigure` removes it. This closes both windows at once: the value every `monkeypatch` teardown restores to is now a temp dir, not "unset". The function-scoped fixture is unchanged and stays layered on top for per-test isolation.
- **`src/api_server.py`** — `LOG_DIR`/`LOG_FILE` module constants become a `None` test seam (same shape as the existing `SYSTEM_UPDATE_STATE_FILE` seam) plus lazy `_log_dir()` / `_log_file()` resolvers over `get_data_dir()`. Resolved at call time, never at import: import-time resolution is what created this class of bug.
- **`src/system/https_certs.py`** — `DEFAULT_CERT_DIR = Path("/app/data/certs")` had the identical shape; replaced with `default_cert_dir()` over the same seam. The `FIESTABOARD_CERT_DIR` override is unchanged.

## Verification

**Five consecutive full-suite runs with the explicit data mount** (`docker run --rm -v "$PWD":/app -v <tmp>:/app/data -w /app fb-test:latest python -m pytest tests/ -q -m "not integration" -n auto -p no:cacheprovider --deselect tests/test_check_image_formats.py`):

| run | pytest | entries in the mounted `data/` (files **and** directories) |
|---|---|---|
| 1 | exit 0 — 5767 passed, 1 skipped | 0 |
| 2 | exit 0 — 5767 passed, 1 skipped | 0 |
| 3 | exit 0 — 5767 passed, 1 skipped | 0 |
| 4 | exit 0 — 5767 passed, 1 skipped | 0 |
| 5 | exit 0 — 5767 passed, 1 skipped | 0 |

A sixth run reproducing CI's exact invocation (`--cov=src --cov-branch --cov-fail-under=80`, `BOARD_READ_WRITE_KEY`/`WEATHER_API_KEY` set) was also clean: 90.14% coverage, zero entries.

**Production logging still lands in the real data dir.** In a container with `FIESTABOARD_DATA_DIR` unset, driving the app's real lifespan:

```
LOG_DIR seam         : None
_log_dir() resolves  : /app/data/logs
_log_file() resolves : /app/data/logs/app.log
INFO - File logging initialized: /app/data/logs/app.log

=== files under the container data mount ===
/app/data/config.json
/app/data/logs/app.log
```

Identical to the old hard-coded path — the seam's default resolves to `<repo-root>/data`, which is `/app/data` in the container, so the `./data:/app/data` bind mount still carries logs and certs across rebuilds.

**Mutation proof** (the tests are not vacuous):

Disabling the `pytest_configure` hook — 3 failures:

```
FAILED ...::test_env_is_already_set_when_test_modules_are_imported
  AssertionError: FIESTABOARD_DATA_DIR was unset while this module was imported — anything
  resolving the data dir at import/collection time writes the repo
  assert None
FAILED ...::test_a_floor_remains_when_no_function_fixture_is_active
  AssertionError: FIESTABOARD_DATA_DIR was left *unset* once the function fixtures were torn down
  assert ''
FAILED ...::test_data_dir_is_unique_per_xdist_worker
  AssertionError: session data dir None is not keyed by worker 'gw1' — parallel workers would
  share one directory
```

Restoring the hard-coded container paths — 3 more:

```
FAILED ...::test_log_dir_follows_the_data_dir_seam
FAILED ...::test_cert_dir_follows_the_data_dir_seam
  AssertionError: assert PosixPath('/app/data/certs') == (PosixPath('/tmp/pytest-of-root/...') / 'certs')
FAILED tests/test_https_certs.py::TestCertPaths::test_cert_default_dir_follows_the_data_dir_seam
```

`test_a_floor_remains_when_no_function_fixture_is_active` measures the post-teardown window for real rather than asserting a proxy: it runs a nested pytest session with the variable scrubbed from its environment and a `-p` plugin that records the surviving value from `pytest_sessionfinish`, after every function fixture has been finalized.

**Other gates**

- Strict subset vs a baseline taken first on `origin/next-rebuild`: failure sets are **identical** — only the known environmental `tests/test_check_image_formats.py::TestRepositoryIsClean::test_no_tracked_file_in_this_repo_reaches_a_vulnerable_parser` (it shells out to git; the worktree's `.git` is a file). 5786 → 5793 passed.
- All four golden corpora unchanged (`git status tests/golden/` clean).
- `ruff 0.16.5`: `ruff check src/ plugins/ tests/ scripts/` → All checks passed; `ruff format --check` → 364 files already formatted.
- The other two CI pytest lanes verified clean and leak-free: `pytest -m integration tests/test_plugin_install_integration.py` (13 passed) and `scripts/run_plugin_tests.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP
