### PR TITLE
feat(schedules): Phase 2 slice 2 — conventions, seam retirement, web lockstep

### DIFF
--- a/docs/internal/reference/API_CONVENTIONS.md
+++ b/docs/internal/reference/API_CONVENTIONS.md
@@ -88,6 +88,10 @@ manifest entry; the cost of a false negative is a shipped 200-on-failure.
      malformed host, an SSRF-guard refusal) is a real 4xx, and anything
      unanticipated is a 5xx.
 
+  `POST /schedules/validate` is the same shape of thing: an inconsistent set
+  of schedules is the verdict the caller asked for, served 200 as a declared
+  `ScheduleValidationResult`.
+
   Without (1) a generic client cannot tell the verdict from a success, which
   is exactly the masking bug this rule replaced (#1887). `POST
   /debug/test-connection` deliberately does *not* qualify: it has no verdict
@@ -146,8 +150,11 @@ Decided 2026-09 with #1888. The asymmetry is deliberate and it is the
 inconsistency-of-record, so read it before "fixing" either half.
 
 - **Writes 404.** Any handler that persists something scoped to a board
-  calls `_require_board(board_id)` (`src/api_server.py`) — the single place
-  the "unknown board" verdict is made. Writing state bound to a board that
+  calls `require_board(board_id, settings_service)` (`src/boards.py`) — the
+  single place the "unknown board" verdict is made. The settings service is a
+  parameter, not a global inside `boards`, so the lookup resolves through
+  whichever `get_settings_service` the *calling* module binds; `api_server`
+  keeps a thin `_require_board` wrapper that passes its own. Writing state bound to a board that
   does not exist is invisible until something else trips over it: the four
   schedule write endpoints used to store a phantom default page, a no-op
   that reported `{"status": "success"}`, and schedules parented to

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -36,8 +36,13 @@ from .auth.middleware import AuthMiddleware  # noqa: E402
 from .auth.routes import router as auth_router  # noqa: E402
 from .board_client import board_client_from_board_dict  # noqa: E402
 from .board_send_executor import run_board_send  # noqa: E402
+from .boards import find_board, require_board  # noqa: E402
 from .collections.models import is_collection_id  # noqa: E402
-from .collections.service import get_collection_service  # noqa: E402
+from .collections.service import (  # noqa: E402
+    get_collection_service,
+    resolve_active_page_id,
+    resolve_next_check_seconds,
+)
 from .config import Config  # noqa: E402
 
 # Patch seams (issues #1756/#1757): no handler left in this module calls
@@ -63,6 +68,7 @@ from .paths import get_data_dir  # noqa: E402
 # tests that patch `src.api_server.get_schedule_service` keep working.
 from .schedules.service import get_schedule_service  # noqa: E402, F401
 from .settings.service import VALID_OUTPUT_TARGETS, VALID_STRATEGIES, get_settings_service  # noqa: E402
+from .settings.service import temporary_override_payload as _temporary_override_payload  # noqa: E402
 from .templates.engine import get_template_engine, reset_template_engine  # noqa: E402, F401
 from .templates.expressions import function_signatures  # noqa: E402
 from .text_to_board import text_to_board_array  # noqa: E402
@@ -5262,40 +5268,18 @@ async def update_output_settings(request: dict):
 
 
 def _resolve_active_page_id(page_id: str | None) -> str | None:
-    """Resolve a collection reference to the page it is currently showing.
+    """This module's binding of :func:`src.collections.service.resolve_active_page_id`.
 
-    When ``page_id`` is a collection ID the Dashboard needs to know which
-    member page the collection's logic is presently rendering on the board so
-    it can name and link to that page (issue #1513). Plain page IDs (and None)
-    are returned unchanged. Never raises — a collection that can't be resolved
-    just yields None.
+    Passes *this* module's ``get_collection_service``, so the resolution goes on
+    resolving through the name the suite stubs when it exercises the handlers
+    that still live here.
     """
-    if not is_collection_id(page_id):
-        return page_id
-    try:
-        return get_collection_service().resolve_page_id(page_id)
-    except Exception:  # pragma: no cover - defensive; resolution is best-effort
-        logger.warning("Failed to resolve collection page for %s", page_id, exc_info=True)
-        return None
+    return resolve_active_page_id(page_id, get_collection_service)
 
 
 def _resolve_next_check_seconds(page_id: str | None) -> int | None:
-    """Seconds until ``page_id``'s collection may switch to a different page.
-
-    A collection can rotate as often as every 5 seconds (2 for variable-mode
-    polling), so a client that caches ``resolved_page_id`` on a fixed timer
-    would name the wrong page for most of the interval. Handing back the
-    collection's own cadence lets the Dashboard re-poll exactly when the page
-    on the board can change (issue #1513). None for plain pages, collections
-    that can't rotate (<2 pages), and any resolution failure.
-    """
-    if not is_collection_id(page_id):
-        return None
-    try:
-        return get_collection_service().seconds_until_next_check(page_id)
-    except Exception:  # pragma: no cover - defensive; resolution is best-effort
-        logger.warning("Failed to compute next check for collection %s", page_id, exc_info=True)
-        return None
+    """This module's binding of :func:`src.collections.service.resolve_next_check_seconds`."""
+    return resolve_next_check_seconds(page_id, get_collection_service)
 
 
 @app.get("/settings/active-page")
@@ -5479,44 +5463,6 @@ async def set_active_page(request: dict):
     if compat_warnings:
         response["warnings"] = compat_warnings
     return response
-
-
-def _temporary_override_payload(override) -> dict:
-    """Serialize a TemporaryOverride (or None) for the API.
-
-    One shape is shared by GET /settings/temporary-override, the POST response
-    and the inline block on GET /schedules/active/page, so the three can never
-    drift. ``remaining_seconds`` is None both when there is no override and
-    when the override is indefinite (issue #1787).
-    """
-    if override is None:
-        return {
-            "active": False,
-            "page_id": None,
-            "expires_at": None,
-            "remaining_seconds": None,
-            "revert_mode": None,
-            "revert_page_id": None,
-            "template": None,
-            "line_metadata": None,
-            "device_type": None,
-            "notes_wide": None,
-            "notes_tall": None,
-        }
-    remaining = override.remaining_seconds()
-    return {
-        "active": True,
-        "page_id": override.page_id,
-        "expires_at": override.expires_at,
-        "remaining_seconds": round(remaining, 1) if remaining is not None else None,
-        "revert_mode": override.revert_mode,
-        "revert_page_id": override.revert_page_id,
-        "template": override.template,
-        "line_metadata": override.line_metadata,
-        "device_type": override.device_type,
-        "notes_wide": override.notes_wide,
-        "notes_tall": override.notes_tall,
-    }
 
 
 @app.get("/settings/temporary-override")
@@ -6468,35 +6414,18 @@ def _get_first_board_dims():
 
 
 def _find_board(board_id: str) -> dict | None:
-    """Return the settings.boards entry for a board id, or None (issue #1244)."""
-    try:
-        boards = get_settings_service().get_board_settings().boards or []
-    except Exception as exc:
-        logger.debug("Could not read boards list: %s", exc)
-        return None
-    for board in boards:
-        if isinstance(board, dict) and board.get("id") == board_id:
-            return board
-    return None
+    """This module's binding of :func:`src.boards.find_board`.
+
+    Kept as a wrapper rather than an import alias so the lookup goes on
+    resolving through *this* module's ``get_settings_service`` — the name the
+    suite stubs when it exercises the handlers that still live here.
+    """
+    return find_board(board_id, get_settings_service())
 
 
 def _require_board(board_id: str) -> dict:
-    """Return the ``settings.boards`` entry for *board_id*, or raise 404.
-
-    The single place the "unknown board" verdict is made. The pattern was
-    open-coded in nine handlers and simply missing from four schedule write
-    endpoints, which persisted state bound to a board that does not exist and
-    reported success (#1888).
-
-    Use this on any path that *writes* something scoped to a board. Board-
-    scoped **reads** deliberately fall back to their safe default instead —
-    see the "board_id validation" note in
-    ``docs/internal/reference/API_CONVENTIONS.md``.
-    """
-    board = _find_board(board_id)
-    if board is None:
-        raise HTTPException(status_code=404, detail=f"Board not found: {board_id}")
-    return board
+    """This module's binding of :func:`src.boards.require_board`. See above."""
+    return require_board(board_id, get_settings_service())
 
 
 def _board_dims(board: dict):

--- a/src/boards.py
+++ b/src/boards.py
@@ -1,0 +1,65 @@
+"""The board directory: the one place a board id is resolved, or refused.
+
+Boards live in ``settings.boards``. Every router needs to answer two questions
+about a ``board_id`` a client sent — "which board is this?" and "does it exist
+at all?" — and before #1888 nine handlers open-coded the second one while four
+schedule write endpoints simply skipped it and persisted state bound to a board
+that does not exist.
+
+Both functions lived in ``src/api_server.py``, which meant a domain router could
+only reach them by importing the 10k-line app module *at call time* — the seam
+Phase 2 §2.3 retires. They are platform helpers, not app-factory internals, so
+they live here.
+
+**The settings service is a parameter, not a global.** Every caller already
+holds one, and passing it keeps the lookup resolving through whichever
+``get_settings_service`` the *calling module* binds — which is what lets a test
+stub one router's settings without reaching into this module. A hidden
+``get_settings_service()`` here would silently detach the board lookup from
+every existing per-module stub.
+
+``require_board`` raises ``HTTPException`` rather than a domain error on
+purpose: it exists to make the HTTP "unknown board" verdict in exactly one
+place, and every caller is a request handler.
+
+**Writes 404, reads fall back** — see the "board_id validation" note in
+``docs/internal/reference/API_CONVENTIONS.md``. Call ``require_board`` on any
+path that persists something scoped to a board; board-scoped reads answer their
+safe default instead.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import HTTPException
+
+logger = logging.getLogger(__name__)
+
+
+def find_board(board_id: str | None, settings_service: Any) -> dict | None:
+    """Return the ``settings.boards`` entry for *board_id*, or None (issue #1244)."""
+    try:
+        boards = settings_service.get_board_settings().boards or []
+    except Exception as exc:
+        logger.debug("Could not read boards list: %s", exc)
+        return None
+    for board in boards:
+        if isinstance(board, dict) and board.get("id") == board_id:
+            return board
+    return None
+
+
+def require_board(board_id: str, settings_service: Any) -> dict:
+    """Return the ``settings.boards`` entry for *board_id*, or raise 404.
+
+    The single place the "unknown board" verdict is made. The pattern was
+    open-coded in nine handlers and simply missing from four schedule write
+    endpoints, which persisted state bound to a board that does not exist and
+    reported success (#1888).
+    """
+    board = find_board(board_id, settings_service)
+    if board is None:
+        raise HTTPException(status_code=404, detail=f"Board not found: {board_id}")
+    return board

--- a/src/collections/service.py
+++ b/src/collections/service.py
@@ -235,3 +235,52 @@ def reset_collection_service_for_tests() -> None:
     """Clear the cached singleton. Tests that swap storage paths use this."""
     global _collection_service
     _collection_service = None
+
+
+def resolve_active_page_id(page_id: str | None, get_collection_service: Callable[[], Any]) -> str | None:
+    """Resolve a collection reference to the page it is currently showing.
+
+    When ``page_id`` is a collection ID the Dashboard needs to know which
+    member page the collection's logic is presently rendering on the board so
+    it can name and link to that page (issue #1513). Plain page IDs (and None)
+    are returned unchanged. Never raises — a collection that can't be resolved
+    just yields None.
+
+    Lived in ``src/api_server.py`` until Phase 2 §2.3; it reads nothing but
+    collections, so the schedules router can import it from here instead of
+    reaching into the app module at call time.
+
+    The service *accessor* is a parameter, not this module's global: the caller
+    passes its own binding, so the lookup keeps resolving through whichever
+    ``get_collection_service`` the calling module binds (and stays lazy — a
+    plain page id never touches the service at all).
+    """
+    if not is_collection_id(page_id):
+        return page_id
+    try:
+        return get_collection_service().resolve_page_id(page_id)
+    except Exception:  # pragma: no cover - defensive; resolution is best-effort
+        logger.warning("Failed to resolve collection page for %s", page_id, exc_info=True)
+        return None
+
+
+def resolve_next_check_seconds(page_id: str | None, get_collection_service: Callable[[], Any]) -> int | None:
+    """Seconds until ``page_id``'s collection may switch to a different page.
+
+    A collection can rotate as often as every 5 seconds (2 for variable-mode
+    polling), so a client that caches ``resolved_page_id`` on a fixed timer
+    would name the wrong page for most of the interval. Handing back the
+    collection's own cadence lets the Dashboard re-poll exactly when the page
+    on the board can change (issue #1513). None for plain pages, collections
+    that can't rotate (<2 pages), and any resolution failure.
+
+    Takes the service accessor as a parameter for the same reason as
+    :func:`resolve_active_page_id`.
+    """
+    if not is_collection_id(page_id):
+        return None
+    try:
+        return get_collection_service().seconds_until_next_check(page_id)
+    except Exception:  # pragma: no cover - defensive; resolution is best-effort
+        logger.warning("Failed to compute next check for collection %s", page_id, exc_info=True)
+        return None

--- a/src/schedules/models.py
+++ b/src/schedules/models.py
@@ -9,7 +9,9 @@ import uuid
 from datetime import UTC, date, datetime
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, StrictBool
+
+from src.settings.service import TemporaryOverrideStatus
 
 DayPattern = Literal["all", "weekdays", "weekends", "custom"]
 TimeType = Literal["fixed", "sunrise", "sunset"]
@@ -280,6 +282,113 @@ class ScheduleUpdate(BaseModel):
     start_sun_offset: int | None = None
     end_type: TimeType | None = None
     end_sun_offset: int | None = None
+
+
+class ScheduleValidateRequest(BaseModel):
+    """Body of ``POST /schedules/validate``. Optional — omit it for all boards."""
+
+    board_id: str | None = None
+
+
+class DefaultPageUpdate(BaseModel):
+    """Body of ``PUT /schedules/default-page``.
+
+    ``page_id`` is required but nullable: ``null`` clears the default page,
+    which is a different request from omitting the field (that is a 422).
+    """
+
+    page_id: str | None
+    board_id: str | None = None
+
+
+class ScheduleEnabledUpdate(BaseModel):
+    """Body of ``PUT /schedules/enabled``.
+
+    ``enabled`` is a ``StrictBool`` on purpose: Pydantic's lax mode would
+    coerce ``"yes"`` / ``"on"`` / ``1`` into ``True`` and silently turn
+    schedule mode on for a client that sent the wrong type. The pre-conversion
+    handler rejected non-booleans by hand; this keeps that promise.
+    """
+
+    enabled: StrictBool
+    board_id: str | None = None
+
+
+class ScheduleResponse(ScheduleEntry):
+    """A schedule as the API serves it: the stored entry plus today's times.
+
+    ``resolved_*`` equals the stored time for fixed schedules and the computed
+    sunrise/sunset time for sun-based ones, so a client never has to know the
+    install's location to render the window.
+    """
+
+    resolved_start_time: str
+    resolved_end_time: str | None = None
+
+
+class ScheduleWriteResponse(ScheduleResponse):
+    """What create and update answer with.
+
+    ``warnings`` carries the non-fatal page<->board size mismatches of issue
+    #1245 — a collection may mix page sizes, and the write is allowed as long
+    as one member fits. The key was previously *omitted* when there was nothing
+    to warn about, so a client could not tell "no warnings" from "this server
+    doesn't report warnings"; it is now always present and empty when clean.
+    """
+
+    warnings: list[str] = Field(default_factory=list)
+
+
+class ScheduleListResponse(BaseModel):
+    """What ``GET /schedules`` answers with.
+
+    ``default_page_id`` and ``enabled`` are per-board, so both are ``null`` on
+    the cross-board listing (``board_id=*``) — that listing has no single board
+    to answer for.
+    """
+
+    schedules: list[ScheduleResponse]
+    total: int
+    default_page_id: str | None = None
+    enabled: bool | None = None
+
+
+class ScheduleDeleteResponse(BaseModel):
+    """The id of the schedule that was deleted."""
+
+    id: str
+
+
+class DefaultPageResponse(BaseModel):
+    """The default page shown when no schedule window is active."""
+
+    default_page_id: str | None = None
+
+
+class ScheduleEnabledResponse(BaseModel):
+    """Whether schedule mode drives the board."""
+
+    enabled: bool
+
+
+class ActiveScheduleResponse(BaseModel):
+    """What ``GET /schedules/active/page`` answers with.
+
+    Every field is always present. The manual branch used to omit
+    ``current_time`` / ``current_day`` / ``default_page_id`` entirely, so one
+    route served two key sets and a client could not tell a missing field from
+    a server that never sends it; they are ``null`` in manual mode now.
+    """
+
+    page_id: str | None = None
+    resolved_page_id: str | None = None
+    resolved_next_check_seconds: int | None = None
+    source: Literal["schedule", "manual", "none"]
+    schedule_enabled: bool
+    current_time: str | None = None
+    current_day: str | None = None
+    default_page_id: str | None = None
+    temporary_override: TemporaryOverrideStatus
 
 
 class Overlap(BaseModel):

--- a/src/schedules/routes.py
+++ b/src/schedules/routes.py
@@ -1,19 +1,55 @@
 """FastAPI router for the schedule endpoints.
 
-Handlers moved verbatim from ``src/api_server.py`` (issue #1756, pure move).
-Names that still live in ``api_server`` — the service getters and the
-active-page/override resolvers shared with the settings routes — are imported
-*inside* each handler so they resolve through the api_server module at call
-time. The test-suite patches them as ``src.api_server.<name>``; a
-module-level import would both create an import cycle (api_server imports
-this router) and detach the moved handlers from those patches.
+Handlers were moved here verbatim from ``src/api_server.py`` (issue #1756);
+Phase 2 slice 2 then applied ``docs/internal/reference/API_CONVENTIONS.md`` to
+them and retired the call-time ``from src.api_server import ...`` seams the
+move left behind.
+
+Collaborators now resolve from their canonical homes at **module import time**,
+so this module never loads ``src.api_server``
+(``tests/test_schedules_decoupled.py`` asserts that in a fresh interpreter).
+Three of them had no canonical home before this pass and were moved out of the
+app module to get one: ``require_board`` (``src/boards.py``),
+``resolve_active_page_id`` / ``resolve_next_check_seconds``
+(``src/collections/service.py``) and ``temporary_override_payload``
+(``src/settings/service.py``).
+
+Tests that need to stub a collaborator patch it where this module binds it —
+``src.schedules.routes.<name>`` — not ``src.api_server.<name>``.
 """
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Body, HTTPException
+from fastapi import APIRouter, HTTPException
 
-from .models import ScheduleCreate, ScheduleUpdate
+from src.api_errors import errors
+from src.boards import require_board
+from src.collections.models import is_collection_id
+from src.collections.service import (
+    get_collection_service,
+    resolve_active_page_id,
+    resolve_next_check_seconds,
+)
+from src.pages.service import check_ref_board_compatibility, get_page_service
+from src.settings.service import get_settings_service, temporary_override_payload
+from src.time_service import get_time_service
+
+from .models import (
+    ActiveScheduleResponse,
+    DefaultPageResponse,
+    DefaultPageUpdate,
+    ScheduleCreate,
+    ScheduleDeleteResponse,
+    ScheduleEnabledResponse,
+    ScheduleEnabledUpdate,
+    ScheduleListResponse,
+    ScheduleResponse,
+    ScheduleUpdate,
+    ScheduleValidateRequest,
+    ScheduleValidationResult,
+    ScheduleWriteResponse,
+)
+from .service import get_schedule_service
 
 router = APIRouter(tags=["schedules"])
 
@@ -35,9 +71,7 @@ def _validate_board(board_id: str | None) -> None:
     """
     if not board_id:
         return
-    from src.api_server import _require_board  # patched-in-tests seam — see module docstring (#1756)
-
-    _require_board(board_id)
+    require_board(board_id, get_settings_service())
 
 
 def _enrich_schedule_with_sun_times(schedule_dict: dict) -> dict:
@@ -47,8 +81,6 @@ def _enrich_schedule_with_sun_times(schedule_dict: dict) -> dict:
     For sun-based schedules (sunrise/sunset) the times are computed
     dynamically for today using the configured location.
     """
-    from src.api_server import get_settings_service  # patched-in-tests seam — see module docstring (#1756)
-
     start_type = schedule_dict.get("start_type", "fixed")
     end_type = schedule_dict.get("end_type", "fixed")
 
@@ -84,20 +116,30 @@ def _enrich_schedule_with_sun_times(schedule_dict: dict) -> dict:
     return schedule_dict
 
 
-@router.get("/schedules")
+def _with_compat_warnings(response: dict, schedule) -> dict:
+    """Attach non-fatal page<->board size warnings to a schedule response.
+
+    Collections may mix page sizes; the write is allowed when at least one
+    member fits the board, and the members that don't fit are surfaced as a
+    ``warnings`` list (issue #1245). The list is empty when there is nothing
+    to warn about — the key is always present so a client can tell "no
+    warnings" from "no warnings reported".
+    """
+    compat = check_ref_board_compatibility(schedule.page_id, schedule.board_id)
+    response["warnings"] = list(compat.warnings) if (compat.ok and compat.warnings) else []
+    return response
+
+
+@router.get("/schedules", response_model=ScheduleListResponse)
 async def list_schedules(board_id: str | None = None):
     """List schedule entries, optionally for one board (query: board_id=).
 
     Use board_id=* to get ALL schedules across all boards (useful for cleanup/admin).
     """
-    from src.api_server import (  # patched-in-tests seam — see module docstring (#1756)
-        get_schedule_service,
-        get_settings_service,
-    )
-
     schedule_service = get_schedule_service()
     settings_service = get_settings_service()
     schedules = schedule_service.list_schedules(board_id=board_id)
+    entries = [_enrich_schedule_with_sun_times(s.model_dump()) for s in schedules]
 
     # When listing all boards (board_id="*") the two per-board fields have no
     # answer, so both are null. `enabled` used to be hardcoded `False`, which a
@@ -106,148 +148,110 @@ async def list_schedules(board_id: str | None = None):
     # honest "not applicable to this listing", and matches what the same branch
     # has always answered for `default_page_id`.
     if board_id == "*":
-        return {
-            "schedules": [_enrich_schedule_with_sun_times(s.model_dump()) for s in schedules],
-            "total": len(schedules),
-            "default_page_id": None,
-            "enabled": None,
-        }
+        return ScheduleListResponse(schedules=entries, total=len(schedules))
 
-    return {
-        "schedules": [_enrich_schedule_with_sun_times(s.model_dump()) for s in schedules],
-        "total": len(schedules),
-        "default_page_id": schedule_service.get_default_page(board_id=board_id),
-        "enabled": settings_service.is_schedule_enabled(board_id=board_id),
-    }
+    return ScheduleListResponse(
+        schedules=entries,
+        total=len(schedules),
+        default_page_id=schedule_service.get_default_page(board_id=board_id),
+        enabled=settings_service.is_schedule_enabled(board_id=board_id),
+    )
 
 
-def _with_compat_warnings(response: dict, schedule) -> dict:
-    """Attach non-fatal page<->board size warnings to a schedule response.
-
-    Collections may mix page sizes; the write is allowed when at least one
-    member fits the board, and the members that don't fit are surfaced as a
-    ``warnings`` list (issue #1245). The key is omitted when there is nothing
-    to warn about.
-    """
-    from src.api_server import check_ref_board_compatibility  # patched-in-tests seam — see module docstring (#1756)
-
-    compat = check_ref_board_compatibility(schedule.page_id, schedule.board_id)
-    if compat.ok and compat.warnings:
-        response["warnings"] = compat.warnings
-    return response
-
-
-@router.post("/schedules")
+@router.post(
+    "/schedules",
+    response_model=ScheduleWriteResponse,
+    status_code=201,
+    responses=errors(400, 404),
+)
 async def create_schedule(schedule_data: ScheduleCreate):
-    """Create a new schedule entry.
-
-    Args:
-        schedule_data: Schedule configuration
-
-    Returns:
-        Created schedule entry
-    """
-    from src.api_server import get_schedule_service  # patched-in-tests seam — see module docstring (#1756)
-
+    """Create a new schedule entry."""
     _validate_board(schedule_data.board_id)
 
     schedule_service = get_schedule_service()
 
     try:
         schedule = schedule_service.create_schedule(schedule_data)
-        response = _enrich_schedule_with_sun_times(schedule.model_dump())
-        return _with_compat_warnings(response, schedule)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
+    response = _enrich_schedule_with_sun_times(schedule.model_dump())
+    return _with_compat_warnings(response, schedule)
 
 
 # Specific routes must come BEFORE parameterized routes
 # to avoid /schedules/{schedule_id} matching everything
 
 
-@router.get("/schedules/active/page")
+@router.get("/schedules/active/page", response_model=ActiveScheduleResponse)
 async def get_active_schedule(board_id: str | None = None):
     """Get the currently active page based on schedule (optional query: board_id=)."""
-    from src.api_server import (  # patched-in-tests seam — see module docstring (#1756)
-        _resolve_active_page_id,
-        _resolve_next_check_seconds,
-        _temporary_override_payload,
-        get_schedule_service,
-        get_settings_service,
-    )
-
     schedule_service = get_schedule_service()
     settings_service = get_settings_service()
 
     # Include temporary override status so the frontend can show the countdown badge
     # without a separate API call.
     override = settings_service.get_temporary_override()
-    temporary_override_payload = _temporary_override_payload(override)
+    override_payload = temporary_override_payload(override)
 
     if not settings_service.is_schedule_enabled(board_id=board_id):
         manual_page_id = settings_service.get_active_page_id()
-        return {
-            "page_id": manual_page_id,
-            "resolved_page_id": _resolve_active_page_id(manual_page_id),
-            "resolved_next_check_seconds": _resolve_next_check_seconds(manual_page_id),
-            "source": "manual",
-            "schedule_enabled": False,
-            "temporary_override": temporary_override_payload,
-        }
-    from src.time_service import get_time_service
+        return ActiveScheduleResponse(
+            page_id=manual_page_id,
+            resolved_page_id=resolve_active_page_id(manual_page_id, get_collection_service),
+            resolved_next_check_seconds=resolve_next_check_seconds(manual_page_id, get_collection_service),
+            source="manual",
+            schedule_enabled=False,
+            temporary_override=override_payload,
+        )
 
     time_service = get_time_service()
     now = time_service.get_current_time()
     current_time = now.time()
     current_day = now.strftime("%A").lower()
     page_id = schedule_service.get_active_page_id(current_time, current_day, board_id=board_id)
-    return {
-        "page_id": page_id,
-        "resolved_page_id": _resolve_active_page_id(page_id),
-        "resolved_next_check_seconds": _resolve_next_check_seconds(page_id),
-        "source": "schedule" if page_id else "none",
-        "schedule_enabled": True,
-        "current_time": now.strftime("%H:%M"),
-        "current_day": current_day,
-        "default_page_id": schedule_service.get_default_page(board_id=board_id),
-        "temporary_override": temporary_override_payload,
-    }
-
-
-@router.post("/schedules/validate")
-async def validate_schedules(request: dict | None = Body(None)):
-    """Validate schedules for overlaps and gaps. Body optional: {"board_id": "..."}."""
-    from src.api_server import get_schedule_service  # patched-in-tests seam — see module docstring (#1756)
-
-    schedule_service = get_schedule_service()
-    board_id = request.get("board_id") if request else None
-    result = schedule_service.validate_schedules(board_id=board_id)
-    return result.model_dump()
-
-
-@router.get("/schedules/default-page")
-async def get_default_page(board_id: str | None = None):
-    """Get the default page ID for schedule gaps (optional query: board_id=)."""
-    from src.api_server import get_schedule_service  # patched-in-tests seam — see module docstring (#1756)
-
-    schedule_service = get_schedule_service()
-    return {"default_page_id": schedule_service.get_default_page(board_id=board_id)}
-
-
-@router.put("/schedules/default-page")
-async def set_default_page(request: dict):
-    """Set the default page ID for schedule gaps. Body: page_id, optional board_id."""
-    from src.api_server import (  # patched-in-tests seam — see module docstring (#1756)
-        get_collection_service,
-        get_page_service,
-        get_schedule_service,
-        is_collection_id,
+    return ActiveScheduleResponse(
+        page_id=page_id,
+        resolved_page_id=resolve_active_page_id(page_id, get_collection_service),
+        resolved_next_check_seconds=resolve_next_check_seconds(page_id, get_collection_service),
+        source="schedule" if page_id else "none",
+        schedule_enabled=True,
+        current_time=now.strftime("%H:%M"),
+        current_day=current_day,
+        default_page_id=schedule_service.get_default_page(board_id=board_id),
+        temporary_override=override_payload,
     )
 
-    if "page_id" not in request:
-        raise HTTPException(status_code=400, detail="page_id parameter required")
-    page_id = request["page_id"]
-    board_id = request.get("board_id")
+
+@router.post("/schedules/validate", response_model=ScheduleValidationResult)
+async def validate_schedules(request: ScheduleValidateRequest | None = None):
+    """Validate schedules for overlaps and gaps. Body optional: {"board_id": "..."}.
+
+    A ``valid: false`` verdict is a 200: the caller asked "are these schedules
+    consistent?" and got the answer it asked for, in a declared response model
+    — the probe-endpoint case of API_CONVENTIONS.md §status codes, not a
+    failure served as a success.
+    """
+    schedule_service = get_schedule_service()
+    board_id = request.board_id if request else None
+    return schedule_service.validate_schedules(board_id=board_id)
+
+
+@router.get("/schedules/default-page", response_model=DefaultPageResponse)
+async def get_default_page(board_id: str | None = None):
+    """Get the default page ID for schedule gaps (optional query: board_id=)."""
+    schedule_service = get_schedule_service()
+    return DefaultPageResponse(default_page_id=schedule_service.get_default_page(board_id=board_id))
+
+
+@router.put(
+    "/schedules/default-page",
+    response_model=DefaultPageResponse,
+    responses=errors(404),
+)
+async def set_default_page(request: DefaultPageUpdate):
+    """Set the default page ID for schedule gaps. Body: page_id, optional board_id."""
+    page_id = request.page_id
+    board_id = request.board_id
     _validate_board(board_id)
     if page_id is not None:
         if is_collection_id(page_id):
@@ -260,54 +264,39 @@ async def set_default_page(request: dict):
                 raise HTTPException(status_code=404, detail=f"Page not found: {page_id}")
     schedule_service = get_schedule_service()
     schedule_service.set_default_page(page_id, board_id=board_id)
-    return {"status": "success", "default_page_id": page_id}
+    return DefaultPageResponse(default_page_id=page_id)
 
 
-@router.get("/schedules/enabled")
+@router.get("/schedules/enabled", response_model=ScheduleEnabledResponse)
 async def get_schedule_enabled(board_id: str | None = None):
     """Check if schedule mode is enabled (optional query: board_id=)."""
-    from src.api_server import get_settings_service  # patched-in-tests seam — see module docstring (#1756)
-
     settings_service = get_settings_service()
-    return {"enabled": settings_service.is_schedule_enabled(board_id=board_id)}
+    return ScheduleEnabledResponse(enabled=settings_service.is_schedule_enabled(board_id=board_id))
 
 
-@router.put("/schedules/enabled")
-async def set_schedule_enabled(request: dict):
+@router.put(
+    "/schedules/enabled",
+    response_model=ScheduleEnabledResponse,
+    responses=errors(404),
+)
+async def set_schedule_enabled(request: ScheduleEnabledUpdate):
     """Enable or disable schedule mode. Body: enabled, optional board_id."""
-    from src.api_server import get_settings_service  # patched-in-tests seam — see module docstring (#1756)
-
-    if "enabled" not in request:
-        raise HTTPException(status_code=400, detail="enabled parameter required")
-    enabled = request["enabled"]
-    if not isinstance(enabled, bool):
-        raise HTTPException(status_code=400, detail="enabled must be boolean")
-    board_id = request.get("board_id")
-    _validate_board(board_id)
+    _validate_board(request.board_id)
     settings_service = get_settings_service()
-    settings_service.set_schedule_enabled(enabled, board_id=board_id)
-    return {
-        "status": "success",
-        "enabled": enabled,
-        "message": f"Schedule mode {'enabled' if enabled else 'disabled'}",
-    }
+    settings_service.set_schedule_enabled(request.enabled, board_id=request.board_id)
+    return ScheduleEnabledResponse(enabled=request.enabled)
 
 
 # Parameterized routes come LAST to avoid matching specific paths
 
 
-@router.get("/schedules/{schedule_id}")
+@router.get(
+    "/schedules/{schedule_id}",
+    response_model=ScheduleResponse,
+    responses=errors(404),
+)
 async def get_schedule(schedule_id: str):
-    """Get a schedule entry by ID.
-
-    Args:
-        schedule_id: Schedule ID
-
-    Returns:
-        Schedule entry
-    """
-    from src.api_server import get_schedule_service  # patched-in-tests seam — see module docstring (#1756)
-
+    """Get a schedule entry by ID."""
     schedule_service = get_schedule_service()
     schedule = schedule_service.get_schedule(schedule_id)
 
@@ -317,49 +306,38 @@ async def get_schedule(schedule_id: str):
     return _enrich_schedule_with_sun_times(schedule.model_dump())
 
 
-@router.put("/schedules/{schedule_id}")
+@router.put(
+    "/schedules/{schedule_id}",
+    response_model=ScheduleWriteResponse,
+    responses=errors(400, 404),
+)
 async def update_schedule(schedule_id: str, schedule_data: ScheduleUpdate):
-    """Update an existing schedule entry.
-
-    Args:
-        schedule_id: Schedule ID
-        schedule_data: Fields to update
-
-    Returns:
-        Updated schedule entry
-    """
-    from src.api_server import get_schedule_service  # patched-in-tests seam — see module docstring (#1756)
-
+    """Update an existing schedule entry."""
     _validate_board(schedule_data.board_id)
 
     schedule_service = get_schedule_service()
 
     try:
         schedule = schedule_service.update_schedule(schedule_id, schedule_data)
-        if not schedule:
-            raise HTTPException(status_code=404, detail=f"Schedule not found: {schedule_id}")
-        response = _enrich_schedule_with_sun_times(schedule.model_dump())
-        return _with_compat_warnings(response, schedule)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
+    if not schedule:
+        raise HTTPException(status_code=404, detail=f"Schedule not found: {schedule_id}")
+    response = _enrich_schedule_with_sun_times(schedule.model_dump())
+    return _with_compat_warnings(response, schedule)
 
 
-@router.delete("/schedules/{schedule_id}")
+@router.delete(
+    "/schedules/{schedule_id}",
+    response_model=ScheduleDeleteResponse,
+    responses=errors(404),
+)
 async def delete_schedule(schedule_id: str):
-    """Delete a schedule entry.
-
-    Args:
-        schedule_id: Schedule ID
-
-    Returns:
-        Success status
-    """
-    from src.api_server import get_schedule_service  # patched-in-tests seam — see module docstring (#1756)
-
+    """Delete a schedule entry."""
     schedule_service = get_schedule_service()
 
     deleted = schedule_service.delete_schedule(schedule_id)
     if not deleted:
         raise HTTPException(status_code=404, detail=f"Schedule not found: {schedule_id}")
 
-    return {"status": "success", "message": f"Schedule {schedule_id} deleted"}
+    return ScheduleDeleteResponse(id=schedule_id)

--- a/src/schedules/routes.py
+++ b/src/schedules/routes.py
@@ -99,13 +99,18 @@ async def list_schedules(board_id: str | None = None):
     settings_service = get_settings_service()
     schedules = schedule_service.list_schedules(board_id=board_id)
 
-    # When listing all boards (board_id="*"), default_page_id and enabled don't make sense
+    # When listing all boards (board_id="*") the two per-board fields have no
+    # answer, so both are null. `enabled` used to be hardcoded `False`, which a
+    # client cannot tell apart from "schedule mode is off on every board" — it
+    # said `false` even with schedule mode on for the only board. `null` is the
+    # honest "not applicable to this listing", and matches what the same branch
+    # has always answered for `default_page_id`.
     if board_id == "*":
         return {
             "schedules": [_enrich_schedule_with_sun_times(s.model_dump()) for s in schedules],
             "total": len(schedules),
             "default_page_id": None,
-            "enabled": False,
+            "enabled": None,
         }
 
     return {

--- a/src/settings/service.py
+++ b/src/settings/service.py
@@ -15,6 +15,8 @@ from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from typing import Literal, Optional
 
+from pydantic import BaseModel
+
 from src.storage.json_store import JsonStore
 
 logger = logging.getLogger(__name__)
@@ -358,6 +360,70 @@ class TemporaryOverride:
             notes_wide=data.get("notes_wide"),
             notes_tall=data.get("notes_tall"),
         )
+
+
+class TemporaryOverrideStatus(BaseModel):
+    """The wire shape of a :class:`TemporaryOverride`, or of "there isn't one".
+
+    One shape is shared by ``GET``/``POST /settings/temporary-override`` and by
+    the inline block on ``GET /schedules/active/page``, so the three can never
+    drift. Declared as a model (rather than assembled ad hoc) so routers can
+    name it in ``response_model=`` — see
+    ``docs/internal/reference/API_CONVENTIONS.md``.
+
+    ``remaining_seconds`` is None both when there is no override and when the
+    override is indefinite (issue #1787).
+    """
+
+    active: bool
+    page_id: str | None = None
+    expires_at: str | None = None
+    remaining_seconds: float | None = None
+    revert_mode: str | None = None
+    revert_page_id: str | None = None
+    template: list[str] | None = None
+    line_metadata: list[dict] | None = None
+    device_type: str | None = None
+    notes_wide: int | None = None
+    notes_tall: int | None = None
+
+
+def temporary_override_payload(override: "TemporaryOverride | None") -> dict:
+    """Serialize a TemporaryOverride (or None) for the API.
+
+    Lived in ``src/api_server.py`` until Phase 2 §2.3. It reads nothing but the
+    override, so it belongs next to the model it serializes — and the schedules
+    router can now import it instead of reaching into the app module at call
+    time.
+    """
+    if override is None:
+        return {
+            "active": False,
+            "page_id": None,
+            "expires_at": None,
+            "remaining_seconds": None,
+            "revert_mode": None,
+            "revert_page_id": None,
+            "template": None,
+            "line_metadata": None,
+            "device_type": None,
+            "notes_wide": None,
+            "notes_tall": None,
+        }
+    remaining = override.remaining_seconds()
+    return {
+        "active": True,
+        "page_id": override.page_id,
+        "expires_at": override.expires_at,
+        "remaining_seconds": round(remaining, 1) if remaining is not None else None,
+        "revert_mode": override.revert_mode,
+        "revert_page_id": override.revert_page_id,
+        "template": override.template,
+        "line_metadata": override.line_metadata,
+        "device_type": override.device_type,
+        "notes_wide": override.notes_wide,
+        "notes_tall": override.notes_tall,
+    }
 
 
 @dataclass

--- a/tests/contract/test_schedules_contract.py
+++ b/tests/contract/test_schedules_contract.py
@@ -4,6 +4,10 @@ Validates that the Python backend returns responses that conform to the
 schema the Next.js frontend expects.
 
 Issue: #502
+
+Patch targets are ``src.schedules.routes.<name>``: the router binds its
+collaborators at import time since the Phase 2 conventions pass (§2.3), so it
+no longer resolves them through ``src.api_server``.
 """
 
 from unittest.mock import Mock, patch
@@ -43,8 +47,8 @@ def sample_schedule():
 class TestListSchedulesContract:
     def test_returns_200(self, client):
         with (
-            patch("src.api_server.get_schedule_service") as mock_svc,
-            patch("src.api_server.get_settings_service") as mock_settings,
+            patch("src.schedules.routes.get_schedule_service") as mock_svc,
+            patch("src.schedules.routes.get_settings_service") as mock_settings,
         ):
             svc = Mock()
             svc.list_schedules.return_value = []
@@ -61,8 +65,8 @@ class TestListSchedulesContract:
 
     def test_response_has_required_keys(self, client):
         with (
-            patch("src.api_server.get_schedule_service") as mock_svc,
-            patch("src.api_server.get_settings_service") as mock_settings,
+            patch("src.schedules.routes.get_schedule_service") as mock_svc,
+            patch("src.schedules.routes.get_settings_service") as mock_settings,
         ):
             svc = Mock()
             svc.list_schedules.return_value = []
@@ -81,8 +85,8 @@ class TestListSchedulesContract:
 
     def test_schedules_is_list(self, client):
         with (
-            patch("src.api_server.get_schedule_service") as mock_svc,
-            patch("src.api_server.get_settings_service") as mock_settings,
+            patch("src.schedules.routes.get_schedule_service") as mock_svc,
+            patch("src.schedules.routes.get_settings_service") as mock_settings,
         ):
             svc = Mock()
             svc.list_schedules.return_value = []
@@ -99,8 +103,8 @@ class TestListSchedulesContract:
 
     def test_total_matches_schedules_length(self, client, sample_schedule):
         with (
-            patch("src.api_server.get_schedule_service") as mock_svc,
-            patch("src.api_server.get_settings_service") as mock_settings,
+            patch("src.schedules.routes.get_schedule_service") as mock_svc,
+            patch("src.schedules.routes.get_settings_service") as mock_settings,
         ):
             svc = Mock()
             svc.list_schedules.return_value = [sample_schedule]
@@ -118,8 +122,8 @@ class TestListSchedulesContract:
 
     def test_schedule_item_has_required_fields(self, client, sample_schedule):
         with (
-            patch("src.api_server.get_schedule_service") as mock_svc,
-            patch("src.api_server.get_settings_service") as mock_settings,
+            patch("src.schedules.routes.get_schedule_service") as mock_svc,
+            patch("src.schedules.routes.get_settings_service") as mock_settings,
         ):
             svc = Mock()
             svc.list_schedules.return_value = [sample_schedule]
@@ -141,8 +145,8 @@ class TestListSchedulesContract:
 
     def test_schedule_time_format_is_hhmm(self, client, sample_schedule):
         with (
-            patch("src.api_server.get_schedule_service") as mock_svc,
-            patch("src.api_server.get_settings_service") as mock_settings,
+            patch("src.schedules.routes.get_schedule_service") as mock_svc,
+            patch("src.schedules.routes.get_settings_service") as mock_settings,
         ):
             svc = Mock()
             svc.list_schedules.return_value = [sample_schedule]
@@ -164,8 +168,8 @@ class TestListSchedulesContract:
     def test_wildcard_board_id_returns_no_default_or_enabled(self, client, sample_schedule):
         """board_id=* returns schedules without enabled/default_page_id semantics."""
         with (
-            patch("src.api_server.get_schedule_service") as mock_svc,
-            patch("src.api_server.get_settings_service") as mock_settings,
+            patch("src.schedules.routes.get_schedule_service") as mock_svc,
+            patch("src.schedules.routes.get_settings_service") as mock_settings,
         ):
             svc = Mock()
             svc.list_schedules.return_value = [sample_schedule]
@@ -179,7 +183,9 @@ class TestListSchedulesContract:
         data = resp.json()
         assert "schedules" in data
         assert "total" in data
-        assert data["enabled"] is False  # wildcard sets enabled=False
+        # Both per-board fields are null on the cross-board listing; `enabled`
+        # used to be hardcoded False, which read as "off on every board".
+        assert data["enabled"] is None
         assert data["default_page_id"] is None
 
 
@@ -190,7 +196,7 @@ class TestListSchedulesContract:
 
 class TestCreateScheduleContract:
     def test_returns_200_on_valid_input(self, client, sample_schedule):
-        with patch("src.api_server.get_schedule_service") as mock_svc:
+        with patch("src.schedules.routes.get_schedule_service") as mock_svc:
             svc = Mock()
             svc.create_schedule.return_value = sample_schedule
             mock_svc.return_value = svc
@@ -205,10 +211,10 @@ class TestCreateScheduleContract:
                 },
             )
 
-        assert resp.status_code == 200
+        assert resp.status_code == 201  # 201 since the conventions pass
 
     def test_created_schedule_has_required_fields(self, client, sample_schedule):
-        with patch("src.api_server.get_schedule_service") as mock_svc:
+        with patch("src.schedules.routes.get_schedule_service") as mock_svc:
             svc = Mock()
             svc.create_schedule.return_value = sample_schedule
             mock_svc.return_value = svc
@@ -231,7 +237,7 @@ class TestCreateScheduleContract:
         assert "day_pattern" in data
 
     def test_returns_400_on_invalid_input(self, client):
-        with patch("src.api_server.get_schedule_service") as mock_svc:
+        with patch("src.schedules.routes.get_schedule_service") as mock_svc:
             svc = Mock()
             svc.create_schedule.side_effect = ValueError("Missing page_id")
             mock_svc.return_value = svc
@@ -252,7 +258,7 @@ class TestCreateScheduleContract:
             end_time="06:00",
             day_pattern="all",
         )
-        with patch("src.api_server.get_schedule_service") as mock_svc:
+        with patch("src.schedules.routes.get_schedule_service") as mock_svc:
             svc = Mock()
             svc.create_schedule.return_value = overnight
             mock_svc.return_value = svc
@@ -267,7 +273,7 @@ class TestCreateScheduleContract:
                 },
             )
 
-        assert resp.status_code == 200
+        assert resp.status_code == 201  # 201 since the conventions pass
         data = resp.json()
         assert data["start_time"] == "22:00"
         assert data["end_time"] == "06:00"
@@ -280,7 +286,7 @@ class TestCreateScheduleContract:
 
 class TestSchedulesEnabledContract:
     def test_returns_200(self, client):
-        with patch("src.api_server.get_settings_service") as mock_settings:
+        with patch("src.schedules.routes.get_settings_service") as mock_settings:
             ss = Mock()
             ss.is_schedule_enabled.return_value = False
             mock_settings.return_value = ss
@@ -290,7 +296,7 @@ class TestSchedulesEnabledContract:
         assert resp.status_code == 200
 
     def test_response_has_enabled_field(self, client):
-        with patch("src.api_server.get_settings_service") as mock_settings:
+        with patch("src.schedules.routes.get_settings_service") as mock_settings:
             ss = Mock()
             ss.is_schedule_enabled.return_value = True
             mock_settings.return_value = ss
@@ -302,7 +308,7 @@ class TestSchedulesEnabledContract:
         assert isinstance(data["enabled"], bool)
 
     def test_enabled_false_validates(self, client):
-        with patch("src.api_server.get_settings_service") as mock_settings:
+        with patch("src.schedules.routes.get_settings_service") as mock_settings:
             ss = Mock()
             ss.is_schedule_enabled.return_value = False
             mock_settings.return_value = ss
@@ -313,7 +319,7 @@ class TestSchedulesEnabledContract:
         assert parsed.enabled is False
 
     def test_enabled_true_validates(self, client):
-        with patch("src.api_server.get_settings_service") as mock_settings:
+        with patch("src.schedules.routes.get_settings_service") as mock_settings:
             ss = Mock()
             ss.is_schedule_enabled.return_value = True
             mock_settings.return_value = ss
@@ -331,7 +337,7 @@ class TestSchedulesEnabledContract:
 
 class TestDefaultPageContract:
     def test_returns_200(self, client):
-        with patch("src.api_server.get_schedule_service") as mock_svc:
+        with patch("src.schedules.routes.get_schedule_service") as mock_svc:
             svc = Mock()
             svc.get_default_page.return_value = None
             mock_svc.return_value = svc
@@ -341,7 +347,7 @@ class TestDefaultPageContract:
         assert resp.status_code == 200
 
     def test_response_has_default_page_id(self, client):
-        with patch("src.api_server.get_schedule_service") as mock_svc:
+        with patch("src.schedules.routes.get_schedule_service") as mock_svc:
             svc = Mock()
             svc.get_default_page.return_value = None
             mock_svc.return_value = svc
@@ -352,7 +358,7 @@ class TestDefaultPageContract:
         assert "default_page_id" in data
 
     def test_null_default_page_is_valid(self, client):
-        with patch("src.api_server.get_schedule_service") as mock_svc:
+        with patch("src.schedules.routes.get_schedule_service") as mock_svc:
             svc = Mock()
             svc.get_default_page.return_value = None
             mock_svc.return_value = svc
@@ -363,7 +369,7 @@ class TestDefaultPageContract:
         assert parsed.page_id is None
 
     def test_set_default_page_id_reflects_in_response(self, client):
-        with patch("src.api_server.get_schedule_service") as mock_svc:
+        with patch("src.schedules.routes.get_schedule_service") as mock_svc:
             svc = Mock()
             svc.get_default_page.return_value = "my-default-page"
             mock_svc.return_value = svc

--- a/tests/conventions_manifest.json
+++ b/tests/conventions_manifest.json
@@ -1,13 +1,39 @@
 {
-  "_comment": "API conventions ratchet (Phase 2, spec \u00a72). Enforced by tests/test_api_conventions_ratchet.py; rules documented in docs/internal/reference/API_CONVENTIONS.md. Append a domain to converted_domains in the slice PR that converts it \u2014 never before. Every exception needs a route that exists, a known rule id, and a reason a reviewer can argue with.",
+  "_comment": "API conventions ratchet (Phase 2, spec §2). Enforced by tests/test_api_conventions_ratchet.py; rules documented in docs/internal/reference/API_CONVENTIONS.md. Append a domain to converted_domains in the slice PR that converts it — never before. Every exception needs a route that exists, a known rule id, and a reason a reviewer can argue with.",
   "converted_domains": [
-    "collections"
+    "collections",
+    "schedules"
   ],
   "exceptions": [
     {
       "route": "GET /collections",
       "rule": "declared_errors",
       "reason": "Listing has no failure path: it returns [] for an empty store and cannot 404 or 400, so declaring a 4xx would document an error the endpoint never raises."
+    },
+    {
+      "route": "GET /schedules",
+      "rule": "declared_errors",
+      "reason": "No failure path. The only argument is board_id, and a board-scoped read deliberately falls back to the empty list instead of 404ing (API_CONVENTIONS.md, 'board_id validation: writes 404, reads fall back'); board_id=* is a documented wildcard, not an id."
+    },
+    {
+      "route": "GET /schedules/enabled",
+      "rule": "declared_errors",
+      "reason": "No failure path. An unknown board_id deliberately answers false rather than 404 — the same read/write asymmetry, decided in #1888 and documented in API_CONVENTIONS.md."
+    },
+    {
+      "route": "GET /schedules/default-page",
+      "rule": "declared_errors",
+      "reason": "No failure path. An unknown board_id deliberately answers the global default rather than 404 — the same read/write asymmetry, decided in #1888 and documented in API_CONVENTIONS.md."
+    },
+    {
+      "route": "GET /schedules/active/page",
+      "rule": "declared_errors",
+      "reason": "No failure path. It reports whatever is on the board right now — manual page, scheduled page, or nothing — and every collection resolution failure is caught and reported as null rather than raised, because a dashboard poll must not error out over a collection that cannot resolve."
+    },
+    {
+      "route": "POST /schedules/validate",
+      "rule": "declared_errors",
+      "reason": "No failure path. It is a read of existing schedules with an optional board_id, which falls back to the empty set; an inconsistent schedule set is the 200 verdict this endpoint exists to report, not an error."
     }
   ]
 }

--- a/tests/golden/responses/schedules.json
+++ b/tests/golden/responses/schedules.json
@@ -106,7 +106,7 @@
       "status": 200,
       "shape": {
         "default_page_id": "null",
-        "enabled": "bool",
+        "enabled": "null",
         "schedules": [
           {
             "annual_date": "null",

--- a/tests/golden/responses/schedules.json
+++ b/tests/golden/responses/schedules.json
@@ -17,7 +17,7 @@
       "label": "create_schedule_ok",
       "method": "POST",
       "path_template": "/schedules",
-      "status": 200,
+      "status": 201,
       "shape": {
         "annual_date": "null",
         "annual_end_date": "null",
@@ -39,7 +39,8 @@
         "start_sun_offset": "int",
         "start_time": "str",
         "start_type": "str",
-        "updated_at": "null"
+        "updated_at": "null",
+        "warnings": []
       }
     },
     {
@@ -141,6 +142,9 @@
       "path_template": "/schedules/active/page",
       "status": 200,
       "shape": {
+        "current_day": "null",
+        "current_time": "null",
+        "default_page_id": "null",
         "page_id": "null",
         "resolved_next_check_seconds": "null",
         "resolved_page_id": "null",
@@ -167,9 +171,7 @@
       "path_template": "/schedules/enabled",
       "status": 200,
       "shape": {
-        "enabled": "bool",
-        "message": "str",
-        "status": "str"
+        "enabled": "bool"
       }
     },
     {
@@ -214,18 +216,38 @@
       "label": "set_enabled_invalid",
       "method": "PUT",
       "path_template": "/schedules/enabled",
-      "status": 400,
+      "status": 422,
       "shape": {
-        "detail": "str"
+        "detail": [
+          {
+            "input": "str",
+            "loc": [
+              "str",
+              "str"
+            ],
+            "msg": "str",
+            "type": "str"
+          }
+        ]
       }
     },
     {
       "label": "set_enabled_missing",
       "method": "PUT",
       "path_template": "/schedules/enabled",
-      "status": 400,
+      "status": 422,
       "shape": {
-        "detail": "str"
+        "detail": [
+          {
+            "input": {},
+            "loc": [
+              "str",
+              "str"
+            ],
+            "msg": "str",
+            "type": "str"
+          }
+        ]
       }
     },
     {
@@ -279,17 +301,26 @@
       "path_template": "/schedules/default-page",
       "status": 200,
       "shape": {
-        "default_page_id": "str",
-        "status": "str"
+        "default_page_id": "str"
       }
     },
     {
       "label": "set_default_page_missing_param",
       "method": "PUT",
       "path_template": "/schedules/default-page",
-      "status": 400,
+      "status": 422,
       "shape": {
-        "detail": "str"
+        "detail": [
+          {
+            "input": {},
+            "loc": [
+              "str",
+              "str"
+            ],
+            "msg": "str",
+            "type": "str"
+          }
+        ]
       }
     },
     {
@@ -365,7 +396,8 @@
         "start_sun_offset": "int",
         "start_time": "str",
         "start_type": "str",
-        "updated_at": "str"
+        "updated_at": "str",
+        "warnings": []
       }
     },
     {
@@ -383,8 +415,7 @@
       "path_template": "/schedules/{schedule_id}",
       "status": 200,
       "shape": {
-        "message": "str",
-        "status": "str"
+        "id": "str"
       }
     },
     {

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -47,7 +47,14 @@ def mock_config_manager():
 @pytest.fixture
 def mock_settings_service():
     """Mock the settings service."""
-    with patch("src.api_server.get_settings_service") as mock_get:
+    # The schedules router binds its collaborators at import time now
+    # (Phase 2 §2.3), so this fixture stubs both places: `src.api_server.<name>`
+    # for the handlers that still live in the app module, and
+    # `src.schedules.routes.<name>` for the eleven that no longer do.
+    with (
+        patch("src.api_server.get_settings_service") as mock_get,
+        patch("src.schedules.routes.get_settings_service") as routes_get,
+    ):
         ss = Mock()
         transition = Mock()
         transition.strategy = "column"
@@ -137,13 +144,21 @@ def mock_settings_service():
         ss.update_plugin_settings.return_value = plugin_settings
 
         mock_get.return_value = ss
+        routes_get.return_value = ss
         yield ss
 
 
 @pytest.fixture
 def mock_page_service():
     """Mock the page service."""
-    with patch("src.api_server.get_page_service") as mock_get:
+    # The schedules router binds its collaborators at import time now
+    # (Phase 2 §2.3), so this fixture stubs both places: `src.api_server.<name>`
+    # for the handlers that still live in the app module, and
+    # `src.schedules.routes.<name>` for the eleven that no longer do.
+    with (
+        patch("src.api_server.get_page_service") as mock_get,
+        patch("src.schedules.routes.get_page_service") as routes_get,
+    ):
         ps = Mock()
         mock_page = Mock()
         mock_page.model_dump.return_value = {
@@ -186,13 +201,21 @@ def mock_page_service():
         ps._invalidate_cache.return_value = None
 
         mock_get.return_value = ps
+        routes_get.return_value = ps
         yield ps
 
 
 @pytest.fixture
 def mock_schedule_service():
     """Mock the schedule service."""
-    with patch("src.api_server.get_schedule_service") as mock_get:
+    # The schedules router binds its collaborators at import time now
+    # (Phase 2 §2.3), so this fixture stubs both places: `src.api_server.<name>`
+    # for the handlers that still live in the app module, and
+    # `src.schedules.routes.<name>` for the eleven that no longer do.
+    with (
+        patch("src.api_server.get_schedule_service") as mock_get,
+        patch("src.schedules.routes.get_schedule_service") as routes_get,
+    ):
         ss = Mock()
         mock_schedule = Mock()
         mock_schedule.model_dump.return_value = {
@@ -209,11 +232,12 @@ def mock_schedule_service():
         ss.delete_schedule.return_value = True
         ss.get_default_page.return_value = "page1"
         ss.get_active_page_id.return_value = "page1"
-        validate_result = Mock()
-        validate_result.model_dump.return_value = {"valid": True, "errors": [], "warnings": []}
-        ss.validate_schedules.return_value = validate_result
+        from src.schedules.models import ScheduleValidationResult
+
+        ss.validate_schedules.return_value = ScheduleValidationResult(valid=True, overlaps=[], gaps=[])
 
         mock_get.return_value = ss
+        routes_get.return_value = ss
         yield ss
 
 
@@ -1276,7 +1300,8 @@ class TestScheduleEndpoints:
         # member page it is currently rendering via resolved_page_id.
         mock_settings_service.is_schedule_enabled.return_value = True
         mock_schedule_service.get_active_page_id.return_value = "collection:abc"
-        with patch("src.api_server.get_collection_service") as mock_get_cs:
+        # The schedules router binds get_collection_service at import time now.
+        with patch("src.schedules.routes.get_collection_service") as mock_get_cs:
             cs = Mock()
             cs.resolve_page_id.return_value = "member-page"
             cs.seconds_until_next_check.return_value = 7
@@ -1303,8 +1328,10 @@ class TestScheduleEndpoints:
         assert response.status_code == 200
 
     def test_set_default_page_missing_param(self, client, mock_schedule_service):
+        # 422 since the conventions pass: the body is a Pydantic model, so a
+        # missing required field is FastAPI's standard validation error.
         response = client.put("/schedules/default-page", json={})
-        assert response.status_code == 400
+        assert response.status_code == 422
 
     def test_set_default_page_not_found(self, client, mock_schedule_service, mock_page_service):
         mock_page_service.get_page.return_value = None
@@ -1326,11 +1353,13 @@ class TestScheduleEndpoints:
 
     def test_set_schedule_enabled_missing_param(self, client, mock_settings_service):
         response = client.put("/schedules/enabled", json={})
-        assert response.status_code == 400
+        assert response.status_code == 422
 
     def test_set_schedule_enabled_not_bool(self, client, mock_settings_service):
+        # StrictBool: "yes" is still refused (Pydantic's lax mode would have
+        # coerced it to True), just as 422 rather than the old hand-rolled 400.
         response = client.put("/schedules/enabled", json={"enabled": "yes"})
-        assert response.status_code == 400
+        assert response.status_code == 422
 
 
 # ============================================================

--- a/tests/test_board_id_validation.py
+++ b/tests/test_board_id_validation.py
@@ -41,7 +41,11 @@ def one_board():
     settings.get_board_settings.return_value = board_settings
     settings.get_primary_board_id.return_value = "board-1"
     settings.is_schedule_enabled.return_value = False
-    with patch("src.api_server.get_settings_service", return_value=settings):
+    # The schedules router binds get_settings_service at import time now
+    # (Phase 2 §2.3), and `require_board` reads the boards list through the
+    # accessor its *caller* holds — so stubbing the router's binding is what
+    # decides both the "unknown board" verdict and `is_schedule_enabled`.
+    with patch("src.schedules.routes.get_settings_service", return_value=settings):
         yield settings
 
 
@@ -51,8 +55,8 @@ class TestScheduleWritesRejectUnknownBoards:
         page_service = Mock()
         page_service.get_page.return_value = Mock(id="page-1")
         with (
-            patch("src.api_server.get_schedule_service", return_value=schedule_service),
-            patch("src.api_server.get_page_service", return_value=page_service),
+            patch("src.schedules.routes.get_schedule_service", return_value=schedule_service),
+            patch("src.schedules.routes.get_page_service", return_value=page_service),
         ):
             response = client.put(
                 "/schedules/default-page",
@@ -69,7 +73,7 @@ class TestScheduleWritesRejectUnknownBoards:
 
     def test_create_schedule_404s_and_persists_nothing(self, client, one_board):
         schedule_service = Mock()
-        with patch("src.api_server.get_schedule_service", return_value=schedule_service):
+        with patch("src.schedules.routes.get_schedule_service", return_value=schedule_service):
             response = client.post(
                 "/schedules",
                 json={
@@ -84,7 +88,7 @@ class TestScheduleWritesRejectUnknownBoards:
 
     def test_update_schedule_404s_and_does_not_reparent(self, client, one_board):
         schedule_service = Mock()
-        with patch("src.api_server.get_schedule_service", return_value=schedule_service):
+        with patch("src.schedules.routes.get_schedule_service", return_value=schedule_service):
             response = client.put("/schedules/sched-1", json={"board_id": "ghost-board"})
         assert response.status_code == 404
         schedule_service.update_schedule.assert_not_called()
@@ -95,7 +99,7 @@ class TestKnownAndOmittedBoardIdsStillWork:
 
     def test_known_board_id_is_accepted(self, client, one_board):
         schedule_service = Mock()
-        with patch("src.api_server.get_schedule_service", return_value=schedule_service):
+        with patch("src.schedules.routes.get_schedule_service", return_value=schedule_service):
             response = client.put("/schedules/enabled", json={"enabled": True, "board_id": "board-1"})
         assert response.status_code == 200
         one_board.set_schedule_enabled.assert_called_once()
@@ -123,14 +127,14 @@ class TestKnownAndOmittedBoardIdsStillWork:
         schedule_service.create_schedule.return_value = created
         compat = Mock(ok=True, warnings=[])
         with (
-            patch("src.api_server.get_schedule_service", return_value=schedule_service),
-            patch("src.api_server.check_ref_board_compatibility", return_value=compat),
+            patch("src.schedules.routes.get_schedule_service", return_value=schedule_service),
+            patch("src.schedules.routes.check_ref_board_compatibility", return_value=compat),
         ):
             response = client.post(
                 "/schedules",
                 json={"page_id": "page-1", "start_time": "09:00", "end_time": "17:00"},
             )
-        assert response.status_code == 200
+        assert response.status_code == 201  # 201 since the conventions pass
 
 
 class TestServiceLevelDefenceInDepth:
@@ -174,7 +178,7 @@ class TestReadsDeliberatelyFallBack:
         schedule_service = Mock()
         schedule_service.list_schedules.return_value = []
         schedule_service.get_default_page.return_value = None
-        with patch("src.api_server.get_schedule_service", return_value=schedule_service):
+        with patch("src.schedules.routes.get_schedule_service", return_value=schedule_service):
             response = client.get("/schedules", params={"board_id": "ghost-board"})
         assert response.status_code == 200
         assert response.json()["schedules"] == []

--- a/tests/test_page_board_compatibility.py
+++ b/tests/test_page_board_compatibility.py
@@ -48,6 +48,12 @@ def env(monkeypatch, tmp_path):
     monkeypatch.setattr("src.api_server.get_settings_service", lambda: settings)
     monkeypatch.setattr("src.api_server.get_collection_service", lambda: collection_service)
     monkeypatch.setattr("src.api_server.get_schedule_service", lambda: schedule_service)
+    # The schedules router binds its collaborators at import time now
+    # (Phase 2 §2.3), so the same stubs have to reach that module too.
+    monkeypatch.setattr("src.schedules.routes.get_schedule_service", lambda: schedule_service)
+    monkeypatch.setattr("src.schedules.routes.get_settings_service", lambda: settings)
+    monkeypatch.setattr("src.schedules.routes.get_page_service", lambda: page_service)
+    monkeypatch.setattr("src.schedules.routes.get_collection_service", lambda: collection_service)
     monkeypatch.setattr("src.api_server.get_service", lambda: None)
     monkeypatch.setattr("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False)
 
@@ -151,7 +157,7 @@ class TestScheduleRoutesCompatibility:
 
     def test_create_compatible_accepted(self, client, env):
         response = client.post("/schedules", json=self._payload(env["flagship_page"].id))
-        assert response.status_code == 200
+        assert response.status_code == 201  # 201 since the conventions pass
 
     def test_create_flagship_page_on_note_board_rejected_400(self, client, env):
         """Pin the multi-board e2e scenario: a default (flagship) page scheduled
@@ -170,11 +176,11 @@ class TestScheduleRoutesCompatibility:
     def test_create_note_page_on_note_board_accepted(self, client, env):
         """The compatible variant of the e2e scenario passes."""
         response = client.post("/schedules", json=self._payload(env["note_page"].id, board_id="board-note"))
-        assert response.status_code == 200
+        assert response.status_code == 201
 
     def test_create_collection_mixed_returns_warnings(self, client, env):
         response = client.post("/schedules", json=self._payload(env["mixed_collection"].id))
-        assert response.status_code == 200
+        assert response.status_code == 201
         warnings = response.json().get("warnings", [])
         assert len(warnings) == 1
         assert "Note Page" in warnings[0]

--- a/tests/test_persistence_round_trip.py
+++ b/tests/test_persistence_round_trip.py
@@ -104,7 +104,7 @@ def _create_schedule(client: TestClient, page_id: str) -> dict:
         "/schedules",
         json={"page_id": page_id, "start_time": "07:30", "end_time": "09:15", "day_pattern": "weekdays"},
     )
-    assert response.status_code == 200, response.text
+    assert response.status_code == 201, response.text  # 201 since the conventions pass
     return response.json()
 
 

--- a/tests/test_schedules_contract.py
+++ b/tests/test_schedules_contract.py
@@ -13,6 +13,36 @@ collaborator, so the seam retirement later in this PR cannot make these tests
 vacuously pass).
 
 All eleven routes are covered, including every 4xx body each one can produce.
+
+Re-pinned by the conventions pass in this same PR. What deliberately changed,
+and nothing else:
+
+* ``POST /schedules`` answers **201** (was 200) — conventions doc, "Status
+  codes". The body is unchanged apart from ``warnings`` below.
+* ``DELETE /schedules/{id}`` answers ``{"id": <deleted id>}`` (was
+  ``{"status": "success", "message": "Schedule <id> deleted"}``) — the doc
+  offers "200 with the deleted resource id" or "204 with no body"; this domain
+  picks the former, as collections did.
+* ``PUT /schedules/default-page`` answers the bare
+  ``{"default_page_id": ...}`` (was ``{"status": "success",
+  "default_page_id": ...}``), which is byte-identical to what ``GET`` on the
+  same path answers.
+* ``PUT /schedules/enabled`` answers the bare ``{"enabled": ...}`` (was
+  ``{"status", "enabled", "message"}``), matching its ``GET``.
+* Create/update carry ``warnings`` **always**, empty when clean (the key used
+  to be omitted when there was nothing to warn about).
+* ``GET /schedules/active/page`` always carries ``current_time``,
+  ``current_day`` and ``default_page_id``; they are ``null`` in manual mode
+  (the manual branch used to omit them, so one route served two key sets).
+* The three untyped ``dict`` bodies became Pydantic models, so a missing or
+  wrongly-typed field is FastAPI's standard **422** instead of a hand-rolled
+  400. The *rejection* is unchanged — notably ``{"enabled": "yes"}`` is still
+  refused, via ``StrictBool``, rather than coerced to ``true``.
+
+Every other value assertion — ids, times, resolved times, list ordering and
+total, gap and overlap contents, error strings, and the failure status codes on
+the 404 paths — is byte-identical to the pre-conversion recording. None was
+weakened.
 """
 
 from __future__ import annotations
@@ -66,7 +96,7 @@ def _create(client: TestClient, **body) -> dict:
     a one-line change instead of a sweep.
     """
     response = client.post("/schedules", json=body)
-    assert response.status_code == 200, response.text
+    assert response.status_code == 201, response.text  # RE-PINNED: 201 (was 200)
     return response.json()
 
 
@@ -76,7 +106,8 @@ def _create(client: TestClient, **body) -> dict:
 def test_create_returns_the_created_schedule_with_its_values(client, page_id):
     response = client.post("/schedules", json={"page_id": page_id, "start_time": "09:00", "end_time": "17:00"})
 
-    assert response.status_code == 200, response.text
+    # RE-PINNED: 201 (was 200). The body is unchanged apart from `warnings`.
+    assert response.status_code == 201, response.text
     schedule = response.json()
     assert schedule["page_id"] == page_id
     assert schedule["start_time"] == "09:00"
@@ -91,6 +122,7 @@ def test_create_returns_the_created_schedule_with_its_values(client, page_id):
     assert schedule["start_sun_offset"] == 0
     assert schedule["end_sun_offset"] == 0
     assert schedule["updated_at"] is None
+    assert schedule["warnings"] == []  # RE-PINNED: always present, was omitted when clean
 
 
 def test_create_mints_an_id_and_a_created_at(client, page_id):
@@ -249,7 +281,10 @@ def test_get_returns_the_schedule_by_id(client, page_id):
     response = client.get(f"/schedules/{created['id']}")
 
     assert response.status_code == 200
-    assert response.json() == created
+    # RE-PINNED: the read carries no `warnings`. Page<->board compatibility is
+    # computed on write, against the payload being written; recomputing it on
+    # every read would be a different (and much more expensive) claim.
+    assert response.json() == {k: v for k, v in created.items() if k != "warnings"}
 
 
 def test_get_missing_schedule_404s_naming_the_id(client):
@@ -319,7 +354,8 @@ def test_delete_removes_the_schedule(client, page_id):
     response = client.delete(f"/schedules/{created['id']}")
 
     assert response.status_code == 200
-    assert response.json() == {"status": "success", "message": f"Schedule {created['id']} deleted"}
+    # RE-PINNED: the deleted id (was {"status": "success", "message": ...}).
+    assert response.json() == {"id": created["id"]}
     assert client.get(f"/schedules/{created['id']}").status_code == 404
 
 
@@ -399,7 +435,9 @@ def test_set_default_page_stores_it_and_reads_back(client, page_id):
     response = client.put("/schedules/default-page", json={"page_id": page_id})
 
     assert response.status_code == 200
-    assert response.json() == {"status": "success", "default_page_id": page_id}
+    # RE-PINNED: bare body (was {"status": "success", "default_page_id": ...}),
+    # byte-identical to what GET on the same path answers.
+    assert response.json() == {"default_page_id": page_id}
     assert client.get("/schedules/default-page").json() == {"default_page_id": page_id}
 
 
@@ -409,15 +447,22 @@ def test_set_default_page_to_null_clears_it(client, page_id):
     response = client.put("/schedules/default-page", json={"page_id": None})
 
     assert response.status_code == 200
-    assert response.json() == {"status": "success", "default_page_id": None}
+    assert response.json() == {"default_page_id": None}  # RE-PINNED: bare body
     assert client.get("/schedules/default-page").json() == {"default_page_id": None}
 
 
-def test_set_default_page_without_page_id_400s(client):
+def test_set_default_page_without_page_id_422s(client):
+    """RE-PINNED: 422 (was a hand-rolled 400 "page_id parameter required").
+
+    The body is a Pydantic model now, so a missing required field is FastAPI's
+    standard validation error. The request is still refused, and nothing is
+    written.
+    """
     response = client.put("/schedules/default-page", json={})
 
-    assert response.status_code == 400
-    assert response.json() == {"detail": "page_id parameter required"}
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["loc"] == ["body", "page_id"]
+    assert client.get("/schedules/default-page").json() == {"default_page_id": None}
 
 
 def test_set_default_page_to_an_unknown_page_404s_naming_the_page(client):
@@ -465,7 +510,8 @@ def test_set_schedule_enabled_turns_it_on_and_reads_back(client):
     response = client.put("/schedules/enabled", json={"enabled": True})
 
     assert response.status_code == 200
-    assert response.json() == {"status": "success", "enabled": True, "message": "Schedule mode enabled"}
+    # RE-PINNED: bare body (was {"status", "enabled", "message"}), matching GET.
+    assert response.json() == {"enabled": True}
     assert client.get("/schedules/enabled").json() == {"enabled": True}
 
 
@@ -475,24 +521,32 @@ def test_set_schedule_enabled_turns_it_off_again(client):
     response = client.put("/schedules/enabled", json={"enabled": False})
 
     assert response.status_code == 200
-    assert response.json() == {"status": "success", "enabled": False, "message": "Schedule mode disabled"}
+    assert response.json() == {"enabled": False}  # RE-PINNED: bare body
     assert client.get("/schedules/enabled").json() == {"enabled": False}
 
 
-def test_set_schedule_enabled_without_the_flag_400s(client):
+def test_set_schedule_enabled_without_the_flag_422s(client):
+    """RE-PINNED: 422 (was a hand-rolled 400 "enabled parameter required")."""
     response = client.put("/schedules/enabled", json={})
 
-    assert response.status_code == 400
-    assert response.json() == {"detail": "enabled parameter required"}
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["loc"] == ["body", "enabled"]
+    assert client.get("/schedules/enabled").json() == {"enabled": False}
 
 
 def test_set_schedule_enabled_rejects_a_non_boolean(client):
     """A truthy string must not be coerced into "on" — that would silently turn
-    schedule mode on for a client that sent the wrong type."""
+    schedule mode on for a client that sent the wrong type.
+
+    RE-PINNED: 422 (was a hand-rolled 400 "enabled must be boolean"). The
+    rejection itself is what matters and is unchanged — Pydantic's lax mode
+    *would* have coerced "yes" to True, so the model declares ``StrictBool``.
+    """
     response = client.put("/schedules/enabled", json={"enabled": "yes"})
 
-    assert response.status_code == 400
-    assert response.json() == {"detail": "enabled must be boolean"}
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["loc"] == ["body", "enabled"]
+    assert client.get("/schedules/enabled").json() == {"enabled": False}
 
 
 def test_set_schedule_enabled_for_an_unknown_board_404s_and_writes_nothing(client):
@@ -527,15 +581,20 @@ def test_active_page_reports_the_manual_page_when_schedule_mode_is_off(client, p
     assert body["schedule_enabled"] is False
 
 
-def test_active_page_omits_the_clock_fields_in_manual_mode(client, page_id):
-    """The manual branch answers a different key set from the schedule branch."""
+def test_active_page_nulls_the_clock_fields_in_manual_mode(client, page_id):
+    """RE-PINNED: the three fields are present and null; they used to be absent.
+
+    One route served two key sets, so a client could not tell "manual mode" from
+    "this server does not report the current day". They are declared on
+    ``ActiveScheduleResponse`` now, and null is the manual-mode answer.
+    """
     client.put("/settings/active-page", json={"page_id": page_id})
 
     body = client.get("/schedules/active/page").json()
 
-    assert "current_time" not in body
-    assert "current_day" not in body
-    assert "default_page_id" not in body
+    assert body["current_time"] is None
+    assert body["current_day"] is None
+    assert body["default_page_id"] is None
 
 
 def test_active_page_reports_the_scheduled_page_when_schedule_mode_is_on(client, page_id):

--- a/tests/test_schedules_contract.py
+++ b/tests/test_schedules_contract.py
@@ -224,17 +224,20 @@ def test_wildcard_listing_reports_no_default_page(client, page_id):
     assert client.get("/schedules", params={"board_id": "*"}).json()["default_page_id"] is None
 
 
-def test_wildcard_listing_reports_enabled_false(client, page_id):
-    """KNOWN BUG, fixed in the next commit of this PR.
+def test_wildcard_listing_does_not_claim_schedule_mode_is_off(client, page_id):
+    """RE-PINNED (bug fix, this PR): ``enabled`` is ``null``, was hardcoded ``false``.
 
-    ``enabled`` is per-board, so the cross-board listing cannot answer it — but
-    the handler hardcodes ``False``, which is indistinguishable from "schedule
-    mode is off everywhere". Pinned here as it behaves *today* so the fix shows
-    up as a deliberate, reviewed diff rather than an unremarked change.
+    ``enabled`` is a per-board flag, so the cross-board listing cannot answer
+    it — exactly like ``default_page_id``, which the same branch already
+    answers with ``null``. Hardcoding ``false`` made "not applicable here"
+    indistinguishable from "schedule mode is off everywhere", which is a lie a
+    client cannot detect: with schedule mode ON for the only board, the
+    wildcard listing still said ``false``.
     """
     client.put("/schedules/enabled", json={"enabled": True})
 
-    assert client.get("/schedules", params={"board_id": "*"}).json()["enabled"] is False
+    assert client.get("/schedules/enabled").json()["enabled"] is True
+    assert client.get("/schedules", params={"board_id": "*"}).json()["enabled"] is None
 
 
 # ── GET /schedules/{schedule_id} ────────────────────────────────────────────

--- a/tests/test_schedules_contract.py
+++ b/tests/test_schedules_contract.py
@@ -1,0 +1,599 @@
+"""Value-level contract goldens for the /schedules API (Phase 2 §2, slice 2).
+
+These are deliberately *values*, not shapes. The shape corpus in
+``tests/golden/responses/schedules.json`` records key sets and type names, so it
+cannot see a schedule that came back with the wrong ``page_id``, a
+``resolved_start_time`` that stopped tracking ``start_time``, a gap list in the
+wrong order, or an error string that stopped naming the missing resource — the
+class of regression Phase 1's masking bug proved shape goldens miss.
+
+Every assertion below is a promise this domain makes to the web client, driven
+through the real services on an isolated data dir (no ``patch`` on any
+collaborator, so the seam retirement later in this PR cannot make these tests
+vacuously pass).
+
+All eleven routes are covered, including every 4xx body each one can produce.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+MISSING_ID = "00000000-dead-beef-0000-000000000000"
+GHOST_BOARD = "ghost-board"
+
+
+@pytest.fixture
+def client(_isolated_data_dir):
+    """A TestClient whose services all resolve into this test's temp data dir."""
+    from src.api_server import app
+
+    return TestClient(app)
+
+
+@pytest.fixture
+def board_id(client) -> str:
+    """The id of the single board a fresh install ships with."""
+    response = client.get("/settings/board")
+    assert response.status_code == 200, response.text
+    return response.json()["boards"][0]["id"]
+
+
+def _seed_page(client: TestClient, name: str, first_line: str) -> str:
+    response = client.post(
+        "/pages",
+        json={
+            "name": name,
+            "type": "template",
+            "device_type": "flagship",
+            "template": [first_line, "", "", "", "", ""],
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["page"]["id"]
+
+
+@pytest.fixture
+def page_id(client) -> str:
+    return _seed_page(client, "Contract Page A", "AAA")
+
+
+def _create(client: TestClient, **body) -> dict:
+    """POST /schedules and return the created schedule.
+
+    The one place that knows the create envelope, so re-pinning the envelope is
+    a one-line change instead of a sweep.
+    """
+    response = client.post("/schedules", json=body)
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+# ── POST /schedules ─────────────────────────────────────────────────────────
+
+
+def test_create_returns_the_created_schedule_with_its_values(client, page_id):
+    response = client.post("/schedules", json={"page_id": page_id, "start_time": "09:00", "end_time": "17:00"})
+
+    assert response.status_code == 200, response.text
+    schedule = response.json()
+    assert schedule["page_id"] == page_id
+    assert schedule["start_time"] == "09:00"
+    assert schedule["end_time"] == "17:00"
+    assert schedule["board_id"] == ""
+    assert schedule["day_pattern"] == "all"
+    assert schedule["custom_days"] is None
+    assert schedule["enabled"] is True
+    assert schedule["recurrence_type"] == "weekly"
+    assert schedule["start_type"] == "fixed"
+    assert schedule["end_type"] == "fixed"
+    assert schedule["start_sun_offset"] == 0
+    assert schedule["end_sun_offset"] == 0
+    assert schedule["updated_at"] is None
+
+
+def test_create_mints_an_id_and_a_created_at(client, page_id):
+    schedule = _create(client, page_id=page_id, start_time="09:00", end_time="17:00")
+
+    assert schedule["id"]
+    assert schedule["created_at"]
+
+
+def test_create_resolves_fixed_times_to_themselves(client, page_id):
+    """``resolved_*`` is what the client renders; for fixed schedules it must
+    equal the stored time, not a recomputed one."""
+    schedule = _create(client, page_id=page_id, start_time="09:00", end_time="17:00")
+
+    assert schedule["resolved_start_time"] == "09:00"
+    assert schedule["resolved_end_time"] == "17:00"
+
+
+def test_create_keeps_an_open_ended_schedule_open_ended(client, page_id):
+    schedule = _create(client, page_id=page_id, start_time="09:00", end_time=None)
+
+    assert schedule["end_time"] is None
+    assert schedule["resolved_end_time"] is None
+
+
+def test_create_rejects_a_zero_duration_schedule_with_400(client, page_id):
+    response = client.post("/schedules", json={"page_id": page_id, "start_time": "09:00", "end_time": "09:00"})
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": (
+            "Invalid schedule configuration: ['end_time must be different from start_time (zero-duration schedule)']"
+        )
+    }
+
+
+def test_create_rejects_an_unknown_board_with_404_naming_the_board(client, page_id):
+    response = client.post(
+        "/schedules",
+        json={"page_id": page_id, "start_time": "09:00", "end_time": "17:00", "board_id": GHOST_BOARD},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": f"Board not found: {GHOST_BOARD}"}
+
+
+def test_create_rejects_a_malformed_start_time_with_422(client, page_id):
+    response = client.post("/schedules", json={"page_id": page_id, "start_time": "9am", "end_time": "17:00"})
+
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["loc"] == ["body", "start_time"]
+
+
+def test_create_accepts_the_installs_real_board_id(client, page_id, board_id):
+    schedule = _create(client, page_id=page_id, start_time="09:00", end_time="17:00", board_id=board_id)
+
+    assert schedule["board_id"] == board_id
+
+
+# ── GET /schedules ──────────────────────────────────────────────────────────
+
+
+def test_list_is_empty_on_a_fresh_install(client):
+    response = client.get("/schedules")
+
+    assert response.status_code == 200
+    assert response.json() == {"schedules": [], "total": 0, "default_page_id": None, "enabled": False}
+
+
+def test_list_returns_the_created_schedules_and_a_matching_total(client, page_id):
+    first = _create(client, page_id=page_id, start_time="06:00", end_time="09:00")
+    second = _create(client, page_id=page_id, start_time="09:00", end_time="17:00")
+
+    body = client.get("/schedules").json()
+
+    assert body["total"] == 2
+    assert {s["id"] for s in body["schedules"]} == {first["id"], second["id"]}
+    assert [s["start_time"] for s in sorted(body["schedules"], key=lambda s: s["start_time"])] == ["06:00", "09:00"]
+
+
+def test_list_reports_the_default_page_and_the_enabled_flag(client, page_id):
+    client.put("/schedules/default-page", json={"page_id": page_id})
+    client.put("/schedules/enabled", json={"enabled": True})
+
+    body = client.get("/schedules").json()
+
+    assert body["default_page_id"] == page_id
+    assert body["enabled"] is True
+
+
+def test_list_scoped_to_the_primary_board_also_returns_legacy_unscoped_entries(client, page_id, board_id):
+    """``board_id=""`` is the pre-multi-board sentinel for "the default board",
+    so the primary board's listing has to include entries stored under it —
+    otherwise every schedule created before multi-board support would vanish
+    from the UI the moment a board id is passed."""
+    scoped = _create(client, page_id=page_id, start_time="06:00", end_time="09:00", board_id=board_id)
+    legacy = _create(client, page_id=page_id, start_time="09:00", end_time="17:00")
+
+    body = client.get("/schedules", params={"board_id": board_id}).json()
+
+    assert {s["id"] for s in body["schedules"]} == {scoped["id"], legacy["id"]}
+    assert body["total"] == 2
+
+
+def test_list_for_an_unknown_board_falls_back_to_empty_rather_than_404(client, page_id):
+    """Documented asymmetry — see the board_id note in API_CONVENTIONS.md.
+    Reads fall back; only writes 404."""
+    _create(client, page_id=page_id, start_time="09:00", end_time="17:00")
+
+    response = client.get("/schedules", params={"board_id": GHOST_BOARD})
+
+    assert response.status_code == 200
+    assert response.json()["schedules"] == []
+    assert response.json()["total"] == 0
+
+
+def test_wildcard_listing_returns_every_board(client, page_id, board_id):
+    scoped = _create(client, page_id=page_id, start_time="06:00", end_time="09:00", board_id=board_id)
+    unscoped = _create(client, page_id=page_id, start_time="09:00", end_time="17:00")
+
+    body = client.get("/schedules", params={"board_id": "*"}).json()
+
+    assert {s["id"] for s in body["schedules"]} == {scoped["id"], unscoped["id"]}
+    assert body["total"] == 2
+
+
+def test_wildcard_listing_reports_no_default_page(client, page_id):
+    """``default_page_id`` is per-board, so the cross-board listing has none."""
+    client.put("/schedules/default-page", json={"page_id": page_id})
+
+    assert client.get("/schedules", params={"board_id": "*"}).json()["default_page_id"] is None
+
+
+def test_wildcard_listing_reports_enabled_false(client, page_id):
+    """KNOWN BUG, fixed in the next commit of this PR.
+
+    ``enabled`` is per-board, so the cross-board listing cannot answer it — but
+    the handler hardcodes ``False``, which is indistinguishable from "schedule
+    mode is off everywhere". Pinned here as it behaves *today* so the fix shows
+    up as a deliberate, reviewed diff rather than an unremarked change.
+    """
+    client.put("/schedules/enabled", json={"enabled": True})
+
+    assert client.get("/schedules", params={"board_id": "*"}).json()["enabled"] is False
+
+
+# ── GET /schedules/{schedule_id} ────────────────────────────────────────────
+
+
+def test_get_returns_the_schedule_by_id(client, page_id):
+    created = _create(client, page_id=page_id, start_time="09:00", end_time="17:00")
+
+    response = client.get(f"/schedules/{created['id']}")
+
+    assert response.status_code == 200
+    assert response.json() == created
+
+
+def test_get_missing_schedule_404s_naming_the_id(client):
+    response = client.get(f"/schedules/{MISSING_ID}")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": f"Schedule not found: {MISSING_ID}"}
+
+
+# ── PUT /schedules/{schedule_id} ────────────────────────────────────────────
+
+
+def test_update_applies_only_the_supplied_fields(client, page_id):
+    created = _create(client, page_id=page_id, start_time="09:00", end_time="17:00")
+
+    response = client.put(f"/schedules/{created['id']}", json={"start_time": "10:00"})
+
+    assert response.status_code == 200
+    updated = response.json()
+    assert updated["id"] == created["id"]
+    assert updated["start_time"] == "10:00"
+    assert updated["end_time"] == "17:00"
+    assert updated["page_id"] == page_id
+
+
+def test_update_stamps_updated_at_and_re_resolves_the_times(client, page_id):
+    created = _create(client, page_id=page_id, start_time="09:00", end_time="17:00")
+
+    updated = client.put(f"/schedules/{created['id']}", json={"start_time": "10:00"}).json()
+
+    assert updated["updated_at"] is not None
+    assert updated["created_at"] == created["created_at"]
+    assert updated["resolved_start_time"] == "10:00"
+
+
+def test_update_missing_schedule_404s_naming_the_id(client):
+    response = client.put(f"/schedules/{MISSING_ID}", json={"start_time": "10:00"})
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": f"Schedule not found: {MISSING_ID}"}
+
+
+def test_update_rejects_an_unknown_board_with_404_naming_the_board(client, page_id):
+    created = _create(client, page_id=page_id, start_time="09:00", end_time="17:00")
+
+    response = client.put(f"/schedules/{created['id']}", json={"board_id": GHOST_BOARD})
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": f"Board not found: {GHOST_BOARD}"}
+
+
+def test_update_to_a_zero_duration_window_400s(client, page_id):
+    created = _create(client, page_id=page_id, start_time="09:00", end_time="17:00")
+
+    response = client.put(f"/schedules/{created['id']}", json={"end_time": "09:00"})
+
+    assert response.status_code == 400
+    assert "zero-duration schedule" in response.json()["detail"]
+
+
+# ── DELETE /schedules/{schedule_id} ─────────────────────────────────────────
+
+
+def test_delete_removes_the_schedule(client, page_id):
+    created = _create(client, page_id=page_id, start_time="09:00", end_time="17:00")
+
+    response = client.delete(f"/schedules/{created['id']}")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "success", "message": f"Schedule {created['id']} deleted"}
+    assert client.get(f"/schedules/{created['id']}").status_code == 404
+
+
+def test_delete_missing_schedule_404s_naming_the_id(client):
+    response = client.delete(f"/schedules/{MISSING_ID}")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": f"Schedule not found: {MISSING_ID}"}
+
+
+# ── POST /schedules/validate ────────────────────────────────────────────────
+
+
+def test_validate_reports_a_valid_empty_schedule_with_one_all_day_gap(client):
+    response = client.post("/schedules/validate")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "valid": True,
+        "overlaps": [],
+        "gaps": [
+            {
+                "start_time": "00:00",
+                "end_time": "23:59",
+                "days": ["friday", "monday", "saturday", "sunday", "thursday", "tuesday", "wednesday"],
+            }
+        ],
+    }
+
+
+def test_validate_names_both_sides_of_an_overlap(client, page_id):
+    first = _create(client, page_id=page_id, start_time="09:00", end_time="12:00")
+    second = _create(client, page_id=page_id, start_time="11:00", end_time="14:00")
+
+    body = client.post("/schedules/validate").json()
+
+    assert body["valid"] is False
+    assert len(body["overlaps"]) == 1
+    overlap = body["overlaps"][0]
+    assert {overlap["schedule1_id"], overlap["schedule2_id"]} == {first["id"], second["id"]}
+    assert overlap["conflict_description"]
+
+
+def test_validate_reports_the_gaps_around_a_single_schedule(client, page_id):
+    _create(client, page_id=page_id, start_time="09:00", end_time="17:00")
+
+    body = client.post("/schedules/validate").json()
+
+    assert body["valid"] is True
+    assert [(gap["start_time"], gap["end_time"]) for gap in body["gaps"]] == [
+        ("00:00", "09:00"),
+        ("17:00", "23:59"),
+    ]
+
+
+def test_validate_scopes_to_the_board_in_the_body(client, page_id, board_id):
+    _create(client, page_id=page_id, start_time="09:00", end_time="17:00", board_id=board_id)
+
+    unscoped = client.post("/schedules/validate", json={"board_id": ""}).json()
+    scoped = client.post("/schedules/validate", json={"board_id": board_id}).json()
+
+    assert [(g["start_time"], g["end_time"]) for g in unscoped["gaps"]] == [("00:00", "23:59")]
+    assert [(g["start_time"], g["end_time"]) for g in scoped["gaps"]] == [("00:00", "09:00"), ("17:00", "23:59")]
+
+
+# ── GET / PUT /schedules/default-page ───────────────────────────────────────
+
+
+def test_default_page_is_null_on_a_fresh_install(client):
+    response = client.get("/schedules/default-page")
+
+    assert response.status_code == 200
+    assert response.json() == {"default_page_id": None}
+
+
+def test_set_default_page_stores_it_and_reads_back(client, page_id):
+    response = client.put("/schedules/default-page", json={"page_id": page_id})
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "success", "default_page_id": page_id}
+    assert client.get("/schedules/default-page").json() == {"default_page_id": page_id}
+
+
+def test_set_default_page_to_null_clears_it(client, page_id):
+    client.put("/schedules/default-page", json={"page_id": page_id})
+
+    response = client.put("/schedules/default-page", json={"page_id": None})
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "success", "default_page_id": None}
+    assert client.get("/schedules/default-page").json() == {"default_page_id": None}
+
+
+def test_set_default_page_without_page_id_400s(client):
+    response = client.put("/schedules/default-page", json={})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "page_id parameter required"}
+
+
+def test_set_default_page_to_an_unknown_page_404s_naming_the_page(client):
+    response = client.put("/schedules/default-page", json={"page_id": MISSING_ID})
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": f"Page not found: {MISSING_ID}"}
+
+
+def test_set_default_page_to_an_unknown_collection_404s_naming_the_collection(client):
+    collection_ref = f"collection:{MISSING_ID}"
+
+    response = client.put("/schedules/default-page", json={"page_id": collection_ref})
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": f"Collection not found: {collection_ref}"}
+
+
+def test_set_default_page_for_an_unknown_board_404s_and_stores_nothing(client, page_id):
+    response = client.put("/schedules/default-page", json={"page_id": page_id, "board_id": GHOST_BOARD})
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": f"Board not found: {GHOST_BOARD}"}
+    assert client.get("/schedules/default-page", params={"board_id": GHOST_BOARD}).json() == {"default_page_id": None}
+
+
+def test_default_page_read_for_an_unknown_board_falls_back_rather_than_404(client):
+    response = client.get("/schedules/default-page", params={"board_id": GHOST_BOARD})
+
+    assert response.status_code == 200
+    assert response.json() == {"default_page_id": None}
+
+
+# ── GET / PUT /schedules/enabled ────────────────────────────────────────────
+
+
+def test_schedule_mode_is_off_on_a_fresh_install(client):
+    response = client.get("/schedules/enabled")
+
+    assert response.status_code == 200
+    assert response.json() == {"enabled": False}
+
+
+def test_set_schedule_enabled_turns_it_on_and_reads_back(client):
+    response = client.put("/schedules/enabled", json={"enabled": True})
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "success", "enabled": True, "message": "Schedule mode enabled"}
+    assert client.get("/schedules/enabled").json() == {"enabled": True}
+
+
+def test_set_schedule_enabled_turns_it_off_again(client):
+    client.put("/schedules/enabled", json={"enabled": True})
+
+    response = client.put("/schedules/enabled", json={"enabled": False})
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "success", "enabled": False, "message": "Schedule mode disabled"}
+    assert client.get("/schedules/enabled").json() == {"enabled": False}
+
+
+def test_set_schedule_enabled_without_the_flag_400s(client):
+    response = client.put("/schedules/enabled", json={})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "enabled parameter required"}
+
+
+def test_set_schedule_enabled_rejects_a_non_boolean(client):
+    """A truthy string must not be coerced into "on" — that would silently turn
+    schedule mode on for a client that sent the wrong type."""
+    response = client.put("/schedules/enabled", json={"enabled": "yes"})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "enabled must be boolean"}
+
+
+def test_set_schedule_enabled_for_an_unknown_board_404s_and_writes_nothing(client):
+    response = client.put("/schedules/enabled", json={"enabled": True, "board_id": GHOST_BOARD})
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": f"Board not found: {GHOST_BOARD}"}
+    assert client.get("/schedules/enabled", params={"board_id": GHOST_BOARD}).json() == {"enabled": False}
+
+
+def test_enabled_read_for_an_unknown_board_falls_back_rather_than_404(client):
+    response = client.get("/schedules/enabled", params={"board_id": GHOST_BOARD})
+
+    assert response.status_code == 200
+    assert response.json() == {"enabled": False}
+
+
+# ── GET /schedules/active/page ──────────────────────────────────────────────
+
+
+def test_active_page_reports_the_manual_page_when_schedule_mode_is_off(client, page_id):
+    client.put("/settings/active-page", json={"page_id": page_id})
+
+    response = client.get("/schedules/active/page")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["page_id"] == page_id
+    assert body["resolved_page_id"] == page_id
+    assert body["resolved_next_check_seconds"] is None
+    assert body["source"] == "manual"
+    assert body["schedule_enabled"] is False
+
+
+def test_active_page_omits_the_clock_fields_in_manual_mode(client, page_id):
+    """The manual branch answers a different key set from the schedule branch."""
+    client.put("/settings/active-page", json={"page_id": page_id})
+
+    body = client.get("/schedules/active/page").json()
+
+    assert "current_time" not in body
+    assert "current_day" not in body
+    assert "default_page_id" not in body
+
+
+def test_active_page_reports_the_scheduled_page_when_schedule_mode_is_on(client, page_id):
+    created = _create(client, page_id=page_id, start_time="00:00", end_time=None)
+    client.put("/schedules/enabled", json={"enabled": True})
+
+    body = client.get("/schedules/active/page").json()
+
+    assert body["page_id"] == page_id
+    assert body["resolved_page_id"] == page_id
+    assert body["source"] == "schedule"
+    assert body["schedule_enabled"] is True
+    assert len(body["current_time"]) == 5
+    assert body["current_day"] in {
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday",
+    }
+    assert created["page_id"] == body["page_id"]
+
+
+def test_active_page_reports_source_none_when_nothing_is_scheduled(client):
+    client.put("/schedules/enabled", json={"enabled": True})
+
+    body = client.get("/schedules/active/page").json()
+
+    assert body["page_id"] is None
+    assert body["source"] == "none"
+    assert body["schedule_enabled"] is True
+
+
+def test_active_page_carries_the_inactive_temporary_override_block(client, page_id):
+    client.put("/settings/active-page", json={"page_id": page_id})
+
+    override = client.get("/schedules/active/page").json()["temporary_override"]
+
+    assert override == {
+        "active": False,
+        "page_id": None,
+        "expires_at": None,
+        "remaining_seconds": None,
+        "revert_mode": None,
+        "revert_page_id": None,
+        "template": None,
+        "line_metadata": None,
+        "device_type": None,
+        "notes_wide": None,
+        "notes_tall": None,
+    }
+
+
+def test_active_page_carries_an_active_temporary_override(client, page_id):
+    client.post("/settings/temporary-override", json={"page_id": page_id, "duration_minutes": 30})
+
+    override = client.get("/schedules/active/page").json()["temporary_override"]
+
+    assert override["active"] is True
+    assert override["page_id"] == page_id
+    assert override["revert_mode"] == "schedule"
+    assert override["remaining_seconds"] is not None

--- a/tests/test_schedules_decoupled.py
+++ b/tests/test_schedules_decoupled.py
@@ -1,0 +1,199 @@
+"""The schedules router must not depend on ``src.api_server`` (Phase 2 §2.3).
+
+The #1756 extraction moved the eleven schedule handlers out of the 10k-line
+``src/api_server.py`` but left eleven call-time ``from src.api_server import
+...`` statements behind, purely so the suite's ``patch("src.api_server.<name>")``
+targets kept resolving. That is not an extraction: importing the router was
+clean, but *serving a request* pulled the whole module — its route table, its
+background tasks, its MCP mount — back in, and the 2026-09 audit counted those
+seams going up 4.2x across Phase 1.
+
+Retiring them needed three names to grow a canonical home first, because they
+had none outside the app module: ``require_board`` (now ``src/boards.py``),
+``resolve_active_page_id`` / ``resolve_next_check_seconds`` (now
+``src/collections/service.py``) and ``temporary_override_payload`` (now
+``src/settings/service.py``).
+
+This test pins the fix the honest way. In a fresh interpreter it imports the
+router, drives all eleven handlers end to end against patched canonical seams
+(``src.schedules.routes.<name>``), asserts the stubs really were driven — so a
+handler that silently no-op'd could not pass — and then asserts
+``src.api_server`` never entered ``sys.modules``.
+
+Importing the module alone would be a much weaker claim: the seams were call
+time, so a module-level import check passes even with every one of them still
+in place.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SCRIPT = r"""
+import asyncio
+import sys
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import src.schedules.routes as routes
+from src.schedules.models import (
+    DefaultPageUpdate,
+    ScheduleCreate,
+    ScheduleEnabledUpdate,
+    ScheduleEntry,
+    ScheduleUpdate,
+    ScheduleValidateRequest,
+    ScheduleValidationResult,
+)
+
+assert "src.api_server" not in sys.modules, "importing the schedules router must not import api_server"
+
+
+def call(coro):
+    return asyncio.run(coro)
+
+
+sample = ScheduleEntry(id="sched-1", board_id="board-1", page_id="p1", start_time="09:00", end_time="17:00")
+
+schedule_service = MagicMock()
+schedule_service.list_schedules.return_value = [sample]
+schedule_service.get_schedule.return_value = sample
+schedule_service.create_schedule.return_value = sample
+schedule_service.update_schedule.return_value = sample
+schedule_service.delete_schedule.return_value = True
+schedule_service.get_default_page.return_value = "p1"
+schedule_service.get_active_page_id.return_value = "p1"
+schedule_service.validate_schedules.return_value = ScheduleValidationResult(valid=True, overlaps=[], gaps=[])
+
+settings_service = MagicMock()
+settings_service.is_schedule_enabled.return_value = True
+settings_service.get_temporary_override.return_value = None
+settings_service.get_active_page_id.return_value = "p1"
+
+page_service = MagicMock()
+page_service.get_page.return_value = object()
+
+time_service = MagicMock()
+time_service.get_current_time.return_value = datetime(2026, 9, 7, 10, 30)
+
+compat = MagicMock()
+compat.ok = True
+compat.warnings = ["mixed sizes"]
+
+with (
+    patch("src.schedules.routes.get_schedule_service", return_value=schedule_service),
+    patch("src.schedules.routes.get_settings_service", return_value=settings_service),
+    patch("src.schedules.routes.get_page_service", return_value=page_service),
+    patch("src.schedules.routes.get_time_service", return_value=time_service),
+    patch("src.schedules.routes.check_ref_board_compatibility", return_value=compat),
+    patch("src.schedules.routes.require_board") as require_board,
+):
+    listed = call(routes.list_schedules())
+    assert listed.total == 1, listed
+    assert listed.schedules[0].id == "sched-1"
+    assert listed.default_page_id == "p1"
+    assert listed.enabled is True
+
+    wildcard = call(routes.list_schedules(board_id="*"))
+    assert wildcard.enabled is None, wildcard
+
+    created = call(routes.create_schedule(ScheduleCreate(board_id="board-1", page_id="p1", start_time="09:00")))
+    assert created["id"] == "sched-1", created
+    assert created["warnings"] == ["mixed sizes"], created
+
+    active = call(routes.get_active_schedule())
+    assert active.page_id == "p1", active
+    assert active.source == "schedule", active
+    assert active.current_time == "10:30", active
+    assert active.temporary_override.active is False, active
+
+    settings_service.is_schedule_enabled.return_value = False
+    manual = call(routes.get_active_schedule())
+    assert manual.source == "manual", manual
+    assert manual.current_time is None, manual
+    settings_service.is_schedule_enabled.return_value = True
+
+    validated = call(routes.validate_schedules(ScheduleValidateRequest(board_id="board-1")))
+    assert validated.valid is True, validated
+
+    default_page = call(routes.get_default_page())
+    assert default_page.default_page_id == "p1", default_page
+
+    set_default = call(routes.set_default_page(DefaultPageUpdate(page_id="p1", board_id="board-1")))
+    assert set_default.default_page_id == "p1", set_default
+
+    enabled = call(routes.get_schedule_enabled())
+    assert enabled.enabled is True, enabled
+
+    set_enabled = call(routes.set_schedule_enabled(ScheduleEnabledUpdate(enabled=True, board_id="board-1")))
+    assert set_enabled.enabled is True, set_enabled
+
+    fetched = call(routes.get_schedule("sched-1"))
+    assert fetched["id"] == "sched-1", fetched
+
+    updated = call(routes.update_schedule("sched-1", ScheduleUpdate(board_id="board-1")))
+    assert updated["id"] == "sched-1", updated
+
+    deleted = call(routes.delete_schedule("sched-1"))
+    assert deleted.id == "sched-1", deleted
+
+# Not vacuous: the handlers really drove their collaborators. A handler that
+# silently returned a canned value would fail here rather than pass above.
+schedule_service.list_schedules.assert_any_call(board_id=None)
+schedule_service.list_schedules.assert_any_call(board_id="*")
+schedule_service.create_schedule.assert_called_once()
+schedule_service.get_schedule.assert_called_once_with("sched-1")
+schedule_service.update_schedule.assert_called_once()
+schedule_service.delete_schedule.assert_called_once_with("sched-1")
+schedule_service.set_default_page.assert_called_once_with("p1", board_id="board-1")
+schedule_service.validate_schedules.assert_called_once_with(board_id="board-1")
+schedule_service.get_active_page_id.assert_called_once()
+settings_service.set_schedule_enabled.assert_called_once_with(True, board_id="board-1")
+settings_service.get_temporary_override.assert_called()
+page_service.get_page.assert_called_with("p1")
+time_service.get_current_time.assert_called()
+# Every board-scoped write validated the board through the shared helper.
+assert require_board.call_count == 4, require_board.call_args_list
+
+assert "src.api_server" not in sys.modules, (
+    "a schedules handler imported src.api_server — the call-time seam regrew"
+)
+print("DECOUPLED")
+"""
+
+
+def test_schedules_router_serves_every_route_without_importing_api_server():
+    result = subprocess.run(
+        [sys.executable, "-c", SCRIPT],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    assert "DECOUPLED" in result.stdout
+
+
+def test_schedules_router_source_declares_no_api_server_import():
+    """A static backstop over every branch, not just the exercised ones.
+
+    The subprocess test above can only catch a seam on a code path it drives.
+    This walks the module's AST, so an ``import api_server`` hidden inside a
+    rarely-taken ``except`` branch fails the build too.
+    """
+    import ast
+
+    tree = ast.parse((REPO_ROOT / "src" / "schedules" / "routes.py").read_text())
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            offenders += [a.name for a in node.names if "api_server" in a.name]
+        elif isinstance(node, ast.ImportFrom) and "api_server" in (node.module or ""):
+            offenders.append(node.module)
+
+    assert offenders == [], f"src/schedules/routes.py imports api_server: {offenders}"

--- a/tests/test_temporary_override.py
+++ b/tests/test_temporary_override.py
@@ -32,10 +32,18 @@ def settings_service(tmp_settings_file):
 
 @pytest.fixture
 def client(settings_service):
-    """TestClient with the settings service singleton patched."""
-    with patch("src.api_server.get_settings_service", return_value=settings_service):
-        with patch("src.settings.service.get_settings_service", return_value=settings_service):
-            yield TestClient(app)
+    """TestClient with the settings service singleton patched.
+
+    ``src.schedules.routes`` binds ``get_settings_service`` at import time since
+    the Phase 2 conventions pass, so GET /schedules/active/page needs its own
+    stub here rather than inheriting the app module's.
+    """
+    with (
+        patch("src.api_server.get_settings_service", return_value=settings_service),
+        patch("src.settings.service.get_settings_service", return_value=settings_service),
+        patch("src.schedules.routes.get_settings_service", return_value=settings_service),
+    ):
+        yield TestClient(app)
 
 
 @pytest.fixture

--- a/tests/test_temporary_override_inline.py
+++ b/tests/test_temporary_override_inline.py
@@ -228,6 +228,9 @@ def client(settings_service):
     with (
         patch("src.api_server.get_settings_service", return_value=settings_service),
         patch("src.settings.service.get_settings_service", return_value=settings_service),
+        # The schedules router binds its collaborators at import time since the
+        # Phase 2 conventions pass, so GET /schedules/active/page reads these.
+        patch("src.schedules.routes.get_settings_service", return_value=settings_service),
         patch("src.api_server.get_page_service", return_value=page_service_mock),
         patch("src.api_server.get_collection_service") as mock_cs,
     ):

--- a/web/src/__tests__/api-extended.test.ts
+++ b/web/src/__tests__/api-extended.test.ts
@@ -331,9 +331,7 @@ describe("API Extended Tests", () => {
           const body = (await request.json()) as any;
           return HttpResponse.json({ id: params.id, ...body });
         }),
-        http.delete(`${API_BASE}/schedules/:id`, () =>
-          HttpResponse.json({ status: "success", message: "Schedule deleted" }),
-        ),
+        http.delete(`${API_BASE}/schedules/:id`, ({ params }) => HttpResponse.json({ id: params.id })),
       );
     });
 
@@ -370,8 +368,9 @@ describe("API Extended Tests", () => {
     });
 
     it("deleteSchedule sends DELETE", async () => {
+      // The delete response is the bare deleted id since the conventions pass.
       const result = await api.deleteSchedule("sched-1");
-      expect(result.status).toBe("success");
+      expect(result.id).toBe("sched-1");
     });
 
     it("getActiveSchedule without boardId", async () => {
@@ -411,7 +410,7 @@ describe("API Extended Tests", () => {
       server.use(
         http.put(`${API_BASE}/schedules/default-page`, async ({ request }) => {
           capturedBody = await request.json();
-          return HttpResponse.json({ status: "success", default_page_id: capturedBody.page_id });
+          return HttpResponse.json({ default_page_id: capturedBody.page_id });
         }),
       );
 
@@ -435,7 +434,7 @@ describe("API Extended Tests", () => {
       server.use(
         http.put(`${API_BASE}/schedules/enabled`, async ({ request }) => {
           capturedBody = await request.json();
-          return HttpResponse.json({ status: "success", enabled: capturedBody.enabled, message: "ok" });
+          return HttpResponse.json({ enabled: capturedBody.enabled });
         }),
       );
 

--- a/web/src/lib/api/schedules.ts
+++ b/web/src/lib/api/schedules.ts
@@ -94,8 +94,10 @@ export interface ScheduleUpdate {
 export interface SchedulesResponse {
   schedules: ScheduleEntry[];
   total: number;
+  // Both per-board fields are null on the cross-board listing
+  // (`board_id=*`), which has no single board to answer for.
   default_page_id: string | null;
-  enabled: boolean;
+  enabled: boolean | null;
 }
 
 export interface Overlap {

--- a/web/src/lib/api/schedules.ts
+++ b/web/src/lib/api/schedules.ts
@@ -168,10 +168,12 @@ export interface ActiveScheduleResponse {
   resolved_next_check_seconds?: number | null;
   source: "schedule" | "manual" | "none";
   schedule_enabled: boolean;
-  current_time?: string;
-  current_day?: string;
-  default_page_id?: string | null;
-  temporary_override?: TemporaryOverrideStatus;
+  // Always present; null in manual mode, when there is no clock reading to
+  // report and no per-board default to name.
+  current_time: string | null;
+  current_day: string | null;
+  default_page_id: string | null;
+  temporary_override: TemporaryOverrideStatus;
 }
 
 export interface ScheduleEnabledResponse {
@@ -180,6 +182,21 @@ export interface ScheduleEnabledResponse {
 
 export interface DefaultPageResponse {
   default_page_id: string | null;
+}
+
+/**
+ * What POST/PUT /schedules answer with: the schedule, plus the non-fatal
+ * page<->board size mismatches of issue #1245. `warnings` is always present
+ * and empty when there is nothing to report — reads (GET, list) do not carry
+ * it, because compatibility is computed against the payload being written.
+ */
+export interface ScheduleWriteResponse extends ScheduleEntry {
+  warnings: string[];
+}
+
+/** DELETE /schedules/{id} answers with the id it removed. */
+export interface ScheduleDeleteResponse {
+  id: string;
 }
 
 export type SilenceMode = "indicator" | "freeze" | "page";
@@ -221,7 +238,7 @@ export const schedulesApi = {
     fetchApi<SchedulesResponse>(boardId ? `/schedules?board_id=${encodeURIComponent(boardId)}` : "/schedules"),
 
   createSchedule: (data: ScheduleCreate) =>
-    fetchApi<ScheduleEntry>("/schedules", {
+    fetchApi<ScheduleWriteResponse>("/schedules", {
       method: "POST",
       body: JSON.stringify(data),
     }),
@@ -229,13 +246,13 @@ export const schedulesApi = {
   getSchedule: (scheduleId: string) => fetchApi<ScheduleEntry>(`/schedules/${scheduleId}`),
 
   updateSchedule: (scheduleId: string, data: ScheduleUpdate) =>
-    fetchApi<ScheduleEntry>(`/schedules/${scheduleId}`, {
+    fetchApi<ScheduleWriteResponse>(`/schedules/${scheduleId}`, {
       method: "PUT",
       body: JSON.stringify(data),
     }),
 
   deleteSchedule: (scheduleId: string) =>
-    fetchApi<{ status: string; message: string }>(`/schedules/${scheduleId}`, {
+    fetchApi<ScheduleDeleteResponse>(`/schedules/${scheduleId}`, {
       method: "DELETE",
     }),
 
@@ -256,7 +273,7 @@ export const schedulesApi = {
     ),
 
   setDefaultPage: (pageId: string | null, boardId?: string) =>
-    fetchApi<{ status: string; default_page_id: string | null }>("/schedules/default-page", {
+    fetchApi<DefaultPageResponse>("/schedules/default-page", {
       method: "PUT",
       body: JSON.stringify({ page_id: pageId, ...(boardId != null && { board_id: boardId }) }),
     }),
@@ -267,7 +284,7 @@ export const schedulesApi = {
     ),
 
   setScheduleEnabled: (enabled: boolean, boardId?: string) =>
-    fetchApi<{ status: string; enabled: boolean; message: string }>("/schedules/enabled", {
+    fetchApi<ScheduleEnabledResponse>("/schedules/enabled", {
       method: "PUT",
       body: JSON.stringify({ enabled, ...(boardId != null && { board_id: boardId }) }),
     }),

--- a/web/tests/api-extended.spec.ts
+++ b/web/tests/api-extended.spec.ts
@@ -229,7 +229,7 @@ test.describe("API – Schedules (extended)", () => {
     });
     expect(res.ok).toBe(true);
     const data = await res.json();
-    expect(data.status).toBe("success");
+    // Phase 2 conventions: unwrapped body, no status envelope.
     expect(data.default_page_id).toBe(pageId);
   });
 

--- a/web/tests/api.spec.ts
+++ b/web/tests/api.spec.ts
@@ -136,7 +136,9 @@ test.describe("API – Pages", () => {
     });
     expect(deleteRes.ok).toBe(true);
     const deleted = await deleteRes.json();
-    expect(deleted.status).toBe("success");
+    // Phase 2 conventions: delete returns the deleted id, not a status
+    // envelope (bare bodies; the HTTP status carries success).
+    expect(deleted.id).toBe(scheduleId);
   });
 });
 

--- a/web/tests/api.spec.ts
+++ b/web/tests/api.spec.ts
@@ -136,9 +136,7 @@ test.describe("API – Pages", () => {
     });
     expect(deleteRes.ok).toBe(true);
     const deleted = await deleteRes.json();
-    // Phase 2 conventions: delete returns the deleted id, not a status
-    // envelope (bare bodies; the HTTP status carries success).
-    expect(deleted.id).toBe(scheduleId);
+    expect(deleted.status).toBe("success");
   });
 });
 
@@ -207,7 +205,9 @@ test.describe("API – Schedules", () => {
     });
     expect(deleteRes.ok).toBe(true);
     const deleted = await deleteRes.json();
-    expect(deleted.status).toBe("success");
+    // Phase 2 conventions: delete answers with the deleted id, not a status
+    // envelope — the HTTP status already carries success.
+    expect(deleted.id).toBe(scheduleId);
   });
 });
 


### PR DESCRIPTION
Phase 2 vertical slice 2 (spec §2, plan Task 4): the **schedules** domain — eleven routes — gets value goldens, the four API conventions, seam retirement, and the lockstep web change, in the shape the collections pilot (#1891) established.

## What lands

**1. Value-level contract goldens, green before any change** (`tests/test_schedules_contract.py`, 50 tests)

All eleven routes and every 4xx body, driven through the real services on an isolated data dir — no collaborator patched, so the seam retirement later in the PR cannot make them vacuously pass. Two surprising behaviors got explicit pins: `board_id=<primary>` also returns legacy `board_id=""` entries (asymmetric, load-bearing for pre-multi-board installs), and the wildcard listing's hardcoded `enabled: false`.

**2. The domain bug: `GET /schedules?board_id=*` claimed schedule mode was off**

`enabled` was hardcoded `false` on the cross-board listing — a claim a client cannot tell apart from "schedule mode is off on every board". With schedule mode **on** for the only board, it still answered `false`. It is per-board, exactly like `default_page_id`, which the same branch already answered `null`. Both are `null` now.

Fail-first, observed before the change:

```
tests/test_schedules_contract.py:240: in test_wildcard_listing_does_not_claim_schedule_mode_is_off
    assert client.get("/schedules", params={"board_id": "*"}).json()["enabled"] is None
E   assert False is None
```

**3. The conventions pass**

`response_model=` on all eleven routes · `POST /schedules` → **201** · `DELETE` → `{"id": ...}` · the two `PUT`s answer the bare bodies their `GET` siblings answer · three bare `dict` bodies became Pydantic models · declared errors through the shared `errors(*codes)` helper.

Two shapes stopped being conditional, because a key that is *sometimes* absent cannot be told apart from a server that never sends it: `warnings` is always present on create/update (empty when clean), and `current_time` / `current_day` / `default_page_id` are always present on `GET /schedules/active/page` (null in manual mode).

`ScheduleEnabledUpdate.enabled` is a **`StrictBool`**. Lax Pydantic would coerce `{"enabled": "yes"}` to `true` and silently turn schedule mode on; the old hand-rolled check refused it, and so does this. The refusal is preserved — only its status code moved (400 → 422).

**4. Seams retired**

The router did **eleven** call-time `from src.api_server import ...` statements. All gone. Three collaborators had no canonical home outside the 10k-line app module and were given one:

| moved | to |
| --- | --- |
| `require_board` / `find_board` | new `src/boards.py` |
| `resolve_active_page_id` / `resolve_next_check_seconds` | `src/collections/service.py` |
| `temporary_override_payload` + a declared `TemporaryOverrideStatus` | `src/settings/service.py` |

Each takes the collaborator **accessor as a parameter** instead of reading a module global, and `api_server` keeps thin wrappers passing its own bindings. That is what keeps ~30 existing `patch("src.api_server.get_settings_service")` / `get_collection_service` sites live for the handlers that still live there. This was measured, not guessed: hiding the lookups behind globals broke **66** tests; the boards fix took it to 37, the resolvers fix to 1.

`tests/test_schedules_decoupled.py` pins the result two ways — a subprocess driving all eleven handlers against patched canonical seams (asserting the stubs were really driven, including that all four board-scoped writes called `require_board`), plus an AST scan for branches no test drives. Both mutation-proven by reinstating one call-time import:

```
FAILED tests/test_schedules_decoupled.py::test_schedules_router_serves_every_route_without_importing_api_server
FAILED tests/test_schedules_decoupled.py::test_schedules_router_source_declares_no_api_server_import
E   AssertionError: src/schedules/routes.py imports api_server: ['src.api_server']
```

**5. The ratchet**

`"schedules"` added to `converted_domains`. Fail-first, with the domain unconverted, three of four rules fired on real routes (11 missing `response_model`, 3 bare `dict` bodies, 11 undeclared 4xx). Five `declared_errors` exceptions are checked in — one per read-only route with no failure path — each naming why: board-scoped **reads deliberately fall back** rather than 404 (#1888), and an inconsistent schedule set is the verdict `POST /schedules/validate` exists to report.

The board_id validation from #1893 is preserved, not redone: `_require_board` moved but every write still 404s, and the read-path fallback decision has its own pins in `tests/test_board_id_validation.py`.

## Goldens

`tests/golden/responses/schedules.json` changes in exactly nine places, every one listed above. `tests/golden/api_routes.json` is unchanged. No other domain's corpus moved.

## Verification

| gate | result |
| --- | --- |
| Full pytest suite | **5920 passed / 2 skipped**, vs a **5868 / 2** baseline on the same tree (+50 contract, +2 decoupling) |
| Only failure | `test_check_image_formats.py::TestRepositoryIsClean` — the documented worktree-environment failure, identical on the baseline |
| Data-dir leaks | **0**, verified with an explicit `-v /tmp/probe:/app/data` mount |
| Conventions ratchet | green with `schedules` converted |
| Web | `tsc --noEmit` clean, **1621 vitest tests** pass, prettier + eslint clean |
| Ruff | `0.16.5` format + check clean |

## Note for the reviewer

`src/api_errors.py` is added here **byte-identical** to the copy in the collections slice (#1891), which is still open. Whichever lands first, the other's copy merges as an identical add. If #1891 lands first, this file's diff hunk simply disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP
