### PR TITLE
test(api): enforce the conventions ratchet on collections

### DIFF
--- a/tests/conventions_manifest.json
+++ b/tests/conventions_manifest.json
@@ -1,5 +1,13 @@
 {
-  "_comment": "API conventions ratchet (Phase 2, spec §2). Enforced by tests/test_api_conventions_ratchet.py; rules documented in docs/internal/reference/API_CONVENTIONS.md. Append a domain to converted_domains in the slice PR that converts it — never before. Every exception needs a route that exists, a known rule id, and a reason a reviewer can argue with.",
-  "converted_domains": [],
-  "exceptions": []
+  "_comment": "API conventions ratchet (Phase 2, spec \u00a72). Enforced by tests/test_api_conventions_ratchet.py; rules documented in docs/internal/reference/API_CONVENTIONS.md. Append a domain to converted_domains in the slice PR that converts it \u2014 never before. Every exception needs a route that exists, a known rule id, and a reason a reviewer can argue with.",
+  "converted_domains": [
+    "collections"
+  ],
+  "exceptions": [
+    {
+      "route": "GET /collections",
+      "rule": "declared_errors",
+      "reason": "Listing has no failure path: it returns [] for an empty store and cannot 404 or 400, so declaring a 4xx would document an error the endpoint never raises."
+    }
+  ]
 }


### PR DESCRIPTION
Closes a gap between two Phase 2 PRs that would otherwise have reproduced the exact failure this whole phase exists to fix.

#1891 converted the collections domain. #1890 built the ratchet. But #1891 was cut before #1890 merged, so it shipped with `converted_domains: []` — **the conventions were applied and nothing enforced them**, which is precisely the Phase 1 pattern (a documented rule with no build failure behind it).

This adds the entry, with one exception: `GET /collections` for `declared_errors`, because listing has no failure path — an empty store returns `[]`, and it cannot 404 or 400, so declaring a 4xx would document an error the endpoint never raises.

**Proven load-bearing, not assumed.** Removing a single `response_model` from a collections route:

```
E       POST /collections: no response_model= declared
FAILED tests/test_api_conventions_ratchet.py::test_converted_domains_declare_response_models
```

And dropping `collections` from `converted_domains` while leaving its exception behind is rejected by the well-formedness validator, so the entry cannot be quietly removed either.

Follow-up for the remaining slices: each one appends its own domain in its own PR, now that the ratchet is on the trunk ahead of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP