### PR TITLE
feat(pages): Phase 2 slice 3 — conventions, seam retirement, web lockstep

### DIFF
--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -52,6 +52,13 @@ When using the default deployment, prefix all paths with `/api` (e.g. `GET http:
 | `DELETE` | `/pages/{id}` | Delete a page |
 | `POST` | `/pages/{id}/preview` | Preview a page (with variables resolved) |
 
+`POST /pages` answers **201** with the created page itself, and
+`POST /pages/import` does the same. `PUT /pages/{id}` answers
+`{"page": {...}, "incompatible_references": [...]}` — the second key lists
+schedules and active-page references that no longer fit after a device/size
+change, and is empty otherwise. Failures are `{"detail": "<message>"}` with a
+4xx or 5xx status; no endpoint reports an error with HTTP 200.
+
 ### Page Fields
 
 When creating or updating a page, the following fields are available:

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -35,6 +35,19 @@ from .auth import is_auth_enabled  # noqa: E402
 from .auth.middleware import AuthMiddleware  # noqa: E402
 from .auth.routes import router as auth_router  # noqa: E402
 from .board_client import board_client_from_board_dict  # noqa: E402
+
+# Board lookup / send guards and the DisplayService accessor now live in
+# neutral modules so the extracted routers can import them directly instead of
+# reaching back into this one at call time (Phase 2 §2.3). They stay bound as
+# `src.api_server.<name>` here: this module's own handlers use them, and the
+# suite patches them at that path for those handlers.
+from .board_guards import (  # noqa: E402
+    _board_dims,
+    _board_is_paused,
+    _find_board,
+    _require_board,
+    _silence_active,
+)
 from .board_send_executor import run_board_send  # noqa: E402
 from .boards import find_board, require_board  # noqa: E402
 from .collections.models import is_collection_id  # noqa: E402
@@ -51,8 +64,8 @@ from .config import Config  # noqa: E402
 # tests that patch `src.api_server.<name>` keep working.
 from .config_manager import get_config_manager, unmask_sensitive_values  # noqa: E402, F401
 from .devices import classify_dimensions, resolve_dimensions  # noqa: E402
+from .display_runtime import get_service, peek_service  # noqa: E402
 from .displays.service import get_display_service, reset_display_service  # noqa: E402, F401
-from .main import DisplayService  # noqa: E402
 from .network.wifi import WiFiError, get_wifi_service  # noqa: E402
 from .pages.service import (  # noqa: E402
     check_ref_board_compatibility,
@@ -299,8 +312,9 @@ def _validate_board_host_is_local_network(host: str) -> None:
 
 
 # Global service instance
-_service: DisplayService | None = None
-_service_lock = threading.Lock()
+# The DisplayService singleton itself lives in src/display_runtime.py so the
+# extracted routers can reach it without importing this module (Phase 2 §2.3).
+# The background-thread lifecycle below is server lifecycle and stays here.
 _service_thread: threading.Thread | None = None
 _service_running = False
 _service_start_time: float | None = None  # Track when service started
@@ -778,8 +792,9 @@ async def lifespan(app: FastAPI):
     logger.info("API server shutting down...")
     _shutting_down = True
     _service_running = False
-    if _service:
-        _service.running = False
+    running_service = peek_service()
+    if running_service:
+        running_service.running = False
 
     # Stop MQTT client
     try:
@@ -928,38 +943,6 @@ log_buffer_handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(le
 logging.getLogger().addHandler(log_buffer_handler)
 
 
-def get_service() -> DisplayService | None:
-    """Get or create the service instance."""
-    global _service
-    if _service is None:
-        with _service_lock:
-            if _service is None:
-                try:
-                    _service = DisplayService()
-                    if not _service.initialize():
-                        logger.warning(
-                            "Service initialization failed - service can be started later when configuration is fixed"
-                        )
-                        # Keep the service instance but mark it as uninitialized
-                        # This allows the /start endpoint to retry initialization
-                        return _service
-                except Exception as e:
-                    logger.error(f"Failed to create service: {e}", exc_info=True)
-                    return None
-    return _service
-
-
-def peek_service() -> DisplayService | None:
-    """Return the existing DisplayService instance without creating one.
-
-    For callers that only need to touch state that already exists (e.g.
-    invalidating dedupe caches after an out-of-band board write, issue
-    #1794): when no service exists there is nothing to invalidate, and
-    building one as a side effect would be wrong.
-    """
-    return _service
-
-
 def _publish_mqtt_state_update() -> None:
     """Push fresh MQTT state after an out-of-band board write (issue #1794).
 
@@ -1064,8 +1047,9 @@ def stop_display_service_sync() -> bool:
     if not _service_running:
         return True
     _shutting_down = True
-    if _service:
-        _service.running = False
+    running_service = peek_service()
+    if running_service:
+        running_service.running = False
     _service_running = False
     return True
 
@@ -2196,8 +2180,9 @@ async def stop_service():
         return {"status": "not_running", "message": "Service is not running"}
 
     _shutting_down = True  # Prevent auto-restart
-    if _service:
-        _service.running = False
+    running_service = peek_service()
+    if running_service:
+        running_service.running = False
         _service_running = False
 
     return {"status": "stopped", "message": "Service stopped successfully"}
@@ -4748,32 +4733,6 @@ def _ensure_transition_plugins_beta() -> None:
         )
 
 
-def _reject_plugin_strategy_when_beta_off(strategy: str | None) -> None:
-    """Reject ``plugin:<id>`` strategies when the transition-plugin beta
-    flag is off.
-
-    Applied to page create / update so a page can't persist a plugin
-    strategy that the runtime won't actually honor.  Symmetric with the
-    settings-service guard on ``update_transition_settings``.
-    """
-    if not isinstance(strategy, str):
-        return
-    from .settings.service import TRANSITION_PLUGIN_PREFIX  # local: avoid cycle
-
-    if not strategy.startswith(TRANSITION_PLUGIN_PREFIX):
-        return
-    settings_service = get_settings_service()
-    if not settings_service.get_beta_settings().transition_plugins_enabled:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                "Transition plugins are an experimental beta. Enable them "
-                "in Settings → Beta before assigning a 'plugin:<id>' "
-                "strategy to a page."
-            ),
-        )
-
-
 @app.get("/transitions/plugins")
 async def list_transition_plugins():
     """List installed transition plugins available for selection.
@@ -6411,79 +6370,6 @@ def _get_first_board_dims():
     except Exception as exc:
         logger.debug("Could not resolve board dims (using flagship default): %s", exc)
     return resolve_dimensions("flagship")
-
-
-def _find_board(board_id: str) -> dict | None:
-    """This module's binding of :func:`src.boards.find_board`.
-
-    Kept as a wrapper rather than an import alias so the lookup goes on
-    resolving through *this* module's ``get_settings_service`` — the name the
-    suite stubs when it exercises the handlers that still live here.
-    """
-    return find_board(board_id, get_settings_service())
-
-
-def _require_board(board_id: str) -> dict:
-    """This module's binding of :func:`src.boards.require_board`. See above."""
-    return require_board(board_id, get_settings_service())
-
-
-def _board_dims(board: dict):
-    """Resolved dimensions for a settings.boards entry (flagship fallback).
-
-    Uses resolve_dimensions — never get_dimensions, which raises for
-    note_array boards. Safe to call from any endpoint — never raises.
-    """
-    try:
-        return resolve_dimensions(
-            board.get("device_type") or "flagship",
-            board.get("notes_wide") or 1,
-            board.get("notes_tall") or 1,
-        )
-    except Exception as exc:
-        logger.debug("Could not resolve board dims (using flagship default): %s", exc)
-        return resolve_dimensions("flagship")
-
-
-def _board_is_paused(board_id: str | None = None) -> bool:
-    """Return True when the target board (or default board) is paused.
-
-    Centralizes the per-board pause check used at every API push site
-    (issue #970). When True, callers MUST skip the send so paused boards
-    are left untouched.
-
-    Only treats a strict ``True`` as paused — any non-bool return
-    (including a ``Mock`` from an under-configured test fixture) is
-    coerced to "not paused" so this guard never silently swallows sends
-    in tests that pre-date the pause feature.
-    """
-    try:
-        result = get_settings_service().is_paused(board_id=board_id)
-    except Exception as e:  # pragma: no cover - defensive
-        logger.debug("Pause check failed (treating as not paused): %s", e)
-        return False
-    return result is True
-
-
-def _silence_active(board_id: str | None = None) -> bool:
-    """Return True when the target board (or the primary board) is silenced.
-
-    Mirrors :func:`_board_is_paused`: silence is per board since issue #1788,
-    so every send guard must resolve the window of the board it is about to
-    touch. ``Config.is_silence_mode_active(None)`` deliberately keeps its
-    legacy install-wide meaning for the ~20 fixtures that call it zero-arg, so
-    the primary board is resolved here instead — without this an override on
-    the bedroom Note was ignored by every manual-send path and a 2am send from
-    the web UI or Home Assistant woke the board up.
-    """
-    resolved = board_id
-    if resolved is None:
-        try:
-            resolved = get_settings_service().get_primary_board_id()
-        except Exception as e:  # pragma: no cover - defensive
-            logger.debug("Could not resolve primary board for silence check: %s", e)
-            resolved = None
-    return Config.is_silence_mode_active(resolved)
 
 
 def _paused_response(board_id: str | None = None) -> dict:

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -49,7 +49,6 @@ from .board_guards import (  # noqa: E402
     _silence_active,
 )
 from .board_send_executor import run_board_send  # noqa: E402
-from .boards import find_board, require_board  # noqa: E402
 from .collections.models import is_collection_id  # noqa: E402
 from .collections.service import (  # noqa: E402
     get_collection_service,

--- a/src/board_guards.py
+++ b/src/board_guards.py
@@ -1,0 +1,135 @@
+"""Board lookup and send guards, shared by every router that pushes to a board.
+
+These five helpers grew up inside ``src/api_server.py``, which meant a router
+extracted out of it could only reach them by importing ``src.api_server``
+*inside each handler* — the call-time seam the 2026-09 audit counted going up
+4.2x across Phase 1. Serving one request then dragged the whole 10k-line
+module, its route table and its background tasks back into the process.
+
+They have no dependency on the app object, so they live here instead:
+``src.api_server`` imports them (its own handlers and the tests that patch
+``src.api_server.<name>`` for those handlers are unaffected — the name is
+still bound there), and each domain router imports them directly and is
+patched at ``src.<domain>.routes.<name>``.
+
+The pause/silence pair is deliberately forgiving: a guard that raises would
+block sends on an unrelated failure, so both degrade to "not blocked" and log.
+``_require_board`` is the opposite — it is the single place the "unknown
+board" verdict is made, and it raises 404. See the "board_id validation" note
+in ``docs/internal/reference/API_CONVENTIONS.md`` for why writes 404 and reads
+fall back.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import HTTPException
+
+from . import settings as _settings_pkg  # noqa: F401  (ensures the submodule is importable)
+from .config import Config
+from .devices import resolve_dimensions
+
+logger = logging.getLogger(__name__)
+
+
+def get_settings_service():
+    """Resolve the settings service at call time.
+
+    Bound late, and re-exported here, so a test can stub the settings a guard
+    sees by patching ``src.board_guards.get_settings_service`` — one seam for
+    every router that imports these guards, rather than one per router.
+    """
+    from .settings.service import get_settings_service as _get
+
+    return _get()
+
+
+def _find_board(board_id: str) -> dict | None:
+    """Return the settings.boards entry for a board id, or None (issue #1244)."""
+    try:
+        boards = get_settings_service().get_board_settings().boards or []
+    except Exception as exc:
+        logger.debug("Could not read boards list: %s", exc)
+        return None
+    for board in boards:
+        if isinstance(board, dict) and board.get("id") == board_id:
+            return board
+    return None
+
+
+def _require_board(board_id: str) -> dict:
+    """Return the ``settings.boards`` entry for *board_id*, or raise 404.
+
+    The single place the "unknown board" verdict is made. The pattern was
+    open-coded in nine handlers and simply missing from four schedule write
+    endpoints, which persisted state bound to a board that does not exist and
+    reported success (#1888).
+
+    Use this on any path that *writes* something scoped to a board. Board-
+    scoped **reads** deliberately fall back to their safe default instead —
+    see the "board_id validation" note in
+    ``docs/internal/reference/API_CONVENTIONS.md``.
+    """
+    board = _find_board(board_id)
+    if board is None:
+        raise HTTPException(status_code=404, detail=f"Board not found: {board_id}")
+    return board
+
+
+def _board_dims(board: dict):
+    """Resolved dimensions for a settings.boards entry (flagship fallback).
+
+    Uses resolve_dimensions — never get_dimensions, which raises for
+    note_array boards. Safe to call from any endpoint — never raises.
+    """
+    try:
+        return resolve_dimensions(
+            board.get("device_type") or "flagship",
+            board.get("notes_wide") or 1,
+            board.get("notes_tall") or 1,
+        )
+    except Exception as exc:
+        logger.debug("Could not resolve board dims (using flagship default): %s", exc)
+        return resolve_dimensions("flagship")
+
+
+def _board_is_paused(board_id: str | None = None) -> bool:
+    """Return True when the target board (or default board) is paused.
+
+    Centralizes the per-board pause check used at every API push site
+    (issue #970). When True, callers MUST skip the send so paused boards
+    are left untouched.
+
+    Only treats a strict ``True`` as paused — any non-bool return
+    (including a ``Mock`` from an under-configured test fixture) is
+    coerced to "not paused" so this guard never silently swallows sends
+    in tests that pre-date the pause feature.
+    """
+    try:
+        result = get_settings_service().is_paused(board_id=board_id)
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug("Pause check failed (treating as not paused): %s", e)
+        return False
+    return result is True
+
+
+def _silence_active(board_id: str | None = None) -> bool:
+    """Return True when the target board (or the primary board) is silenced.
+
+    Mirrors :func:`_board_is_paused`: silence is per board since issue #1788,
+    so every send guard must resolve the window of the board it is about to
+    touch. ``Config.is_silence_mode_active(None)`` deliberately keeps its
+    legacy install-wide meaning for the ~20 fixtures that call it zero-arg, so
+    the primary board is resolved here instead — without this an override on
+    the bedroom Note was ignored by every manual-send path and a 2am send from
+    the web UI or Home Assistant woke the board up.
+    """
+    resolved = board_id
+    if resolved is None:
+        try:
+            resolved = get_settings_service().get_primary_board_id()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("Could not resolve primary board for silence check: %s", e)
+            resolved = None
+    return Config.is_silence_mode_active(resolved)

--- a/src/display_runtime.py
+++ b/src/display_runtime.py
@@ -1,0 +1,62 @@
+"""The ``DisplayService`` singleton, owned outside the FastAPI app module.
+
+``get_service()`` and ``peek_service()`` lived in ``src/api_server.py``, so
+every extracted router had to reach them with a call-time
+``from src.api_server import get_service`` — the seam that makes serving one
+request re-import the whole 10k-line app module (2026-09 audit, Phase 2 §2.3).
+The accessor has nothing to do with the app object, so it lives here.
+
+``src.api_server`` still imports both names, so its own handlers and the tests
+that patch ``src.api_server.get_service`` / ``.peek_service`` for those
+handlers are unchanged. Domain routers import from here and are patched at
+``src.<domain>.routes.get_service``.
+
+What stays in ``api_server``: the background-thread lifecycle
+(``_service_running``, ``run_service_background``, ``start_service``,
+``stop_service``). That is server lifecycle, not an accessor, and
+``tests/test_service_lifecycle.py`` owns it.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+from .main import DisplayService
+
+logger = logging.getLogger(__name__)
+
+_service: DisplayService | None = None
+_service_lock = threading.Lock()
+
+
+def get_service() -> DisplayService | None:
+    """Get or create the service instance."""
+    global _service
+    if _service is None:
+        with _service_lock:
+            if _service is None:
+                try:
+                    _service = DisplayService()
+                    if not _service.initialize():
+                        logger.warning(
+                            "Service initialization failed - service can be started later when configuration is fixed"
+                        )
+                        # Keep the service instance but mark it as uninitialized
+                        # This allows the /start endpoint to retry initialization
+                        return _service
+                except Exception as e:
+                    logger.error(f"Failed to create service: {e}", exc_info=True)
+                    return None
+    return _service
+
+
+def peek_service() -> DisplayService | None:
+    """Return the existing DisplayService instance without creating one.
+
+    For callers that only need to touch state that already exists (e.g.
+    invalidating dedupe caches after an out-of-band board write, issue
+    #1794): when no service exists there is nothing to invalidate, and
+    building one as a side effect would be wrong.
+    """
+    return _service

--- a/src/pages/models.py
+++ b/src/pages/models.py
@@ -184,3 +184,245 @@ class PageUpdate(BaseModel):
     # Note-array dimensions (only used when device_type is "note_array")
     notes_wide: int | None = Field(default=None, ge=1, le=MAX_NOTES_PER_AXIS)
     notes_tall: int | None = Field(default=None, ge=1, le=MAX_NOTES_PER_AXIS)
+
+
+# ---------------------------------------------------------------------------
+# Response models (Phase 2 slice 3 — API_CONVENTIONS.md "Response shapes")
+#
+# Every route in this domain declares one of these, so the response is a typed
+# contract the TS client (`web/src/lib/api/pages.ts`) and `/check-types` can be
+# held to, instead of whatever dict the handler happened to build.
+# ---------------------------------------------------------------------------
+
+
+class PageListResponse(BaseModel):
+    """``GET /pages`` — every saved page, plus the count."""
+
+    pages: list[Page]
+    total: int
+
+
+class IncompatibleReference(BaseModel):
+    """A reference left pointing this page at a board it no longer fits.
+
+    Produced by a device/size retarget (issue #1250, extended by #1788).
+    Warn-only: the backend never mutates or removes the reference.
+    """
+
+    board_id: str
+    board_name: str
+    surface: Literal["schedule", "active_page", "silence"]
+    schedule_id: str | None = None
+
+
+class PageUpdateResponse(BaseModel):
+    """``PUT /pages/{page_id}`` — the updated page and its stale references.
+
+    Not a bare ``Page`` because the retarget warning is genuine payload, not
+    an envelope: the editor shows it to the user after a size change.
+    ``incompatible_references`` is always present and empty when the update
+    did not change the page's size.
+    """
+
+    page: Page
+    incompatible_references: list[IncompatibleReference] = Field(default_factory=list)
+
+
+class PageDeleteResponse(BaseModel):
+    """``DELETE /pages/{page_id}`` — the deleted id plus what else moved.
+
+    Deleting the last page auto-creates a default welcome page, and deleting
+    the active page re-points the active reference; both are reported here so
+    the client can follow without re-fetching everything.
+    """
+
+    id: str
+    message: str
+    default_page_created: bool = False
+    new_page_id: str | None = None
+    active_page_updated: bool = False
+    new_active_page_id: str | None = None
+
+
+class ShareStringResponse(BaseModel):
+    """``GET /pages/{page_id}/share`` and ``GET /staff-picks/{id}/share``."""
+
+    share_string: str
+
+
+class PageImportRequest(BaseModel):
+    """Body of ``POST /pages/import`` and ``POST /pages/import/preview``."""
+
+    share_string: str
+
+
+class PageImportPreview(BaseModel):
+    """``POST /pages/import/preview`` — the decoded page, not yet persisted.
+
+    Exactly the content fields ``src/pages/share.py`` puts in the envelope:
+    no ``id``, ``created_at``, ``updated_at`` or ``demo_plugin_id``, because a
+    preview has not been created yet.
+    """
+
+    name: str
+    type: PageType
+    device_type: DeviceType = DEFAULT_DEVICE_TYPE
+    display_type: str | None = None
+    rows: list[RowConfig] | None = None
+    template: list[str] | None = None
+    line_metadata: list[LineMetadata] | None = None
+    duration_seconds: int | None = None
+    transition_strategy: str | None = None
+    transition_interval_ms: int | None = None
+    transition_step_size: int | None = None
+
+
+class StaffPickPlugin(BaseModel):
+    """A plugin a staff pick's template depends on."""
+
+    id: str
+    name: str
+
+
+class StaffPick(BaseModel):
+    """``GET /staff-picks`` entry — the share string is deliberately absent.
+
+    It is served only by ``GET /staff-picks/{pick_id}/share``, so the list
+    stays small and a pick cannot be imported straight out of the listing.
+    """
+
+    id: str
+    name: str
+    description: str = ""
+    device_type: DeviceType = DEFAULT_DEVICE_TYPE
+    tags: list[str] = Field(default_factory=list)
+    image: str | None = None
+    featured_at: str | None = None
+    required_plugins: list[StaffPickPlugin] = Field(default_factory=list)
+
+
+class PagePreviewResponse(BaseModel):
+    """``POST /pages/{page_id}/preview`` — the rendered board text."""
+
+    page_id: str
+    message: str
+    lines: list[str]
+    display_type: str
+    raw: dict
+
+
+class PagePreviewBatchSuccess(BaseModel):
+    """One rendered page inside ``POST /pages/preview/batch``."""
+
+    available: Literal[True] = True
+    page_id: str
+    message: str
+    lines: list[str]
+    display_type: str
+    raw: dict
+
+
+class PagePreviewBatchError(BaseModel):
+    """One page inside ``POST /pages/preview/batch`` that could not render.
+
+    A per-entry failure, not a request failure: the batch itself answers 200
+    because the other pages rendered. ``available`` discriminates the two
+    arms so a client can narrow without probing for keys.
+    """
+
+    available: Literal[False] = False
+    error: str
+
+
+class PagePreviewBatchRequest(BaseModel):
+    """Body of ``POST /pages/preview/batch``."""
+
+    page_ids: list[str] = Field(default_factory=list)
+    force_refresh: bool = False
+
+
+class PagePreviewBatchResponse(BaseModel):
+    """``POST /pages/preview/batch`` — one entry per requested page id."""
+
+    previews: dict[str, PagePreviewBatchSuccess | PagePreviewBatchError]
+    total: int
+    successful: int
+
+
+class PageCacheStatsResponse(BaseModel):
+    """``GET /pages/cache/stats`` — preview-cache occupancy and TTL."""
+
+    cache_size: int
+    cached_pages: list[str]
+    ttl_seconds: int
+
+
+class PageCacheClearRequest(BaseModel):
+    """Body of ``POST /pages/cache/clear``. Omit ``page_id`` to clear all."""
+
+    page_id: str | None = None
+
+
+class PageCacheClearResponse(BaseModel):
+    """``POST /pages/cache/clear`` — what was evicted."""
+
+    message: str
+    page_id: str | None = None
+
+
+class PageSendRequest(BaseModel):
+    """Body of ``POST /pages/{page_id}/send``.
+
+    Both fields may equally be given as query parameters; the query wins.
+    """
+
+    target: str | None = None
+    board_id: str | None = None
+
+
+class PageSendResponse(BaseModel):
+    """``POST /pages/{page_id}/send`` — what was rendered and where it went.
+
+    ``sent_to_board`` is False for a UI-only target, a silenced board, or a
+    paused board (``paused`` tells those last two apart from the first).
+    """
+
+    page_id: str
+    message: str
+    sent_to_board: bool
+    paused: bool = False
+    target: str
+    board_id: str | None = None
+
+
+class PageSendFailure(BaseModel):
+    """The 500 body when the board refused or could not be reached.
+
+    Deliberately not 502/503/504: nginx intercepts those on ``/api/`` and
+    replaces the body with its startup placeholder, so the caller would lose
+    the reason entirely.
+    """
+
+    detail: str
+    page_id: str
+    sent_to_board: bool = False
+    paused: bool = False
+    target: str
+    board_id: str | None = None
+
+
+class CurrentDisplayResponse(BaseModel):
+    """``GET /pages/current-display`` — what the board is showing now.
+
+    For a template page ``template`` is the **raw** template (``{{vars}}``
+    intact) plus its per-line metadata, so the editor can start a new page
+    from it. For every other page type it is the rendered output lines and
+    ``line_metadata`` is null.
+    """
+
+    page_id: str
+    page_name: str
+    page_type: PageType
+    device_type: DeviceType
+    template: list[str]
+    line_metadata: list[LineMetadata] | None = None

--- a/src/pages/routes.py
+++ b/src/pages/routes.py
@@ -1,12 +1,22 @@
 """FastAPI router for the pages, staff-picks and page-send endpoints.
 
-Handlers moved verbatim from ``src/api_server.py`` (issue #1756, pure move).
-Names that still live in ``api_server`` — the service getters, the
-board/silence/pause guards, and the utilities the test-suite monkeypatches as
-``src.api_server.<name>`` — are imported *inside* each handler so they resolve
-through the api_server module at call time. A module-level import would both
-create an import cycle (api_server imports this router) and detach the
-handlers from those patches.
+Handlers were moved here verbatim from ``src/api_server.py`` (issue #1756);
+Phase 2 slice 3 then applied ``docs/internal/reference/API_CONVENTIONS.md`` to
+them and retired the thirteen call-time ``from src.api_server import ...``
+seams the move left behind.
+
+Collaborators now resolve from their canonical homes at **module import
+time**, so this module never loads ``src.api_server``
+(``tests/test_pages_decoupled.py`` asserts that in a fresh interpreter, after
+driving all sixteen handlers). Tests that need to stub a collaborator patch it
+where this module binds it — ``src.pages.routes.<name>`` — not
+``src.api_server.<name>``.
+
+Two of those collaborators had no canonical home to move to, so they got one:
+``src/board_guards.py`` (board lookup, pause and silence guards) and
+``src/display_runtime.py`` (the ``DisplayService`` singleton accessor).
+``src.api_server`` imports both, so its own handlers and their patch targets
+are unchanged.
 """
 
 from __future__ import annotations
@@ -16,14 +26,42 @@ import json
 import logging
 from pathlib import Path
 
-from fastapi import APIRouter, Body, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
 
-from src.settings.service import VALID_OUTPUT_TARGETS
+from src.api_errors import errors
+from src.board_guards import _board_dims, _board_is_paused, _require_board, _silence_active
+from src.collections.models import is_collection_id
+from src.collections.service import get_collection_service
+from src.devices import resolve_dimensions, size_key
+from src.display_runtime import get_service
+from src.schedules.service import get_schedule_service
+from src.settings.service import VALID_OUTPUT_TARGETS, get_settings_service
+from src.text_to_board import text_to_board_array
 
-from .models import PageCreate, PageUpdate
-from .service import find_incompatible_references
+from .models import (
+    CurrentDisplayResponse,
+    IncompatibleReference,
+    PageCacheClearRequest,
+    PageCacheClearResponse,
+    PageCacheStatsResponse,
+    PageCreate,
+    PageDeleteResponse,
+    PageImportPreview,
+    PageImportRequest,
+    PageListResponse,
+    PagePreviewBatchRequest,
+    PagePreviewBatchResponse,
+    PagePreviewResponse,
+    PageSendRequest,
+    PageSendResponse,
+    PageUpdate,
+    PageUpdateResponse,
+    ShareStringResponse,
+    StaffPick,
+)
+from .models import Page as PageModel
+from .service import find_incompatible_references, get_page_service
 from .share import decode_page, encode_page
 
 logger = logging.getLogger(__name__)
@@ -31,18 +69,52 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["pages"])
 
 
-@router.get("/pages")
+def _reject_plugin_strategy_when_beta_off(strategy: str | None) -> None:
+    """Reject ``plugin:<id>`` strategies when the transition-plugin beta
+    flag is off.
+
+    Applied to page create / update / import so a page can't persist a plugin
+    strategy that the runtime won't actually honor.  Symmetric with the
+    settings-service guard on ``update_transition_settings``.
+
+    Lived in ``src/api_server.py`` until Phase 2 slice 3. Nothing else ever
+    called it — these three handlers are its only callers — so it moved here
+    with the routes rather than staying behind as a call-time seam.
+    """
+    if not isinstance(strategy, str):
+        return
+    from src.settings.service import TRANSITION_PLUGIN_PREFIX  # local: avoid cycle
+
+    if not strategy.startswith(TRANSITION_PLUGIN_PREFIX):
+        return
+    settings_service = get_settings_service()
+    if not settings_service.get_beta_settings().transition_plugins_enabled:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Transition plugins are an experimental beta. Enable them "
+                "in Settings → Beta before assigning a 'plugin:<id>' "
+                "strategy to a page."
+            ),
+        )
+
+
+# No 4xx of its own: an empty instance is an empty list, not an error. See the
+# declared_errors exception in tests/conventions_manifest.json.
+@router.get("/pages", response_model=PageListResponse)
 async def list_pages():
     """List all saved pages."""
-    from src.api_server import get_page_service  # patched-in-tests seam — see module docstring (#1756)
-
     page_service = get_page_service()
     pages = page_service.list_pages()
 
-    return {"pages": [p.model_dump() for p in pages], "total": len(pages)}
+    return PageListResponse(pages=pages, total=len(pages))
 
 
-@router.get("/pages/current-display")
+@router.get(
+    "/pages/current-display",
+    response_model=CurrentDisplayResponse,
+    responses=errors(404),
+)
 async def get_current_display():
     """Get the template content of the currently active board display.
 
@@ -53,14 +125,6 @@ async def get_current_display():
 
     Returns 404 when no active page can be determined.
     """
-    from src.api_server import (  # patched-in-tests seam — see module docstring (#1756)
-        get_collection_service,
-        get_page_service,
-        get_schedule_service,
-        get_settings_service,
-        is_collection_id,
-    )
-
     settings_service = get_settings_service()
     page_service = get_page_service()
     collection_service = get_collection_service()
@@ -92,32 +156,28 @@ async def get_current_display():
     if not page:
         raise HTTPException(status_code=404, detail="Active page not found")
 
-    response: dict = {
-        "page_id": page.id,
-        "page_name": page.name,
-        "page_type": page.type,
-        "device_type": page.device_type,
-    }
-
     if page.type == "template" and page.template:
         # Return raw template so variables like {{weather.temp}} are preserved
-        response["template"] = page.template
-        response["line_metadata"] = [m.model_dump() for m in page.line_metadata] if page.line_metadata else None
+        template = page.template
+        line_metadata = page.line_metadata
     else:
         # For single/composite pages, return the rendered output as template
         # lines. The forced render fans out to plugins — off the loop (#1826).
         result = await asyncio.to_thread(page_service.preview_page, active_page_id, force_refresh=True)
-        if result and result.available:
-            response["template"] = result.formatted.split("\n")
-            response["line_metadata"] = None
-        else:
-            response["template"] = []
-            response["line_metadata"] = None
+        template = result.formatted.split("\n") if result and result.available else []
+        line_metadata = None
 
-    return response
+    return CurrentDisplayResponse(
+        page_id=page.id,
+        page_name=page.name,
+        page_type=page.type,
+        device_type=page.device_type,
+        template=template,
+        line_metadata=line_metadata,
+    )
 
 
-@router.post("/pages")
+@router.post("/pages", response_model=PageModel, status_code=201, responses=errors(400))
 async def create_page(page_data: PageCreate):
     """
     Create a new page.
@@ -127,71 +187,62 @@ async def create_page(page_data: PageCreate):
     - composite: Combine rows from multiple sources (set rows)
     - template: Custom templated content (set template)
     """
-    from src.api_server import (  # patched-in-tests seam — see module docstring (#1756)
-        _reject_plugin_strategy_when_beta_off,
-        get_page_service,
-    )
-
     _reject_plugin_strategy_when_beta_off(page_data.transition_strategy)
     page_service = get_page_service()
 
     try:
-        page = page_service.create_page(page_data)
-        return {"status": "success", "page": page.model_dump()}
+        return page_service.create_page(page_data)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
 
-@router.get("/pages/{page_id}")
+@router.get("/pages/{page_id}", response_model=PageModel, responses=errors(404))
 async def get_page(page_id: str):
     """Get a page by ID."""
-    from src.api_server import get_page_service  # patched-in-tests seam — see module docstring (#1756)
-
     page_service = get_page_service()
     page = page_service.get_page(page_id)
 
     if not page:
         raise HTTPException(status_code=404, detail=f"Page not found: {page_id}")
 
-    return page.model_dump()
+    return page
 
 
-@router.put("/pages/{page_id}")
+@router.put(
+    "/pages/{page_id}",
+    response_model=PageUpdateResponse,
+    responses=errors(400, 404),
+)
 async def update_page(page_id: str, page_data: PageUpdate):
     """Update an existing page.
 
     When the update changes the page's size (device/size retarget, issue
-    #1250), the response includes ``incompatible_references``: schedule
-    entries and per-board active pages that now point this page at a board
-    it no longer fits. Warn-only — no reference is mutated or removed.
+    #1250), ``incompatible_references`` lists the schedule entries and
+    per-board active pages that now point this page at a board it no longer
+    fits. Warn-only — no reference is mutated or removed. The list is empty
+    when the size did not change, or when nothing broke.
     """
-    from src.api_server import (  # patched-in-tests seam — see module docstring (#1756)
-        _reject_plugin_strategy_when_beta_off,
-        get_page_service,
-    )
-    from src.devices import size_key
-
     _reject_plugin_strategy_when_beta_off(page_data.transition_strategy)
     page_service = get_page_service()
     existing = page_service.get_page(page_id)
 
     try:
         page = page_service.update_page(page_id, page_data)
-        if not page:
-            raise HTTPException(status_code=404, detail=f"Page not found: {page_id}")
-
-        response = {"status": "success", "page": page.model_dump()}
-        if existing is not None:
-            old_size = size_key(existing.device_type, existing.notes_wide, existing.notes_tall)
-            new_size = size_key(page.device_type, page.notes_wide, page.notes_tall)
-            if old_size != new_size:
-                response["incompatible_references"] = find_incompatible_references(page)
-        return response
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
+    if not page:
+        raise HTTPException(status_code=404, detail=f"Page not found: {page_id}")
+
+    incompatible: list[IncompatibleReference] = []
+    if existing is not None:
+        old_size = size_key(existing.device_type, existing.notes_wide, existing.notes_tall)
+        new_size = size_key(page.device_type, page.notes_wide, page.notes_tall)
+        if old_size != new_size:
+            incompatible = [IncompatibleReference(**ref) for ref in find_incompatible_references(page)]
+    return PageUpdateResponse(page=page, incompatible_references=incompatible)
 
 
-@router.delete("/pages/{page_id}")
+@router.delete("/pages/{page_id}", response_model=PageDeleteResponse, responses=errors(404))
 async def delete_page(page_id: str):
     """Delete a page.
 
@@ -201,8 +252,6 @@ async def delete_page(page_id: str):
     If the deleted page was the active display page, the active page will be
     updated to another valid page automatically.
     """
-    from src.api_server import get_page_service  # patched-in-tests seam — see module docstring (#1756)
-
     page_service = get_page_service()
 
     result = page_service.delete_page(page_id)
@@ -210,40 +259,39 @@ async def delete_page(page_id: str):
     if not result.deleted:
         raise HTTPException(status_code=404, detail=f"Page not found: {page_id}")
 
-    response = {
-        "status": "success",
-        "message": f"Page {page_id} deleted",
-        "default_page_created": result.default_page_created,
-        "active_page_updated": result.active_page_updated,
-    }
-
+    message = f"Page {page_id} deleted"
     if result.default_page_created:
-        response["message"] = f"Page {page_id} deleted. A default welcome page was created."
-        response["new_page_id"] = result.new_page_id
+        message = f"Page {page_id} deleted. A default welcome page was created."
 
-    if result.active_page_updated:
-        response["new_active_page_id"] = result.new_active_page_id
+    return PageDeleteResponse(
+        id=page_id,
+        message=message,
+        default_page_created=result.default_page_created,
+        new_page_id=result.new_page_id if result.default_page_created else None,
+        active_page_updated=result.active_page_updated,
+        new_active_page_id=result.new_active_page_id if result.active_page_updated else None,
+    )
 
-    return response
 
-
-@router.get("/pages/{page_id}/share")
+@router.get(
+    "/pages/{page_id}/share",
+    response_model=ShareStringResponse,
+    responses=errors(404),
+)
 async def get_page_share_string(page_id: str):
     """Return a portable share string for an existing page."""
-    from src.api_server import get_page_service  # patched-in-tests seam — see module docstring (#1756)
-
     page_service = get_page_service()
     page = page_service.get_page(page_id)
     if not page:
         raise HTTPException(status_code=404, detail=f"Page not found: {page_id}")
-    return {"share_string": encode_page(page)}
+    return ShareStringResponse(share_string=encode_page(page))
 
 
-class PageImportRequest(BaseModel):
-    share_string: str
-
-
-@router.post("/pages/import/preview")
+@router.post(
+    "/pages/import/preview",
+    response_model=PageImportPreview,
+    responses=errors(422),
+)
 async def preview_page_import(body: PageImportRequest):
     """Decode a share string and return the page data without persisting it."""
     try:
@@ -253,29 +301,39 @@ async def preview_page_import(body: PageImportRequest):
     return page_data
 
 
-@router.post("/pages/import")
+@router.post(
+    "/pages/import",
+    response_model=PageModel,
+    status_code=201,
+    responses=errors(400, 422),
+)
 async def import_page(body: PageImportRequest):
-    """Create a new page from a share string."""
-    from src.api_server import (  # patched-in-tests seam — see module docstring (#1756)
-        _reject_plugin_strategy_when_beta_off,
-        get_page_service,
-    )
+    """Create a new page from a share string.
 
+    A share string the decoder rejects, or one whose contents do not satisfy
+    ``PageCreate``, is the caller's problem: 422. A page that decodes and
+    validates but that the service refuses is a 400. Anything else is a
+    server fault and propagates as a 500 — this handler used to convert
+    *every* unexpected exception to 422, which reported a storage failure or
+    a bug in this process as "your share string is bad" (Phase 2 slice 3).
+    """
     try:
         page_data = decode_page(body.share_string)
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
 
-    page_service = get_page_service()
     try:
         page_create = PageCreate(**{k: v for k, v in page_data.items() if k in PageCreate.model_fields})
-        _reject_plugin_strategy_when_beta_off(page_create.transition_strategy)
-        page = page_service.create_page(page_create)
-        return {"status": "success", "page": page.model_dump()}
-    except HTTPException:
-        raise
     except Exception as e:
-        raise HTTPException(status_code=422, detail=str(e)) from e
+        raise HTTPException(status_code=422, detail=f"Invalid share string — {e}") from e
+
+    _reject_plugin_strategy_when_beta_off(page_create.transition_strategy)
+
+    page_service = get_page_service()
+    try:
+        return page_service.create_page(page_create)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
 
 
 # ---------------------------------------------------------------------------
@@ -294,24 +352,34 @@ def _load_staff_picks() -> list:
         return []
 
 
-@router.get("/staff-picks")
+# No 4xx of its own: a missing picks.json degrades to []. See the
+# declared_errors exception in tests/conventions_manifest.json.
+@router.get("/staff-picks", response_model=list[StaffPick])
 async def list_staff_picks():
     """Return all staff picks (without share strings)."""
     picks = _load_staff_picks()
     return [{k: v for k, v in pick.items() if k != "share_string"} for pick in picks]
 
 
-@router.get("/staff-picks/{pick_id}/share")
+@router.get(
+    "/staff-picks/{pick_id}/share",
+    response_model=ShareStringResponse,
+    responses=errors(404),
+)
 async def get_staff_pick_share(pick_id: str):
     """Return the share string for a specific staff pick."""
     picks = _load_staff_picks()
     pick = next((p for p in picks if p["id"] == pick_id), None)
     if not pick:
         raise HTTPException(status_code=404, detail=f"Staff pick not found: {pick_id}")
-    return {"share_string": pick["share_string"]}
+    return ShareStringResponse(share_string=pick["share_string"])
 
 
-@router.post("/pages/{page_id}/preview")
+@router.post(
+    "/pages/{page_id}/preview",
+    response_model=PagePreviewResponse,
+    responses=errors(404, 503),
+)
 async def preview_page(
     page_id: str, force_refresh: bool = Query(default=False, description="Force fresh render, bypass cache")
 ):
@@ -328,11 +396,6 @@ async def preview_page(
     Returns:
         The formatted text that would be displayed.
     """
-    from src.api_server import (  # patched-in-tests seam — see module docstring (#1756)
-        get_page_service,
-        get_settings_service,
-    )
-
     page_service = get_page_service()
     settings_service = get_settings_service()
 
@@ -353,46 +416,39 @@ async def preview_page(
     if not result.available:
         raise HTTPException(status_code=503, detail=result.error or "Page rendering failed")
 
-    return {
-        "page_id": page_id,
-        "message": result.formatted,
-        "lines": result.formatted.split("\n"),
-        "display_type": result.display_type,
-        "raw": result.raw,
-    }
+    return PagePreviewResponse(
+        page_id=page_id,
+        message=result.formatted,
+        lines=result.formatted.split("\n"),
+        display_type=result.display_type,
+        raw=result.raw,
+    )
 
 
-@router.post("/pages/preview/batch")
-async def preview_pages_batch(request: dict):
+@router.post(
+    "/pages/preview/batch",
+    response_model=PagePreviewBatchResponse,
+    responses=errors(422),
+)
+async def preview_pages_batch(request: PagePreviewBatchRequest):
     """
     Preview multiple pages in a single request.
-
-    Request body:
-        {
-            "page_ids": ["page1", "page2", ...],
-            "force_refresh": false  // Optional, defaults to false
-        }
 
     Returns a dict mapping page_id to preview data (or error).
     Uses cached previews by default for fast responses.
     Active page is always rendered fresh regardless of force_refresh setting.
     Template context (plugin data) is built once and shared across all page renders.
+
+    A per-page render failure is reported inside ``previews`` with
+    ``available: false`` — the request itself still succeeded. Only a
+    malformed body (``page_ids`` that is not a list of strings) is a 422.
     """
-    from src.api_server import (  # patched-in-tests seam — see module docstring (#1756)
-        get_page_service,
-        get_settings_service,
-    )
-
-    page_ids = request.get("page_ids", [])
-    force_refresh = request.get("force_refresh", False)
-
-    if not isinstance(page_ids, list):
-        raise HTTPException(status_code=400, detail="page_ids must be a list")
+    page_ids = request.page_ids
 
     page_service = get_page_service()
     settings_service = get_settings_service()
     active_page_id = settings_service.get_active_page_id()
-    results = {}
+    results: dict = {}
 
     # Use batch preview to build template context once for all pages. One
     # worker-thread call for the whole batch — the internal context sharing
@@ -402,7 +458,7 @@ async def preview_pages_batch(request: dict):
     batch_results = await asyncio.to_thread(
         page_service.preview_pages_batch,
         page_ids,
-        force_refresh=force_refresh,
+        force_refresh=request.force_refresh,
         active_page_id=active_page_id,
     )
 
@@ -422,14 +478,16 @@ async def preview_pages_batch(request: dict):
                 "available": True,
             }
 
-    return {
-        "previews": results,
-        "total": len(page_ids),
-        "successful": sum(1 for r in results.values() if r.get("available", False)),
-    }
+    return PagePreviewBatchResponse(
+        previews=results,
+        total=len(page_ids),
+        successful=sum(1 for r in results.values() if r.get("available", False)),
+    )
 
 
-@router.get("/pages/cache/stats")
+# No 4xx of its own: reports in-memory cache state that always exists. See the
+# declared_errors exception in tests/conventions_manifest.json.
+@router.get("/pages/cache/stats", response_model=PageCacheStatsResponse)
 async def get_page_cache_stats():
     """
     Get preview cache statistics.
@@ -437,14 +495,16 @@ async def get_page_cache_stats():
     Returns information about the preview cache including size,
     cached page IDs, and TTL configuration.
     """
-    from src.api_server import get_page_service  # patched-in-tests seam — see module docstring (#1756)
-
     page_service = get_page_service()
-    return page_service.get_cache_stats()
+    return PageCacheStatsResponse(**page_service.get_cache_stats())
 
 
-@router.post("/pages/cache/clear")
-async def clear_page_cache(request: dict = None):
+@router.post(
+    "/pages/cache/clear",
+    response_model=PageCacheClearResponse,
+    responses=errors(422),
+)
+async def clear_page_cache(request: PageCacheClearRequest | None = None):
     """
     Clear preview cache.
 
@@ -456,25 +516,30 @@ async def clear_page_cache(request: dict = None):
     Clears the preview cache, forcing fresh renders on next preview.
     Useful for testing or when data sources have been updated.
     """
-    from src.api_server import get_page_service  # patched-in-tests seam — see module docstring (#1756)
-
     page_service = get_page_service()
 
-    page_id = None
-    if request:
-        page_id = request.get("page_id")
+    page_id = request.page_id if request else None
 
-    page_service._invalidate_cache(page_id)
+    # Public service method, not `_invalidate_cache` — a route must not reach
+    # into another object's privates (API_CONVENTIONS.md, "Routers and
+    # services").
+    page_service.invalidate_preview_cache(page_id)
 
     if page_id:
-        return {"status": "success", "message": f"Cache cleared for page {page_id}"}
-    else:
-        return {"status": "success", "message": "All preview caches cleared"}
+        return PageCacheClearResponse(message=f"Cache cleared for page {page_id}", page_id=page_id)
+    return PageCacheClearResponse(message="All preview caches cleared")
 
 
-@router.post("/pages/{page_id}/send")
+@router.post(
+    "/pages/{page_id}/send",
+    response_model=PageSendResponse,
+    responses=errors(400, 404, 503),
+)
 async def send_page(
-    page_id: str, target: str | None = None, board_id: str | None = None, payload: dict | None = Body(None)
+    page_id: str,
+    target: str | None = None,
+    board_id: str | None = None,
+    payload: PageSendRequest | None = None,
 ):
     """
     Send a page to the configured target.
@@ -487,22 +552,10 @@ async def send_page(
             ``{"board_id": ...}`` in the JSON body). Omitted → primary
             board, legacy behavior (issue #1244).
     """
-    from src.api_server import (  # patched-in-tests seam — see module docstring (#1756)
-        _board_dims,
-        _board_is_paused,
-        _require_board,
-        _silence_active,
-        get_page_service,
-        get_service,
-        get_settings_service,
-        resolve_dimensions,
-        text_to_board_array,
-    )
-
     if target is None and payload:
-        target = payload.get("target")
+        target = payload.target
     if board_id is None and payload:
-        board_id = payload.get("board_id")
+        board_id = payload.board_id
     if target is not None and target not in VALID_OUTPUT_TARGETS:
         raise HTTPException(status_code=400, detail=f"Invalid target: {target}. Valid targets: {VALID_OUTPUT_TARGETS}")
 
@@ -530,7 +583,7 @@ async def send_page(
     # they run as one worker-thread unit and the event loop keeps serving
     # requests (#1826). HTTPExceptions raised inside propagate through the
     # await unchanged.
-    def _work() -> dict | JSONResponse:
+    def _work() -> PageSendResponse | JSONResponse:
         # Get the page for transition settings
         page = page_service.get_page(page_id)
         if not page:
@@ -604,7 +657,6 @@ async def send_page(
                     return JSONResponse(
                         status_code=500,
                         content={
-                            "status": "error",
                             "detail": "Failed to send to board",
                             "page_id": page_id,
                             "sent_to_board": False,
@@ -617,15 +669,14 @@ async def send_page(
                     # Adaptive post-send refresh polls the primary board only.
                     service.request_board_refresh()
 
-        return {
-            "status": "success",
-            "page_id": page_id,
-            "message": result.formatted,
-            "sent_to_board": sent_to_board,
-            "paused": paused,
-            "target": target or settings_service.get_output_settings().target,
-            "board_id": board_id,
-        }
+        return PageSendResponse(
+            page_id=page_id,
+            message=result.formatted,
+            sent_to_board=sent_to_board,
+            paused=paused,
+            target=target or settings_service.get_output_settings().target,
+            board_id=board_id,
+        )
 
     # Board network I/O goes on the dedicated bounded send pool, never the
     # shared default executor (#1878) — see src/board_send_executor.py.

--- a/src/pages/service.py
+++ b/src/pages/service.py
@@ -762,6 +762,18 @@ class PageService:
         else:
             self._preview_cache.clear()
 
+    def invalidate_preview_cache(self, page_id: str | None = None) -> None:
+        """Public entry point for ``POST /pages/cache/clear``.
+
+        The route used to call ``_invalidate_cache`` directly, which
+        ``docs/internal/reference/API_CONVENTIONS.md`` bans ("Routes never
+        touch another object's ``_private`` members"). The private method
+        stays as the internal write-path hook the mutators call; this is the
+        one the API is allowed to see, so the cache's shape can change without
+        an endpoint changing with it.
+        """
+        self._invalidate_cache(page_id)
+
     def get_cache_stats(self) -> dict[str, any]:
         """Get cache statistics for monitoring.
 

--- a/tests/contract/schemas.py
+++ b/tests/contract/schemas.py
@@ -64,11 +64,8 @@ class PagesListResponse(BaseModel):
     total: int
 
 
-class CreatePageResponse(BaseModel):
-    """POST /pages"""
-
-    status: str  # "success"
-    page: PageSchema
+class CreatePageResponse(PageSchema):
+    """POST /pages — 201 with the bare page (Phase 2 conventions pass)."""
 
 
 class GetPageResponse(PageSchema):
@@ -76,16 +73,19 @@ class GetPageResponse(PageSchema):
 
 
 class UpdatePageResponse(BaseModel):
-    """PUT /pages/{page_id}"""
+    """PUT /pages/{page_id} — the page plus its retarget warnings."""
 
-    status: str  # "success"
     page: PageSchema
+    incompatible_references: list[dict]
 
 
 class DeletePageResponse(BaseModel):
-    """DELETE /pages/{page_id}"""
+    """DELETE /pages/{page_id} — the deleted id and what else moved."""
 
-    status: str  # "success" | "not_found"
+    id: str
+    message: str
+    default_page_created: bool
+    active_page_updated: bool
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_pages_contract.py
+++ b/tests/contract/test_pages_contract.py
@@ -43,7 +43,7 @@ def sample_page():
 
 class TestListPagesContract:
     def test_returns_200(self, client):
-        with patch("src.api_server.get_page_service") as mock_svc:
+        with patch("src.pages.routes.get_page_service") as mock_svc:
             svc = Mock()
             svc.list_pages.return_value = []
             mock_svc.return_value = svc
@@ -52,7 +52,7 @@ class TestListPagesContract:
         assert resp.status_code == 200
 
     def test_response_has_pages_and_total(self, client):
-        with patch("src.api_server.get_page_service") as mock_svc:
+        with patch("src.pages.routes.get_page_service") as mock_svc:
             svc = Mock()
             svc.list_pages.return_value = []
             mock_svc.return_value = svc
@@ -64,7 +64,7 @@ class TestListPagesContract:
         assert "total" in data
 
     def test_response_validates_against_schema(self, client):
-        with patch("src.api_server.get_page_service") as mock_svc:
+        with patch("src.pages.routes.get_page_service") as mock_svc:
             svc = Mock()
             svc.list_pages.return_value = []
             mock_svc.return_value = svc
@@ -77,7 +77,7 @@ class TestListPagesContract:
         assert parsed.pages == []
 
     def test_pages_list_with_items_validates(self, client, sample_page):
-        with patch("src.api_server.get_page_service") as mock_svc:
+        with patch("src.pages.routes.get_page_service") as mock_svc:
             svc = Mock()
             svc.list_pages.return_value = [sample_page]
             mock_svc.return_value = svc
@@ -92,7 +92,7 @@ class TestListPagesContract:
         assert parsed.pages[0].type == "template"
 
     def test_page_id_is_string(self, client, sample_page):
-        with patch("src.api_server.get_page_service") as mock_svc:
+        with patch("src.pages.routes.get_page_service") as mock_svc:
             svc = Mock()
             svc.list_pages.return_value = [sample_page]
             mock_svc.return_value = svc
@@ -105,7 +105,7 @@ class TestListPagesContract:
 
     def test_total_matches_pages_length(self, client, sample_page):
         page2 = Page(id="test-2", name="Page Two", type="template", template=["X"])
-        with patch("src.api_server.get_page_service") as mock_svc:
+        with patch("src.pages.routes.get_page_service") as mock_svc:
             svc = Mock()
             svc.list_pages.return_value = [sample_page, page2]
             mock_svc.return_value = svc
@@ -123,7 +123,7 @@ class TestListPagesContract:
 
 class TestCreatePageContract:
     def test_returns_200_on_valid_input(self, client, sample_page):
-        with patch("src.api_server.get_page_service") as mock_svc:
+        with patch("src.pages.routes.get_page_service") as mock_svc:
             svc = Mock()
             svc.create_page.return_value = sample_page
             mock_svc.return_value = svc
@@ -133,10 +133,11 @@ class TestCreatePageContract:
                 json={"name": "Contract Test", "type": "template", "template": ["HELLO", "", "", "", "", ""]},
             )
 
-        assert resp.status_code == 200
+        # 201 + the bare page since the Phase 2 conventions pass.
+        assert resp.status_code == 201
 
     def test_response_validates_against_schema(self, client, sample_page):
-        with patch("src.api_server.get_page_service") as mock_svc:
+        with patch("src.pages.routes.get_page_service") as mock_svc:
             svc = Mock()
             svc.create_page.return_value = sample_page
             mock_svc.return_value = svc
@@ -147,11 +148,11 @@ class TestCreatePageContract:
             )
 
         parsed = CreatePageResponse(**resp.json())
-        assert parsed.status == "success"
-        assert parsed.page.id == "test-page-contract-1"
+        assert parsed.id == "test-page-contract-1"
 
-    def test_response_status_is_success(self, client, sample_page):
-        with patch("src.api_server.get_page_service") as mock_svc:
+    def test_response_is_the_created_page_not_an_envelope(self, client, sample_page):
+        """The {"status": "success"} envelope is gone (Phase 2 conventions)."""
+        with patch("src.pages.routes.get_page_service") as mock_svc:
             svc = Mock()
             svc.create_page.return_value = sample_page
             mock_svc.return_value = svc
@@ -161,10 +162,11 @@ class TestCreatePageContract:
                 json={"name": "T", "type": "template", "template": ["X", "", "", "", "", ""]},
             )
 
-        assert resp.json()["status"] == "success"
+        assert "status" not in resp.json()
+        assert resp.json()["name"] == "Contract Test"
 
     def test_returns_400_for_invalid_page(self, client):
-        with patch("src.api_server.get_page_service") as mock_svc:
+        with patch("src.pages.routes.get_page_service") as mock_svc:
             svc = Mock()
             svc.create_page.side_effect = ValueError("Missing required field")
             mock_svc.return_value = svc
@@ -178,7 +180,7 @@ class TestCreatePageContract:
         assert resp.status_code in (400, 422)
 
     def test_created_page_has_required_fields(self, client, sample_page):
-        with patch("src.api_server.get_page_service") as mock_svc:
+        with patch("src.pages.routes.get_page_service") as mock_svc:
             svc = Mock()
             svc.create_page.return_value = sample_page
             mock_svc.return_value = svc
@@ -188,7 +190,7 @@ class TestCreatePageContract:
                 json={"name": "T", "type": "template", "template": ["X", "", "", "", "", ""]},
             )
 
-        page = resp.json()["page"]
+        page = resp.json()
         assert "id" in page
         assert "name" in page
         assert "type" in page
@@ -201,7 +203,7 @@ class TestCreatePageContract:
 
 class TestGetPageContract:
     def test_returns_200_for_existing_page(self, client, sample_page):
-        with patch("src.api_server.get_page_service") as mock_svc:
+        with patch("src.pages.routes.get_page_service") as mock_svc:
             svc = Mock()
             svc.get_page.return_value = sample_page
             mock_svc.return_value = svc
@@ -211,7 +213,7 @@ class TestGetPageContract:
         assert resp.status_code == 200
 
     def test_response_validates_against_schema(self, client, sample_page):
-        with patch("src.api_server.get_page_service") as mock_svc:
+        with patch("src.pages.routes.get_page_service") as mock_svc:
             svc = Mock()
             svc.get_page.return_value = sample_page
             mock_svc.return_value = svc
@@ -223,7 +225,7 @@ class TestGetPageContract:
         assert parsed.id == "test-page-contract-1"
 
     def test_returns_404_for_missing_page(self, client):
-        with patch("src.api_server.get_page_service") as mock_svc:
+        with patch("src.pages.routes.get_page_service") as mock_svc:
             svc = Mock()
             svc.get_page.return_value = None
             mock_svc.return_value = svc
@@ -240,7 +242,7 @@ class TestGetPageContract:
 
 class TestDeletePageContract:
     def test_returns_200_on_delete(self, client, sample_page):
-        with patch("src.api_server.get_page_service") as mock_svc:
+        with patch("src.pages.routes.get_page_service") as mock_svc:
             from src.pages.service import DeleteResult
 
             svc = Mock()
@@ -251,8 +253,8 @@ class TestDeletePageContract:
 
         assert resp.status_code == 200
 
-    def test_response_has_status_field(self, client, sample_page):
-        with patch("src.api_server.get_page_service") as mock_svc:
+    def test_response_reports_the_deleted_id(self, client, sample_page):
+        with patch("src.pages.routes.get_page_service") as mock_svc:
             from src.pages.service import DeleteResult
 
             svc = Mock()
@@ -262,4 +264,5 @@ class TestDeletePageContract:
             resp = client.delete("/pages/test-page-contract-1")
 
         data = resp.json()
-        assert "status" in data
+        # The envelope's "status" is gone; the deleted id is the contract now.
+        assert data["id"] == "test-page-contract-1"

--- a/tests/conventions_manifest.json
+++ b/tests/conventions_manifest.json
@@ -2,6 +2,7 @@
   "_comment": "API conventions ratchet (Phase 2, spec §2). Enforced by tests/test_api_conventions_ratchet.py; rules documented in docs/internal/reference/API_CONVENTIONS.md. Append a domain to converted_domains in the slice PR that converts it — never before. Every exception needs a route that exists, a known rule id, and a reason a reviewer can argue with.",
   "converted_domains": [
     "collections",
+    "pages",
     "schedules"
   ],
   "exceptions": [
@@ -11,14 +12,24 @@
       "reason": "Listing has no failure path: it returns [] for an empty store and cannot 404 or 400, so declaring a 4xx would document an error the endpoint never raises."
     },
     {
+      "route": "GET /pages",
+      "rule": "declared_errors",
+      "reason": "Has no failure path of its own: an instance with no pages answers {\"pages\": [], \"total\": 0}. The only 4xx it can produce is the auth middleware's 401, which is applied app-wide and is not this route's contract to declare."
+    },
+    {
+      "route": "GET /pages/cache/stats",
+      "rule": "declared_errors",
+      "reason": "Reports in-memory preview-cache occupancy, which always exists — an empty cache is a valid answer, not an error. Nothing it reads can be missing or unauthorized at the route level."
+    },
+    {
       "route": "GET /schedules",
       "rule": "declared_errors",
       "reason": "No failure path. The only argument is board_id, and a board-scoped read deliberately falls back to the empty list instead of 404ing (API_CONVENTIONS.md, 'board_id validation: writes 404, reads fall back'); board_id=* is a documented wildcard, not an id."
     },
     {
-      "route": "GET /schedules/enabled",
+      "route": "GET /schedules/active/page",
       "rule": "declared_errors",
-      "reason": "No failure path. An unknown board_id deliberately answers false rather than 404 — the same read/write asymmetry, decided in #1888 and documented in API_CONVENTIONS.md."
+      "reason": "No failure path. It reports whatever is on the board right now — manual page, scheduled page, or nothing — and every collection resolution failure is caught and reported as null rather than raised, because a dashboard poll must not error out over a collection that cannot resolve."
     },
     {
       "route": "GET /schedules/default-page",
@@ -26,9 +37,14 @@
       "reason": "No failure path. An unknown board_id deliberately answers the global default rather than 404 — the same read/write asymmetry, decided in #1888 and documented in API_CONVENTIONS.md."
     },
     {
-      "route": "GET /schedules/active/page",
+      "route": "GET /schedules/enabled",
       "rule": "declared_errors",
-      "reason": "No failure path. It reports whatever is on the board right now — manual page, scheduled page, or nothing — and every collection resolution failure is caught and reported as null rather than raised, because a dashboard poll must not error out over a collection that cannot resolve."
+      "reason": "No failure path. An unknown board_id deliberately answers false rather than 404 — the same read/write asymmetry, decided in #1888 and documented in API_CONVENTIONS.md."
+    },
+    {
+      "route": "GET /staff-picks",
+      "rule": "declared_errors",
+      "reason": "Reads the bundled staff-picks/picks.json and degrades a missing file to [] on purpose, so a caller can never see a 4xx from it. The per-pick 404 lives on GET /staff-picks/{pick_id}/share, which declares it."
     },
     {
       "route": "POST /schedules/validate",

--- a/tests/golden/responses/pages.json
+++ b/tests/golden/responses/pages.json
@@ -68,35 +68,32 @@
       "label": "create_page_ok",
       "method": "POST",
       "path_template": "/pages",
-      "status": 200,
+      "status": 201,
       "shape": {
-        "page": {
-          "created_at": "str",
-          "demo_plugin_id": "null",
-          "device_type": "str",
-          "display_type": "null",
-          "duration_seconds": "int",
-          "id": "str",
-          "line_metadata": "null",
-          "name": "str",
-          "notes_tall": "int",
-          "notes_wide": "int",
-          "rows": "null",
-          "template": [
-            "str",
-            "str",
-            "str",
-            "str",
-            "str",
-            "str"
-          ],
-          "transition_interval_ms": "null",
-          "transition_step_size": "null",
-          "transition_strategy": "null",
-          "type": "str",
-          "updated_at": "null"
-        },
-        "status": "str"
+        "created_at": "str",
+        "demo_plugin_id": "null",
+        "device_type": "str",
+        "display_type": "null",
+        "duration_seconds": "int",
+        "id": "str",
+        "line_metadata": "null",
+        "name": "str",
+        "notes_tall": "int",
+        "notes_wide": "int",
+        "rows": "null",
+        "template": [
+          "str",
+          "str",
+          "str",
+          "str",
+          "str",
+          "str"
+        ],
+        "transition_interval_ms": "null",
+        "transition_step_size": "null",
+        "transition_strategy": "null",
+        "type": "str",
+        "updated_at": "null"
       }
     },
     {
@@ -167,6 +164,7 @@
       "path_template": "/pages/{page_id}",
       "status": 200,
       "shape": {
+        "incompatible_references": [],
         "page": {
           "created_at": "str",
           "demo_plugin_id": "null",
@@ -192,8 +190,7 @@
           "transition_strategy": "null",
           "type": "str",
           "updated_at": "str"
-        },
-        "status": "str"
+        }
       }
     },
     {
@@ -213,8 +210,10 @@
       "shape": {
         "active_page_updated": "bool",
         "default_page_created": "bool",
+        "id": "str",
         "message": "str",
-        "status": "str"
+        "new_active_page_id": "null",
+        "new_page_id": "null"
       }
     },
     {
@@ -283,35 +282,32 @@
       "label": "import_ok",
       "method": "POST",
       "path_template": "/pages/import",
-      "status": 200,
+      "status": 201,
       "shape": {
-        "page": {
-          "created_at": "str",
-          "demo_plugin_id": "null",
-          "device_type": "str",
-          "display_type": "null",
-          "duration_seconds": "int",
-          "id": "str",
-          "line_metadata": "null",
-          "name": "str",
-          "notes_tall": "int",
-          "notes_wide": "int",
-          "rows": "null",
-          "template": [
-            "str",
-            "str",
-            "str",
-            "str",
-            "str",
-            "str"
-          ],
-          "transition_interval_ms": "null",
-          "transition_step_size": "null",
-          "transition_strategy": "null",
-          "type": "str",
-          "updated_at": "null"
-        },
-        "status": "str"
+        "created_at": "str",
+        "demo_plugin_id": "null",
+        "device_type": "str",
+        "display_type": "null",
+        "duration_seconds": "int",
+        "id": "str",
+        "line_metadata": "null",
+        "name": "str",
+        "notes_tall": "int",
+        "notes_wide": "int",
+        "rows": "null",
+        "template": [
+          "str",
+          "str",
+          "str",
+          "str",
+          "str",
+          "str"
+        ],
+        "transition_interval_ms": "null",
+        "transition_step_size": "null",
+        "transition_strategy": "null",
+        "type": "str",
+        "updated_at": "null"
       }
     },
     {
@@ -546,9 +542,19 @@
       "label": "preview_batch_invalid",
       "method": "POST",
       "path_template": "/pages/preview/batch",
-      "status": 400,
+      "status": 422,
       "shape": {
-        "detail": "str"
+        "detail": [
+          {
+            "input": "str",
+            "loc": [
+              "str",
+              "str"
+            ],
+            "msg": "str",
+            "type": "str"
+          }
+        ]
       }
     },
     {
@@ -571,7 +577,7 @@
       "status": 200,
       "shape": {
         "message": "str",
-        "status": "str"
+        "page_id": "null"
       }
     },
     {
@@ -581,7 +587,7 @@
       "status": 200,
       "shape": {
         "message": "str",
-        "status": "str"
+        "page_id": "str"
       }
     },
     {
@@ -652,7 +658,6 @@
         "page_id": "str",
         "paused": "bool",
         "sent_to_board": "bool",
-        "status": "str",
         "target": "str"
       }
     }

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -40,7 +40,12 @@ def mock_service():
     service.initialize.return_value = True
     service.reinitialize_board_client.return_value = None
     service.check_and_send_active_page.return_value = None
-    with patch("src.api_server.get_service", return_value=service):
+    # Patched on api_server and on the pages router, which since Phase 2
+    # slice 3 imports the accessor from src/display_runtime.py at import time.
+    with (
+        patch("src.api_server.get_service", return_value=service),
+        patch("src.pages.routes.get_service", return_value=service),
+    ):
         yield service
 
 
@@ -70,8 +75,17 @@ def mock_config_manager():
 
 @pytest.fixture
 def mock_settings_service():
-    """Mock the settings service."""
-    with patch("src.api_server.get_settings_service") as mock_get:
+    """Mock the settings service.
+
+    Patched on api_server, on the pages router (which binds it at import time
+    since Phase 2 slice 3) and on src/board_guards.py (where the board lookup
+    and pause/silence guards now live). One stub, every resolution path.
+    """
+    with (
+        patch("src.api_server.get_settings_service") as mock_get,
+        patch("src.pages.routes.get_settings_service") as routes_get,
+        patch("src.board_guards.get_settings_service") as guards_get,
+    ):
         ss = Mock()
         transition = Mock()
         transition.strategy = "column"
@@ -102,39 +116,57 @@ def mock_settings_service():
         ss.should_send_to_board.return_value = False
         ss.set_active_page_id.return_value = None
         mock_get.return_value = ss
+        routes_get.return_value = ss
+        guards_get.return_value = ss
         yield ss
 
 
 @pytest.fixture
 def mock_page_service():
-    """Mock the page service."""
-    with patch("src.api_server.get_page_service") as mock_get:
+    """Mock the page service.
+
+    Patched on both api_server and the pages router, which binds its
+    collaborators at import time since Phase 2 slice 3.
+    """
+    with (
+        patch("src.api_server.get_page_service") as mock_get,
+        patch("src.pages.routes.get_page_service") as routes_get,
+    ):
         ps = Mock()
         page = Mock()
         page.transition_strategy = None
         page.transition_interval_ms = None
         page.transition_step_size = None
         page.device_type = "flagship"
+        page.notes_wide = 1
+        page.notes_tall = 1
         ps.get_page.return_value = page
 
         preview = Mock()
         preview.available = True
         preview.formatted = "HELLO WORLD"
+        preview.display_type = "page:template"
+        preview.raw = {}
         preview.error = None
         ps.preview_page.return_value = preview
 
         mock_get.return_value = ps
+        routes_get.return_value = ps
         yield ps
 
 
 @pytest.fixture
 def mock_collection_service():
     """Mock the collection service."""
-    with patch("src.api_server.get_collection_service") as mock_get:
+    with (
+        patch("src.api_server.get_collection_service") as mock_get,
+        patch("src.pages.routes.get_collection_service") as routes_get,
+    ):
         cs = Mock()
         cs.get_collection.return_value = None
         cs.resolve_page_id.return_value = None
         mock_get.return_value = cs
+        routes_get.return_value = cs
         yield cs
 
 
@@ -224,7 +256,10 @@ class TestStopService:
     def test_stop_success(self, client):
         """Stopping a running service."""
         service = Mock()
-        with patch("src.api_server._service_running", True), patch("src.api_server._service", service):
+        with (
+            patch("src.api_server._service_running", True),
+            patch("src.api_server.peek_service", return_value=service),
+        ):
             response = client.post("/stop")
             assert response.status_code == 200
             assert response.json()["status"] == "stopped"
@@ -235,7 +270,9 @@ class TestSendWelcomeMessage:
 
     def test_welcome_silence_mode(self, client):
         """Welcome is blocked during silence mode."""
-        with patch("src.api_server.Config") as mock_config:
+        # _silence_active reads Config from src/board_guards.py since Phase 2
+        # slice 3, so the silence verdict is stubbed there.
+        with patch("src.board_guards.Config") as mock_config:
             mock_config.is_silence_mode_active.return_value = True
             response = client.post("/send-welcome-message")
             assert response.status_code == 200
@@ -1429,7 +1466,9 @@ class TestSendPage:
     def test_send_page_silence_mode_blocks(self, client, mock_service, mock_settings_service, mock_page_service):
         """Silence mode blocks board send but does not error."""
         mock_settings_service.should_send_to_board.return_value = True
-        with patch("src.api_server.Config") as mock_config:
+        # _silence_active reads Config from src/board_guards.py since Phase 2
+        # slice 3, so the silence verdict is stubbed there.
+        with patch("src.board_guards.Config") as mock_config:
             mock_config.is_silence_mode_active.return_value = True
             response = client.post("/pages/page1/send")
             assert response.status_code == 200

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -46,14 +46,19 @@ def mock_config_manager():
 
 @pytest.fixture
 def mock_settings_service():
-    """Mock the settings service."""
-    # The schedules router binds its collaborators at import time now
-    # (Phase 2 §2.3), so this fixture stubs both places: `src.api_server.<name>`
-    # for the handlers that still live in the app module, and
-    # `src.schedules.routes.<name>` for the eleven that no longer do.
+    """Mock the settings service.
+
+    Every module that resolves this collaborator gets the same stub:
+    ``src.api_server`` for the handlers still in the app module, the
+    ``pages`` and ``schedules`` routers (which bind at import time since
+    Phase 2 §2.3), and ``src.board_guards``, where the board lookup and the
+    pause/silence guards now live. One stub, every resolution path.
+    """
     with (
         patch("src.api_server.get_settings_service") as mock_get,
+        patch("src.pages.routes.get_settings_service") as pages_get,
         patch("src.schedules.routes.get_settings_service") as routes_get,
+        patch("src.board_guards.get_settings_service") as guards_get,
     ):
         ss = Mock()
         transition = Mock()
@@ -144,34 +149,37 @@ def mock_settings_service():
         ss.update_plugin_settings.return_value = plugin_settings
 
         mock_get.return_value = ss
+        pages_get.return_value = ss
         routes_get.return_value = ss
+        guards_get.return_value = ss
         yield ss
 
 
 @pytest.fixture
 def mock_page_service():
-    """Mock the page service."""
-    # The schedules router binds its collaborators at import time now
-    # (Phase 2 §2.3), so this fixture stubs both places: `src.api_server.<name>`
-    # for the handlers that still live in the app module, and
-    # `src.schedules.routes.<name>` for the eleven that no longer do.
+    """Mock the page service.
+
+    Patched on ``src.api_server`` (for the handlers still in that module) and
+    on both routers that bind this collaborator at import time since Phase 2
+    §2.3. One stub, every resolution path.
+    """
     with (
         patch("src.api_server.get_page_service") as mock_get,
+        patch("src.pages.routes.get_page_service") as pages_get,
         patch("src.schedules.routes.get_page_service") as routes_get,
     ):
         ps = Mock()
-        mock_page = Mock()
-        mock_page.model_dump.return_value = {
-            "id": "page1",
-            "name": "Test Page",
-            "type": "template",
-            "template": ["Hello"],
-            "device_type": "flagship",
-        }
-        mock_page.transition_strategy = None
-        mock_page.transition_interval_ms = None
-        mock_page.transition_step_size = None
-        mock_page.device_type = "flagship"
+        # A real Page, not a Mock: the pages routes declare response_model=Page,
+        # so FastAPI validates what the service hands back.
+        from src.pages.models import Page as _Page
+
+        mock_page = _Page(
+            id="page1",
+            name="Test Page",
+            type="template",
+            template=["Hello"],
+            device_type="flagship",
+        )
 
         ps.list_pages.return_value = [mock_page]
         ps.get_page.return_value = mock_page
@@ -197,10 +205,11 @@ def mock_page_service():
         # Batch preview returns a dict mapping page_id to DisplayResult
         ps.preview_pages_batch.return_value = {"page1": preview_result}
 
-        ps.get_cache_stats.return_value = {"size": 0, "cached_pages": [], "ttl_seconds": 30}
-        ps._invalidate_cache.return_value = None
+        ps.get_cache_stats.return_value = {"cache_size": 0, "cached_pages": [], "ttl_seconds": 30}
+        ps.invalidate_preview_cache.return_value = None
 
         mock_get.return_value = ps
+        pages_get.return_value = ps
         routes_get.return_value = ps
         yield ps
 
@@ -320,8 +329,15 @@ def mock_plugin_registry():
 
 @pytest.fixture
 def mock_service():
-    """Mock the global service."""
-    with patch("src.api_server.get_service") as mock_get:
+    """Mock the global service.
+
+    Patched on api_server and on the pages router, which since Phase 2 slice 3
+    imports the accessor from src/display_runtime.py at module import time.
+    """
+    with (
+        patch("src.api_server.get_service") as mock_get,
+        patch("src.pages.routes.get_service") as routes_get,
+    ):
         svc = Mock()
         svc.vb_client = Mock()
         svc.vb_client.send_characters.return_value = (True, True)
@@ -337,6 +353,7 @@ def mock_service():
         svc._polled_characters = None
         svc._polled_at = None
         mock_get.return_value = svc
+        routes_get.return_value = svc
         yield svc
 
 
@@ -1089,8 +1106,9 @@ class TestPagesEndpoints:
                 "template": ["Hello"],
             },
         )
-        assert response.status_code == 200
-        assert response.json()["status"] == "success"
+        # 201 + the bare page since the Phase 2 conventions pass.
+        assert response.status_code == 201
+        assert response.json()["id"] == "page1"
 
     def test_get_page(self, client, mock_page_service):
         response = client.get("/pages/page1")
@@ -1104,7 +1122,9 @@ class TestPagesEndpoints:
     def test_update_page(self, client, mock_page_service):
         response = client.put("/pages/page1", json={"name": "Updated"})
         assert response.status_code == 200
-        assert response.json()["status"] == "success"
+        # The {"status": "success"} key is gone; the page and its retarget
+        # warnings are the whole body now.
+        assert response.json()["page"]["id"] == "page1"
 
     def test_update_page_not_found(self, client, mock_page_service):
         mock_page_service.update_page.return_value = None
@@ -1175,7 +1195,9 @@ class TestPagesEndpoints:
 
     def test_preview_pages_batch_invalid_input(self, client, mock_page_service, mock_settings_service):
         response = client.post("/pages/preview/batch", json={"page_ids": "not_a_list"})
-        assert response.status_code == 400
+        # 422: the body is a typed model since the Phase 2 conventions pass, so
+        # this is FastAPI's standard validation error (was a hand-rolled 400).
+        assert response.status_code == 422
 
     def test_preview_pages_batch_page_not_found(self, client, mock_page_service, mock_settings_service):
         mock_page_service.preview_pages_batch.return_value = {"gone": None}
@@ -1218,7 +1240,9 @@ class TestPagesEndpoints:
         response = client.post("/pages/page1/send")
         assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "success"
+        # The {"status": "success"} key is gone since the Phase 2 conventions
+        # pass — the 200 already said it. The payload is unchanged.
+        assert data["page_id"] == "page1"
 
     def test_send_page_not_found(self, client, mock_page_service, mock_settings_service, mock_service):
         mock_page_service.get_page.return_value = None
@@ -1525,11 +1549,16 @@ class TestServiceLifecycle:
         assert response.json()["status"] == "success"
 
     def test_peek_service_does_not_create_service(self):
-        """peek_service returns the existing instance only — never creates one."""
-        from src import api_server
+        """peek_service returns the existing instance only — never creates one.
 
-        with patch.object(api_server, "_service", None):
-            assert api_server.peek_service() is None
+        The singleton moved to ``src/display_runtime.py`` in Phase 2 slice 3
+        so the extracted routers can reach it without importing api_server;
+        the state it guards is the same object.
+        """
+        from src import display_runtime
+
+        with patch.object(display_runtime, "_service", None):
+            assert display_runtime.peek_service() is None
 
     def test_send_message_marks_the_board_as_out_of_band(self, client, mock_service, mock_settings_service):
         """Issue #1831: a manual send replaces the page on the board, so the

--- a/tests/test_blocking_io_event_loop.py
+++ b/tests/test_blocking_io_event_loop.py
@@ -95,7 +95,9 @@ def _page_mock() -> Mock:
 
 
 def _preview_result_mock() -> Mock:
-    return Mock(available=True, formatted="HELLO", display_type="text", raw=None, error=None)
+    # raw is a real dict: DisplayResult declares it dict[str, Any] and
+    # PagePreviewResponse now types it, so a None here was never realistic.
+    return Mock(available=True, formatted="HELLO", display_type="text", raw={}, error=None)
 
 
 def _transition_settings_mock() -> Mock:
@@ -132,6 +134,10 @@ async def test_a_slow_force_refresh_does_not_block_the_event_loop():
     _assert_loop_stayed_free(health, waited, still_running, "force refresh")
 
 
+# The four /pages handlers below live in src/pages/routes.py, which binds its
+# collaborators at import time since Phase 2 slice 3 — so their stubs go on
+# that module, not on api_server. The api_server-owned handlers in this file
+# (refresh, force-refresh, active-page) keep their existing targets.
 @pytest.mark.asyncio
 async def test_a_slow_page_preview_does_not_block_the_event_loop():
     """POST /pages/{id}/preview renders the page (plugin fan-out) inline."""
@@ -142,8 +148,8 @@ async def test_a_slow_page_preview_does_not_block_the_event_loop():
         settings = Mock()
         settings.get_active_page_id.return_value = None
         with (
-            patch("src.api_server.get_page_service", return_value=page_service),
-            patch("src.api_server.get_settings_service", return_value=settings),
+            patch("src.pages.routes.get_page_service", return_value=page_service),
+            patch("src.pages.routes.get_settings_service", return_value=settings),
         ):
             return await ac.post("/pages/p1/preview")
 
@@ -161,8 +167,8 @@ async def test_a_slow_batch_preview_does_not_block_the_event_loop():
         settings = Mock()
         settings.get_active_page_id.return_value = None
         with (
-            patch("src.api_server.get_page_service", return_value=page_service),
-            patch("src.api_server.get_settings_service", return_value=settings),
+            patch("src.pages.routes.get_page_service", return_value=page_service),
+            patch("src.pages.routes.get_settings_service", return_value=settings),
         ):
             return await ac.post("/pages/preview/batch", json={"page_ids": ["p1", "p2"]})
 
@@ -182,9 +188,9 @@ async def test_a_slow_current_display_lookup_does_not_block_the_event_loop():
         page_service.get_page.return_value = _page_mock()
         page_service.preview_page = _blocking(release, _preview_result_mock())
         with (
-            patch("src.api_server.get_settings_service", return_value=settings),
-            patch("src.api_server.get_page_service", return_value=page_service),
-            patch("src.api_server.get_collection_service", return_value=Mock()),
+            patch("src.pages.routes.get_settings_service", return_value=settings),
+            patch("src.pages.routes.get_page_service", return_value=page_service),
+            patch("src.pages.routes.get_collection_service", return_value=Mock()),
         ):
             return await ac.get("/pages/current-display")
 
@@ -241,11 +247,11 @@ async def test_a_slow_page_send_does_not_block_the_event_loop():
         service.vb_client = Mock()
         service.vb_client.render = _blocking(release, (True, True))
         with (
-            patch("src.api_server.get_settings_service", return_value=settings),
-            patch("src.api_server.get_page_service", return_value=page_service),
-            patch("src.api_server.get_service", return_value=service),
-            patch("src.api_server._silence_active", return_value=False),
-            patch("src.api_server._board_is_paused", return_value=False),
+            patch("src.pages.routes.get_settings_service", return_value=settings),
+            patch("src.pages.routes.get_page_service", return_value=page_service),
+            patch("src.pages.routes.get_service", return_value=service),
+            patch("src.pages.routes._silence_active", return_value=False),
+            patch("src.pages.routes._board_is_paused", return_value=False),
         ):
             return await ac.post("/pages/p1/send?target=board")
 

--- a/tests/test_board_id_validation.py
+++ b/tests/test_board_id_validation.py
@@ -41,11 +41,17 @@ def one_board():
     settings.get_board_settings.return_value = board_settings
     settings.get_primary_board_id.return_value = "board-1"
     settings.is_schedule_enabled.return_value = False
-    # The schedules router binds get_settings_service at import time now
-    # (Phase 2 §2.3), and `require_board` reads the boards list through the
-    # accessor its *caller* holds — so stubbing the router's binding is what
-    # decides both the "unknown board" verdict and `is_schedule_enabled`.
-    with patch("src.schedules.routes.get_settings_service", return_value=settings):
+    # Three modules resolve this collaborator after Phase 2 §2.3, and the
+    # board verdict depends on which one the caller holds: the schedules and
+    # pages routers bind it at import time, and `require_board` reads the
+    # boards list through `src.board_guards`. Stub all three so the "unknown
+    # board" verdict and `is_schedule_enabled` are decided by this fixture
+    # whichever path a handler takes.
+    with (
+        patch("src.api_server.get_settings_service", return_value=settings),
+        patch("src.schedules.routes.get_settings_service", return_value=settings),
+        patch("src.board_guards.get_settings_service", return_value=settings),
+    ):
         yield settings
 
 

--- a/tests/test_board_paused.py
+++ b/tests/test_board_paused.py
@@ -145,7 +145,12 @@ def client():
 def mock_paused_settings_service():
     """Mock SettingsService with a single board and an in-memory paused
     flag so set_paused/is_paused round-trip realistically."""
-    with patch("src.api_server.get_settings_service") as mock_get:
+    with (
+        patch("src.api_server.get_settings_service") as mock_get,
+        # Board guards moved to src/board_guards.py (Phase 2 slice 3); they
+        # resolve the settings service there, not through api_server.
+        patch("src.board_guards.get_settings_service") as guard_get,
+    ):
         ss = Mock()
         state = {"paused": False}
 
@@ -170,6 +175,7 @@ def mock_paused_settings_service():
         ss.set_paused.side_effect = _set_paused
 
         mock_get.return_value = ss
+        guard_get.return_value = ss
         yield ss
 
 

--- a/tests/test_board_send_executor.py
+++ b/tests/test_board_send_executor.py
@@ -49,7 +49,9 @@ def _fresh_send_pool():
 
 
 def _preview_result_mock() -> Mock:
-    return Mock(available=True, formatted="HELLO", display_type="text", raw=None, error=None)
+    # raw is a real dict: DisplayResult declares it dict[str, Any] and
+    # PagePreviewResponse now types it, so a None here was never realistic.
+    return Mock(available=True, formatted="HELLO", display_type="text", raw={}, error=None)
 
 
 @pytest.mark.asyncio
@@ -79,8 +81,11 @@ async def test_concurrent_board_sends_do_not_starve_unrelated_thread_work():
         async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as ac:
             with (
                 patch("src.api_server.get_service", return_value=service),
-                patch("src.api_server.get_page_service", return_value=page_service),
-                patch("src.api_server.get_settings_service", return_value=settings),
+                # The unrelated endpoint below is POST /pages/{id}/preview, served
+                # by src/pages/routes.py, which binds its collaborators at import
+                # time since Phase 2 slice 3.
+                patch("src.pages.routes.get_page_service", return_value=page_service),
+                patch("src.pages.routes.get_settings_service", return_value=settings),
             ):
                 sends = [asyncio.create_task(ac.post("/refresh")) for _ in range(_CONCURRENT_SENDS)]
 

--- a/tests/test_collections_contract.py
+++ b/tests/test_collections_contract.py
@@ -52,8 +52,10 @@ def _seed_page(client: TestClient, name: str, first_line: str) -> str:
             "template": [first_line, "", "", "", "", ""],
         },
     )
-    assert response.status_code == 200, response.text
-    return response.json()["page"]["id"]
+    # RE-PINNED (pages slice): POST /pages now returns 201 with the created
+    # page as a bare body, replacing the 200 + {"page": {...}} envelope.
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
 
 
 @pytest.fixture

--- a/tests/test_live_output.py
+++ b/tests/test_live_output.py
@@ -135,7 +135,11 @@ class TestRenderTemplateLiveEndpoint:
         settings.get_transition_settings.return_value = transition_settings
         mock_settings.return_value = settings
 
-        with patch("src.api_server.board_client_from_board_dict", return_value=mock_board_client):
+        with (
+            patch("src.api_server.board_client_from_board_dict", return_value=mock_board_client),
+            # _require_board moved to src/board_guards.py (Phase 2 slice 3).
+            patch("src.board_guards.get_settings_service", return_value=settings),
+        ):
             response = client.post(
                 "/templates/render/live",
                 json={
@@ -344,6 +348,8 @@ class TestRenderTemplateLiveEndpoint:
 
         with (
             patch("src.api_server.board_client_from_board_dict", return_value=mock_board_client),
+            # _require_board moved to src/board_guards.py (Phase 2 slice 3).
+            patch("src.board_guards.get_settings_service", return_value=settings),
             patch("src.api_server.text_to_board_array") as mock_t2b,
         ):
             mock_t2b.return_value = [[0] * 15] * 3

--- a/tests/test_page_board_compatibility.py
+++ b/tests/test_page_board_compatibility.py
@@ -46,6 +46,8 @@ def env(monkeypatch, tmp_path):
     monkeypatch.setattr("src.collections.service.get_collection_service", lambda: collection_service)
     monkeypatch.setattr("src.api_server.get_page_service", lambda: page_service)
     monkeypatch.setattr("src.api_server.get_settings_service", lambda: settings)
+    # Board guards live in src/board_guards.py since Phase 2 slice 3.
+    monkeypatch.setattr("src.board_guards.get_settings_service", lambda: settings)
     monkeypatch.setattr("src.api_server.get_collection_service", lambda: collection_service)
     monkeypatch.setattr("src.api_server.get_schedule_service", lambda: schedule_service)
     # The schedules router binds its collaborators at import time now

--- a/tests/test_page_retarget.py
+++ b/tests/test_page_retarget.py
@@ -55,11 +55,19 @@ def env(monkeypatch, tmp_path):
     monkeypatch.setattr("src.collections.service.get_collection_service", lambda: collection_service)
     monkeypatch.setattr("src.schedules.service.get_schedule_service", lambda: schedule_service)
     monkeypatch.setattr("src.schedules.service.get_settings_service", lambda: settings)
+    # PUT /pages/{id} is served by src/pages/routes.py, which binds its
+    # collaborators at import time since Phase 2 slice 3.
+    monkeypatch.setattr("src.pages.routes.get_page_service", lambda: page_service)
+    monkeypatch.setattr("src.pages.routes.get_settings_service", lambda: settings)
+    monkeypatch.setattr("src.pages.routes.get_collection_service", lambda: collection_service)
+    monkeypatch.setattr("src.pages.routes.get_schedule_service", lambda: schedule_service)
+    monkeypatch.setattr("src.pages.routes.get_service", lambda: None)
     monkeypatch.setattr("src.api_server.get_page_service", lambda: page_service)
     monkeypatch.setattr("src.api_server.get_settings_service", lambda: settings)
     monkeypatch.setattr("src.api_server.get_collection_service", lambda: collection_service)
     monkeypatch.setattr("src.api_server.get_schedule_service", lambda: schedule_service)
     monkeypatch.setattr("src.api_server.get_service", lambda: None)
+    monkeypatch.setattr("src.board_guards.get_settings_service", lambda: settings)
     monkeypatch.setattr("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False)
 
     flagship_page = page_service.create_page(PageCreate(name="Flag Page", type="template", template=["a"]))
@@ -316,12 +324,19 @@ class TestUpdatePageRoute:
         assert response.status_code == 200
         assert response.json()["incompatible_references"] == []
 
-    def test_no_size_change_omits_key(self, client, env):
+    def test_no_size_change_reports_no_references(self, client, env):
+        """An edit that keeps the size never reports a stale reference.
+
+        The key used to be absent entirely; since the Phase 2 conventions pass
+        the response is one typed shape and the list is simply empty. The
+        behavior under test is the same: a rename must not warn about the
+        schedule entry that still points at this page.
+        """
         page = env["flagship_page"]
         _schedule(env, page.id)
         response = client.put(f"/pages/{page.id}", json={"name": "Renamed"})
         assert response.status_code == 200
-        assert "incompatible_references" not in response.json()
+        assert response.json()["incompatible_references"] == []
 
     def test_references_not_mutated(self, client, env):
         """Warn-only: the stale schedule entry and active page are untouched."""

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -1206,7 +1206,7 @@ class TestPagesAPIEndpoints:
     @pytest.fixture
     def mock_page_service(self):
         """Mock the page service."""
-        with patch("src.api_server.get_page_service") as mock:
+        with patch("src.pages.routes.get_page_service") as mock:
             mock_service = Mock()
             mock.return_value = mock_service
             yield mock_service
@@ -1233,10 +1233,9 @@ class TestPagesAPIEndpoints:
 
         response = client.post("/pages", json={"name": "New Page", "type": "single", "display_type": "weather"})
 
-        assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "success"
-        assert data["page"]["name"] == "New Page"
+        # 201 + the bare page since the Phase 2 conventions pass.
+        assert response.status_code == 201
+        assert response.json()["name"] == "New Page"
 
     def test_get_page(self, client, mock_page_service):
         """Test GET /pages/{id}."""
@@ -1316,7 +1315,7 @@ class TestPagesAPIEndpoints:
         assert data["page_id"] == "test-id"
         assert "Preview Content" in data["message"]
 
-    @patch("src.api_server.get_settings_service")
+    @patch("src.pages.routes.get_settings_service")
     def test_current_display_template_page(self, mock_settings, client, mock_page_service):
         """Test GET /pages/current-display returns raw template for template pages."""
         mock_svc = Mock()
@@ -1352,7 +1351,7 @@ class TestPagesAPIEndpoints:
         assert data["line_metadata"][0]["alignment"] == "center"
         assert data["line_metadata"][1]["wrap"] is True
 
-    @patch("src.api_server.get_settings_service")
+    @patch("src.pages.routes.get_settings_service")
     def test_current_display_single_page(self, mock_settings, client, mock_page_service):
         """Test GET /pages/current-display returns rendered lines for non-template pages."""
         mock_svc = Mock()
@@ -1383,7 +1382,7 @@ class TestPagesAPIEndpoints:
         assert data["template"] == ["72°F Sunny", "Humidity 45%"]
         assert data["line_metadata"] is None
 
-    @patch("src.api_server.get_settings_service")
+    @patch("src.pages.routes.get_settings_service")
     def test_current_display_no_active_page(self, mock_settings, client, mock_page_service):
         """Test GET /pages/current-display returns 404 when no active page."""
         mock_svc = Mock()
@@ -1395,8 +1394,8 @@ class TestPagesAPIEndpoints:
 
         assert response.status_code == 404
 
-    @patch("src.api_server.get_collection_service")
-    @patch("src.api_server.get_settings_service")
+    @patch("src.pages.routes.get_collection_service")
+    @patch("src.pages.routes.get_settings_service")
     def test_current_display_collection_resolved(self, mock_settings, mock_collection, client, mock_page_service):
         """Test GET /pages/current-display resolves collection to underlying page."""
         mock_svc = Mock()
@@ -1559,7 +1558,7 @@ class TestPageShareAPIEndpoints:
 
     @pytest.fixture
     def mock_page_service(self):
-        with patch("src.api_server.get_page_service") as mock:
+        with patch("src.pages.routes.get_page_service") as mock:
             mock_service = Mock()
             mock.return_value = mock_service
             yield mock_service
@@ -1609,10 +1608,9 @@ class TestPageShareAPIEndpoints:
             template=["Hello", "World", "", "", "", ""],
         )
         response = client.post("/pages/import", json={"share_string": share_string})
-        assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "success"
-        assert data["page"]["name"] == "Test Page"
+        # 201 + the bare page since the Phase 2 conventions pass.
+        assert response.status_code == 201
+        assert response.json()["name"] == "Test Page"
         mock_page_service.create_page.assert_called_once()
 
     def test_import_page_creates_new_id(self, client, mock_page_service):

--- a/tests/test_pages_contract.py
+++ b/tests/test_pages_contract.py
@@ -1,0 +1,503 @@
+"""Value-level contract goldens for the /pages API (Phase 2 §2, slice 3).
+
+These are deliberately *values*, not shapes. The shape corpus in
+``tests/golden/responses/pages.json`` records key sets and type names, so it
+cannot see a wrong page id, a template whose lines got reordered, a
+``sent_to_board`` that flipped, or an error string that stopped naming the
+missing resource — the class of regression Phase 1's masking bug proved shape
+goldens miss.
+
+Every assertion below is a promise this domain makes to the web client:
+the page builder reads the created/updated page straight into editor state,
+the compose dialog reads the import result, and the dashboard reads the
+send result — unlike collections, whose client discarded every mutation body.
+
+Covers all 16 routes the ``pages`` router serves, success and failure paths.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+MISSING_ID = "00000000-dead-beef-0000-000000000000"
+
+FLAGSHIP_TEMPLATE = ["HELLO CONTRACT", "", "", "", "", ""]
+
+
+@pytest.fixture
+def client(_isolated_data_dir):
+    """A TestClient whose services all resolve into this test's temp data dir."""
+    from src.api_server import app
+
+    return TestClient(app)
+
+
+def _create(client: TestClient, name: str, first_line: str) -> dict:
+    """POST /pages and return the created page as a dict.
+
+    The one place that knows the create envelope, so re-pinning the envelope
+    is a one-line change here instead of a sweep through the file.
+    """
+    response = client.post(
+        "/pages",
+        json={
+            "name": name,
+            "type": "template",
+            "device_type": "flagship",
+            "template": [first_line, "", "", "", "", ""],
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["page"]
+
+
+@pytest.fixture
+def page(client) -> dict:
+    return _create(client, "Contract Page A", "HELLO CONTRACT")
+
+
+# ── POST /pages ─────────────────────────────────────────────────────────────
+
+
+def test_create_returns_the_created_page_with_its_values(client):
+    response = client.post(
+        "/pages",
+        json={
+            "name": "Morning Board",
+            "type": "template",
+            "device_type": "flagship",
+            "template": FLAGSHIP_TEMPLATE,
+            "duration_seconds": 45,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    created = response.json()["page"]
+    assert created["name"] == "Morning Board"
+    assert created["type"] == "template"
+    assert created["device_type"] == "flagship"
+    # Line ORDER is the thing a shape golden cannot see.
+    assert created["template"] == FLAGSHIP_TEMPLATE
+    assert created["duration_seconds"] == 45
+    assert isinstance(created["id"], str) and created["id"]
+    assert created["updated_at"] is None
+
+
+def test_create_persists_the_page_under_the_id_it_returned(client):
+    created = _create(client, "Persisted", "PERSISTED")
+
+    fetched = client.get(f"/pages/{created['id']}")
+
+    assert fetched.status_code == 200
+    assert fetched.json()["id"] == created["id"]
+    assert fetched.json()["name"] == "Persisted"
+
+
+def test_create_rejects_a_body_missing_required_fields_with_422(client):
+    response = client.post("/pages", json={"type": "template"})
+
+    assert response.status_code == 422
+    # FastAPI's structured validation list, naming the field that was missing.
+    locations = [entry["loc"] for entry in response.json()["detail"]]
+    assert ["body", "name"] in locations
+
+
+def test_create_rejects_an_invalid_page_configuration_with_400(client):
+    # A template page with no template content fails the service's own
+    # validate_config(), not Pydantic's — so this is the 400 path, not 422.
+    response = client.post("/pages", json={"name": "Empty", "type": "template", "template": []})
+
+    assert response.status_code == 400
+    assert "template" in response.json()["detail"].lower()
+
+
+# ── GET /pages ──────────────────────────────────────────────────────────────
+
+
+def test_list_returns_every_page_and_a_matching_total(client):
+    first = _create(client, "List One", "ONE")
+    second = _create(client, "List Two", "TWO")
+
+    body = client.get("/pages").json()
+
+    ids = [p["id"] for p in body["pages"]]
+    assert first["id"] in ids
+    assert second["id"] in ids
+    assert body["total"] == len(body["pages"])
+
+
+# ── GET /pages/{page_id} ────────────────────────────────────────────────────
+
+
+def test_get_returns_the_bare_page_not_an_envelope(client, page):
+    body = client.get(f"/pages/{page['id']}").json()
+
+    assert body["id"] == page["id"]
+    assert body["name"] == "Contract Page A"
+    assert body["template"] == FLAGSHIP_TEMPLATE
+
+
+def test_get_missing_page_is_404_naming_the_id(client):
+    response = client.get(f"/pages/{MISSING_ID}")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == f"Page not found: {MISSING_ID}"
+
+
+# ── PUT /pages/{page_id} ────────────────────────────────────────────────────
+
+
+def test_update_returns_the_updated_page_with_the_new_values(client, page):
+    response = client.put(f"/pages/{page['id']}", json={"name": "Renamed", "duration_seconds": 90})
+
+    assert response.status_code == 200, response.text
+    updated = response.json()["page"]
+    assert updated["id"] == page["id"]
+    assert updated["name"] == "Renamed"
+    assert updated["duration_seconds"] == 90
+    # Unnamed fields survive a partial update.
+    assert updated["template"] == FLAGSHIP_TEMPLATE
+    assert updated["updated_at"] is not None
+
+
+def test_update_without_a_size_change_omits_incompatible_references(client, page):
+    body = client.put(f"/pages/{page['id']}", json={"name": "Same Size"}).json()
+
+    assert "incompatible_references" not in body
+
+
+def test_update_that_retargets_the_size_reports_incompatible_references(client, page):
+    body = client.put(f"/pages/{page['id']}", json={"device_type": "note"}).json()
+
+    # Present (list-valued) because the size changed; empty because nothing
+    # references this page yet. Warn-only — the page itself did retarget.
+    assert body["incompatible_references"] == []
+    assert body["page"]["device_type"] == "note"
+
+
+def test_update_missing_page_is_404_naming_the_id(client):
+    response = client.put(f"/pages/{MISSING_ID}", json={"name": "Nobody"})
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == f"Page not found: {MISSING_ID}"
+
+
+# ── DELETE /pages/{page_id} ─────────────────────────────────────────────────
+
+
+def test_delete_reports_the_deleted_page_and_removes_it(client, page):
+    other = _create(client, "Survivor", "SURVIVES")
+
+    response = client.delete(f"/pages/{other['id']}")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["message"] == f"Page {other['id']} deleted"
+    assert body["default_page_created"] is False
+    assert body["active_page_updated"] is False
+    assert client.get(f"/pages/{other['id']}").status_code == 404
+    # The other page is untouched.
+    assert client.get(f"/pages/{page['id']}").status_code == 200
+
+
+def test_deleting_the_last_page_creates_a_default_and_says_so(client, page):
+    response = client.delete(f"/pages/{page['id']}")
+
+    body = response.json()
+    assert body["default_page_created"] is True
+    assert body["message"] == f"Page {page['id']} deleted. A default welcome page was created."
+    assert body["new_page_id"] != page["id"]
+    assert client.get(f"/pages/{body['new_page_id']}").status_code == 200
+
+
+def test_delete_missing_page_is_404_naming_the_id(client):
+    response = client.delete(f"/pages/{MISSING_ID}")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == f"Page not found: {MISSING_ID}"
+
+
+# ── GET /pages/{page_id}/share and the import pair ──────────────────────────
+
+
+def test_share_round_trips_through_import_preview_without_persisting(client, page):
+    share_string = client.get(f"/pages/{page['id']}/share").json()["share_string"]
+    assert isinstance(share_string, str) and share_string
+
+    preview = client.post("/pages/import/preview", json={"share_string": share_string})
+
+    assert preview.status_code == 200, preview.text
+    decoded = preview.json()
+    assert decoded["name"] == "Contract Page A"
+    assert decoded["template"] == FLAGSHIP_TEMPLATE
+    assert decoded["device_type"] == "flagship"
+    # A preview never persists: still exactly one page on the instance.
+    assert client.get("/pages").json()["total"] == 1
+
+
+def test_share_missing_page_is_404_naming_the_id(client):
+    response = client.get(f"/pages/{MISSING_ID}/share")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == f"Page not found: {MISSING_ID}"
+
+
+def test_import_preview_rejects_a_malformed_share_string_with_422(client):
+    response = client.post("/pages/import/preview", json={"share_string": "not-a-share"})
+
+    assert response.status_code == 422
+    assert isinstance(response.json()["detail"], str)
+
+
+def test_import_creates_a_new_page_carrying_the_shared_values(client, page):
+    share_string = client.get(f"/pages/{page['id']}/share").json()["share_string"]
+
+    response = client.post("/pages/import", json={"share_string": share_string})
+
+    assert response.status_code == 200, response.text
+    imported = response.json()["page"]
+    assert imported["name"] == "Contract Page A"
+    assert imported["template"] == FLAGSHIP_TEMPLATE
+    # A fresh resource, not the one that was shared.
+    assert imported["id"] != page["id"]
+    assert client.get("/pages").json()["total"] == 2
+
+
+def test_import_rejects_a_malformed_share_string_with_422(client):
+    response = client.post("/pages/import", json={"share_string": "not-a-share"})
+
+    assert response.status_code == 422
+    assert isinstance(response.json()["detail"], str)
+
+
+# ── staff picks ─────────────────────────────────────────────────────────────
+
+
+def test_staff_picks_list_never_leaks_the_share_string(client):
+    picks = client.get("/staff-picks").json()
+
+    assert isinstance(picks, list) and picks
+    for pick in picks:
+        assert "share_string" not in pick
+        assert isinstance(pick["id"], str)
+        assert isinstance(pick["name"], str)
+        assert isinstance(pick["required_plugins"], list)
+
+
+def test_staff_pick_share_returns_a_string_that_imports(client):
+    pick_id = client.get("/staff-picks").json()[0]["id"]
+
+    share_string = client.get(f"/staff-picks/{pick_id}/share").json()["share_string"]
+
+    assert isinstance(share_string, str) and share_string
+    assert client.post("/pages/import/preview", json={"share_string": share_string}).status_code == 200
+
+
+def test_staff_pick_share_missing_is_404_naming_the_id(client):
+    response = client.get(f"/staff-picks/{MISSING_ID}/share")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == f"Staff pick not found: {MISSING_ID}"
+
+
+# ── previews ────────────────────────────────────────────────────────────────
+
+
+def test_preview_renders_the_page_and_returns_its_lines(client, page):
+    response = client.post(f"/pages/{page['id']}/preview")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["page_id"] == page["id"]
+    assert body["lines"] == body["message"].split("\n")
+    assert body["lines"][0].strip() == "HELLO CONTRACT"
+    assert body["display_type"] == "page:template"
+
+
+def test_preview_missing_page_is_404_naming_the_id(client):
+    response = client.post(f"/pages/{MISSING_ID}/preview")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == f"Page not found: {MISSING_ID}"
+
+
+def test_preview_batch_reports_each_page_separately(client, page):
+    response = client.post("/pages/preview/batch", json={"page_ids": [page["id"], MISSING_ID]})
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["total"] == 2
+    assert body["successful"] == 1
+    good = body["previews"][page["id"]]
+    assert good["available"] is True
+    assert good["page_id"] == page["id"]
+    assert good["lines"][0].strip() == "HELLO CONTRACT"
+    bad = body["previews"][MISSING_ID]
+    assert bad == {"error": "Page not found", "available": False}
+
+
+def test_preview_batch_rejects_a_non_list_page_ids_with_400(client):
+    response = client.post("/pages/preview/batch", json={"page_ids": "nope"})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "page_ids must be a list"
+
+
+# ── cache ───────────────────────────────────────────────────────────────────
+
+
+def test_cache_stats_counts_the_pages_that_have_been_previewed(client, page):
+    assert client.get("/pages/cache/stats").json()["cached_pages"] == []
+
+    client.post(f"/pages/{page['id']}/preview")
+
+    stats = client.get("/pages/cache/stats").json()
+    assert page["id"] in stats["cached_pages"]
+    assert stats["cache_size"] == len(stats["cached_pages"])
+    assert isinstance(stats["ttl_seconds"], int)
+
+
+def test_clearing_one_page_evicts_only_that_page(client, page):
+    other = _create(client, "Other Cached", "OTHER")
+    client.post(f"/pages/{page['id']}/preview")
+    client.post(f"/pages/{other['id']}/preview")
+
+    response = client.post("/pages/cache/clear", json={"page_id": page["id"]})
+
+    assert response.status_code == 200, response.text
+    assert response.json()["message"] == f"Cache cleared for page {page['id']}"
+    cached = client.get("/pages/cache/stats").json()["cached_pages"]
+    assert page["id"] not in cached
+    assert other["id"] in cached
+
+
+def test_clearing_with_no_body_evicts_every_page(client, page):
+    client.post(f"/pages/{page['id']}/preview")
+
+    response = client.post("/pages/cache/clear", json={})
+
+    assert response.status_code == 200, response.text
+    assert response.json()["message"] == "All preview caches cleared"
+    assert client.get("/pages/cache/stats").json()["cached_pages"] == []
+
+
+# ── GET /pages/current-display ──────────────────────────────────────────────
+
+
+def test_current_display_is_404_when_no_page_is_active(client, page):
+    response = client.get("/pages/current-display")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "No active page set"
+
+
+def test_current_display_returns_the_active_template_page_raw(client, page):
+    from src.settings.service import get_settings_service
+
+    get_settings_service().set_active_page_id(page["id"])
+
+    body = client.get("/pages/current-display").json()
+
+    assert body["page_id"] == page["id"]
+    assert body["page_name"] == "Contract Page A"
+    assert body["page_type"] == "template"
+    assert body["device_type"] == "flagship"
+    # RAW template, not rendered output — the editor starts a new page from it.
+    assert body["template"] == FLAGSHIP_TEMPLATE
+    assert body["line_metadata"] is None
+
+
+# ── POST /pages/{page_id}/send ──────────────────────────────────────────────
+
+
+def test_send_is_503_when_the_display_service_is_not_initialized(client, page):
+    with patch("src.api_server.get_service", return_value=None):
+        response = client.post(f"/pages/{page['id']}/send")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Service not initialized"
+
+
+def test_send_rejects_an_unknown_target_with_400(client, page):
+    response = client.post(f"/pages/{page['id']}/send", json={"target": "carrier-pigeon"})
+
+    assert response.status_code == 400
+    assert response.json()["detail"].startswith("Invalid target: carrier-pigeon")
+
+
+def test_send_missing_page_is_404_naming_the_id(client):
+    service = Mock()
+    service.vb_client = Mock()
+    with patch("src.api_server.get_service", return_value=service):
+        response = client.post(f"/pages/{MISSING_ID}/send", json={"target": "ui"})
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == f"Page not found: {MISSING_ID}"
+
+
+def test_send_to_ui_renders_the_page_without_touching_the_board(client, page):
+    service = Mock()
+    service.vb_client = Mock()
+
+    with patch("src.api_server.get_service", return_value=service):
+        response = client.post(f"/pages/{page['id']}/send", json={"target": "ui"})
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["page_id"] == page["id"]
+    assert body["sent_to_board"] is False
+    assert body["paused"] is False
+    assert body["target"] == "ui"
+    assert body["board_id"] is None
+    assert body["message"].split("\n")[0].strip() == "HELLO CONTRACT"
+    service.vb_client.render.assert_not_called()
+
+
+def test_send_to_board_renders_through_the_board_client(client, page):
+    service = Mock()
+    service.vb_client.render.return_value = (True, True)
+
+    with patch("src.api_server.get_service", return_value=service):
+        response = client.post(f"/pages/{page['id']}/send", json={"target": "board"})
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["sent_to_board"] is True
+    assert body["paused"] is False
+    assert body["target"] == "board"
+    board_array = service.vb_client.render.call_args[0][0]
+    assert len(board_array) == 6 and len(board_array[0]) == 22
+
+
+def test_send_to_an_unreachable_board_is_500_not_a_200_success(client, page):
+    """A board that refused the send is never reported as a success.
+
+    Deliberately NOT 502/503/504: nginx intercepts those on /api/ and swaps
+    the body for its startup placeholder, so the caller would lose the
+    structured reason entirely.
+    """
+    service = Mock()
+    service.vb_client.render.return_value = (False, False)
+
+    with patch("src.api_server.get_service", return_value=service):
+        response = client.post(f"/pages/{page['id']}/send", json={"target": "board"})
+
+    assert response.status_code == 500
+    body = response.json()
+    assert body["detail"] == "Failed to send to board"
+    assert body["sent_to_board"] is False
+    assert body["page_id"] == page["id"]
+
+
+def test_send_to_an_unknown_board_id_is_404(client, page):
+    service = Mock()
+    service.vb_client = Mock()
+
+    with patch("src.api_server.get_service", return_value=service):
+        response = client.post(f"/pages/{page['id']}/send?board_id=board:nope", json={"target": "board"})
+
+    assert response.status_code == 404
+    assert "board:nope" in response.json()["detail"]

--- a/tests/test_pages_contract.py
+++ b/tests/test_pages_contract.py
@@ -13,6 +13,32 @@ the compose dialog reads the import result, and the dashboard reads the
 send result — unlike collections, whose client discarded every mutation body.
 
 Covers all 16 routes the ``pages`` router serves, success and failure paths.
+
+Re-pinned by the conventions pass in this same PR. What deliberately changed,
+and nothing else:
+
+* ``POST /pages`` answers **201** (was 200) with the **bare** page (was
+  ``{"status": "success", "page": {...}}``) — conventions doc, "Status codes"
+  and "Bare bodies".
+* ``POST /pages/import`` answers **201** with the bare page, same reason. Its
+  catch-all ``except Exception -> 422`` is gone: a share string the decoder or
+  ``PageCreate`` rejects is still 422, a page the service refuses is 400, and
+  an unexpected internal fault is now a 500 instead of being reported to the
+  user as a bad share string.
+* ``PUT /pages/{id}`` drops the ``"status": "success"`` key and always carries
+  ``incompatible_references`` (empty when the size did not change), so the
+  response is one typed shape instead of two.
+* ``DELETE /pages/{id}`` drops ``status`` and gains ``id`` — the conventions
+  doc's "200 with the deleted resource id", the arm collections also picked.
+* ``POST /pages/{id}/send`` drops ``status`` from both the success body and
+  the unreachable-board 500 body; the status code already carries it.
+* ``POST /pages/cache/clear`` drops ``status``.
+* ``POST /pages/preview/batch`` takes a typed body, so a non-list ``page_ids``
+  is FastAPI's standard **422** (was a hand-rolled 400).
+
+Every other value assertion — ids, template line ordering, list totals, error
+strings, ``sent_to_board`` / ``paused``, the 404/503 status codes — is
+unchanged from the pre-conversion recording. None was weakened.
 """
 
 from __future__ import annotations
@@ -39,7 +65,7 @@ def _create(client: TestClient, name: str, first_line: str) -> dict:
     """POST /pages and return the created page as a dict.
 
     The one place that knows the create envelope, so re-pinning the envelope
-    is a one-line change here instead of a sweep through the file.
+    was a one-line change here instead of a sweep through the file.
     """
     response = client.post(
         "/pages",
@@ -50,8 +76,8 @@ def _create(client: TestClient, name: str, first_line: str) -> dict:
             "template": [first_line, "", "", "", "", ""],
         },
     )
-    assert response.status_code == 200, response.text
-    return response.json()["page"]
+    assert response.status_code == 201, response.text
+    return response.json()
 
 
 @pytest.fixture
@@ -74,8 +100,9 @@ def test_create_returns_the_created_page_with_its_values(client):
         },
     )
 
-    assert response.status_code == 200, response.text
-    created = response.json()["page"]
+    # RE-PINNED: 201 + bare resource (was 200 + {"status", "page"}).
+    assert response.status_code == 201, response.text
+    created = response.json()
     assert created["name"] == "Morning Board"
     assert created["type"] == "template"
     assert created["device_type"] == "flagship"
@@ -154,6 +181,8 @@ def test_update_returns_the_updated_page_with_the_new_values(client, page):
     response = client.put(f"/pages/{page['id']}", json={"name": "Renamed", "duration_seconds": 90})
 
     assert response.status_code == 200, response.text
+    # RE-PINNED: the {"status": "success"} key is gone; the page and its
+    # retarget warnings remain.
     updated = response.json()["page"]
     assert updated["id"] == page["id"]
     assert updated["name"] == "Renamed"
@@ -163,10 +192,12 @@ def test_update_returns_the_updated_page_with_the_new_values(client, page):
     assert updated["updated_at"] is not None
 
 
-def test_update_without_a_size_change_omits_incompatible_references(client, page):
+def test_update_without_a_size_change_reports_no_incompatible_references(client, page):
     body = client.put(f"/pages/{page['id']}", json={"name": "Same Size"}).json()
 
-    assert "incompatible_references" not in body
+    # RE-PINNED: the key used to be absent unless the size changed. It is now
+    # always present so the response is one typed shape, and empty here.
+    assert body["incompatible_references"] == []
 
 
 def test_update_that_retargets_the_size_reports_incompatible_references(client, page):
@@ -195,6 +226,8 @@ def test_delete_reports_the_deleted_page_and_removes_it(client, page):
 
     assert response.status_code == 200, response.text
     body = response.json()
+    # RE-PINNED: gained "id" (the deleted resource id) and lost "status".
+    assert body["id"] == other["id"]
     assert body["message"] == f"Page {other['id']} deleted"
     assert body["default_page_created"] is False
     assert body["active_page_updated"] is False
@@ -257,8 +290,9 @@ def test_import_creates_a_new_page_carrying_the_shared_values(client, page):
 
     response = client.post("/pages/import", json={"share_string": share_string})
 
-    assert response.status_code == 200, response.text
-    imported = response.json()["page"]
+    # RE-PINNED: 201 + bare resource, matching POST /pages.
+    assert response.status_code == 201, response.text
+    imported = response.json()
     assert imported["name"] == "Contract Page A"
     assert imported["template"] == FLAGSHIP_TEMPLATE
     # A fresh resource, not the one that was shared.
@@ -339,11 +373,14 @@ def test_preview_batch_reports_each_page_separately(client, page):
     assert bad == {"error": "Page not found", "available": False}
 
 
-def test_preview_batch_rejects_a_non_list_page_ids_with_400(client):
+def test_preview_batch_rejects_a_non_list_page_ids_with_422(client):
     response = client.post("/pages/preview/batch", json={"page_ids": "nope"})
 
-    assert response.status_code == 400
-    assert response.json()["detail"] == "page_ids must be a list"
+    # RE-PINNED: 422 (was a hand-rolled 400 with "page_ids must be a list").
+    # The body is now a typed model, so this is FastAPI's standard validation
+    # error — same rejection, the shape every other typed body already uses.
+    assert response.status_code == 422
+    assert [e["loc"] for e in response.json()["detail"]] == [["body", "page_ids"]]
 
 
 # ── cache ───────────────────────────────────────────────────────────────────
@@ -414,7 +451,7 @@ def test_current_display_returns_the_active_template_page_raw(client, page):
 
 
 def test_send_is_503_when_the_display_service_is_not_initialized(client, page):
-    with patch("src.api_server.get_service", return_value=None):
+    with patch("src.pages.routes.get_service", return_value=None):
         response = client.post(f"/pages/{page['id']}/send")
 
     assert response.status_code == 503
@@ -431,7 +468,7 @@ def test_send_rejects_an_unknown_target_with_400(client, page):
 def test_send_missing_page_is_404_naming_the_id(client):
     service = Mock()
     service.vb_client = Mock()
-    with patch("src.api_server.get_service", return_value=service):
+    with patch("src.pages.routes.get_service", return_value=service):
         response = client.post(f"/pages/{MISSING_ID}/send", json={"target": "ui"})
 
     assert response.status_code == 404
@@ -442,7 +479,7 @@ def test_send_to_ui_renders_the_page_without_touching_the_board(client, page):
     service = Mock()
     service.vb_client = Mock()
 
-    with patch("src.api_server.get_service", return_value=service):
+    with patch("src.pages.routes.get_service", return_value=service):
         response = client.post(f"/pages/{page['id']}/send", json={"target": "ui"})
 
     assert response.status_code == 200, response.text
@@ -460,7 +497,7 @@ def test_send_to_board_renders_through_the_board_client(client, page):
     service = Mock()
     service.vb_client.render.return_value = (True, True)
 
-    with patch("src.api_server.get_service", return_value=service):
+    with patch("src.pages.routes.get_service", return_value=service):
         response = client.post(f"/pages/{page['id']}/send", json={"target": "board"})
 
     assert response.status_code == 200, response.text
@@ -482,7 +519,7 @@ def test_send_to_an_unreachable_board_is_500_not_a_200_success(client, page):
     service = Mock()
     service.vb_client.render.return_value = (False, False)
 
-    with patch("src.api_server.get_service", return_value=service):
+    with patch("src.pages.routes.get_service", return_value=service):
         response = client.post(f"/pages/{page['id']}/send", json={"target": "board"})
 
     assert response.status_code == 500
@@ -496,8 +533,58 @@ def test_send_to_an_unknown_board_id_is_404(client, page):
     service = Mock()
     service.vb_client = Mock()
 
-    with patch("src.api_server.get_service", return_value=service):
+    with patch("src.pages.routes.get_service", return_value=service):
         response = client.post(f"/pages/{page['id']}/send?board_id=board:nope", json={"target": "board"})
 
     assert response.status_code == 404
     assert "board:nope" in response.json()["detail"]
+
+
+# ── POST /pages/import: 422 is for the caller's mistake, not ours ────────────
+
+
+def test_import_reports_an_internal_storage_failure_as_500_not_422(client, page):
+    """A fault inside this process is a server error, not a bad share string.
+
+    The handler used to wrap the whole create in ``except Exception -> 422``,
+    so a storage write that blew up was reported to the user as "Invalid share
+    string" — pointing them at the one thing that was fine. Only the decoder
+    and ``PageCreate`` validation answer 422 now; a ``ValueError`` the service
+    raises is the 400 it always was; everything else propagates.
+    """
+    share_string = client.get(f"/pages/{page['id']}/share").json()["share_string"]
+    service = Mock()
+    service.create_page.side_effect = RuntimeError("disk exploded")
+
+    with patch("src.pages.routes.get_page_service", return_value=service):
+        with pytest.raises(RuntimeError, match="disk exploded"):
+            client.post("/pages/import", json={"share_string": share_string})
+
+
+def test_import_reports_a_rejected_page_as_400(client, page):
+    """A page the service refuses is the caller's error, but not a bad string."""
+    share_string = client.get(f"/pages/{page['id']}/share").json()["share_string"]
+    service = Mock()
+    service.create_page.side_effect = ValueError("Template page requires template content")
+
+    with patch("src.pages.routes.get_page_service", return_value=service):
+        response = client.post("/pages/import", json={"share_string": share_string})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Template page requires template content"
+
+
+def test_import_reports_share_contents_pydantic_rejects_as_422(client):
+    """A well-formed envelope carrying an invalid page is still the caller's."""
+    import base64
+    import json as _json
+
+    from src.pages.share import SHARE_VERSION
+
+    envelope = {"v": SHARE_VERSION, "page": {"name": "", "type": "template"}}
+    share_string = base64.urlsafe_b64encode(_json.dumps(envelope).encode()).decode().rstrip("=")
+
+    response = client.post("/pages/import", json={"share_string": share_string})
+
+    assert response.status_code == 422
+    assert response.json()["detail"].startswith("Invalid share string — ")

--- a/tests/test_pages_decoupled.py
+++ b/tests/test_pages_decoupled.py
@@ -1,0 +1,263 @@
+"""The pages router must not depend on ``src.api_server`` (Phase 2 §2.3).
+
+The #1756 extraction moved the sixteen pages/staff-picks handlers out of the
+10k-line ``src/api_server.py`` but left **thirteen** call-time
+``from src.api_server import ...`` statements behind — the second-heaviest of
+any router — purely so the suite's ``patch("src.api_server.<name>")`` targets
+kept resolving. That is not an extraction: importing the router was clean, but
+*serving a request* pulled the whole module — its route table, its background
+tasks, its MCP mount — back in, and the 2026-09 audit counted those seams going
+up 4.2x across Phase 1.
+
+This test pins the fix the honest way. In a fresh interpreter it imports the
+router, drives **all sixteen** handlers end to end against patched canonical
+seams (``src.pages.routes.<name>``), asserts the stubs really were driven — so
+a handler that silently no-op'd could not pass — and then asserts
+``src.api_server`` never entered ``sys.modules``.
+
+Importing the module alone would be a much weaker claim: the seams were call
+time, so a module-level import check passes with every one of them still in
+place.
+
+Where the collaborators went, for the reader chasing a patch target:
+
+===========================================  ==================================
+Was                                          Now
+===========================================  ==================================
+``api_server.get_page_service``              ``src.pages.service``
+``api_server.get_settings_service``          ``src.settings.service``
+``api_server.get_collection_service``        ``src.collections.service``
+``api_server.get_schedule_service``          ``src.schedules.service``
+``api_server.is_collection_id``              ``src.collections.models``
+``api_server.resolve_dimensions``            ``src.devices``
+``api_server.text_to_board_array``           ``src.text_to_board``
+``api_server.get_service``                   ``src.display_runtime`` (new)
+``api_server._require_board``                ``src.board_guards`` (new)
+``api_server._board_dims``                   ``src.board_guards``
+``api_server._board_is_paused``              ``src.board_guards``
+``api_server._silence_active``               ``src.board_guards``
+``api_server._reject_plugin_...beta_off``    ``src.pages.routes`` (sole caller)
+===========================================  ==================================
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SCRIPT = r"""
+import asyncio
+import sys
+from unittest.mock import MagicMock, patch
+
+import src.pages.routes as routes
+from src.pages.models import (
+    Page,
+    PageCacheClearRequest,
+    PageCreate,
+    PageImportRequest,
+    PagePreviewBatchRequest,
+    PageSendRequest,
+    PageUpdate,
+)
+from src.pages.share import encode_page
+
+assert "src.api_server" not in sys.modules, "importing the pages router must not import api_server"
+
+
+def call(coro):
+    return asyncio.run(coro)
+
+
+sample = Page(
+    id="page:abc",
+    name="Decoupled",
+    type="template",
+    device_type="flagship",
+    template=["DECOUPLED", "", "", "", "", ""],
+)
+share_string = encode_page(sample)
+
+rendered = MagicMock(available=True, formatted="DECOUPLED\n", display_type="page:template", raw={}, error=None)
+
+delete_result = MagicMock(
+    deleted=True,
+    default_page_created=False,
+    new_page_id=None,
+    active_page_updated=False,
+    new_active_page_id=None,
+)
+
+page_service = MagicMock()
+page_service.list_pages.return_value = [sample]
+page_service.get_page.return_value = sample
+page_service.create_page.return_value = sample
+page_service.update_page.return_value = sample
+page_service.delete_page.return_value = delete_result
+page_service.preview_page.return_value = rendered
+page_service.preview_pages_batch.return_value = {"page:abc": rendered}
+page_service.get_cache_stats.return_value = {"cache_size": 1, "cached_pages": ["page:abc"], "ttl_seconds": 30}
+
+settings_service = MagicMock()
+settings_service.is_schedule_enabled.return_value = False
+settings_service.get_active_page_id.return_value = "page:abc"
+settings_service.should_send_to_board.return_value = False
+settings_service.get_primary_board_id.return_value = "board-1"
+settings_service.get_output_settings.return_value = MagicMock(target="ui")
+settings_service.get_transition_settings.return_value = MagicMock(strategy=None, step_interval_ms=None, step_size=None)
+settings_service.get_beta_settings.return_value = MagicMock(transition_plugins_enabled=True)
+
+collection_service = MagicMock()
+collection_service.resolve_page_id.return_value = "page:abc"
+
+schedule_service = MagicMock()
+schedule_service.get_active_page_id.return_value = "page:abc"
+
+board_client = MagicMock()
+board_client.render.return_value = (True, True)
+display_service = MagicMock()
+display_service.vb_client = board_client
+display_service.get_board_client.return_value = board_client
+
+BOARD = {"id": "board-1", "name": "Kitchen", "device_type": "flagship"}
+
+with (
+    patch("src.pages.routes.get_page_service", return_value=page_service),
+    patch("src.pages.routes.get_settings_service", return_value=settings_service),
+    patch("src.pages.routes.get_collection_service", return_value=collection_service),
+    patch("src.pages.routes.get_schedule_service", return_value=schedule_service),
+    patch("src.pages.routes.get_service", return_value=display_service),
+    patch("src.pages.routes._require_board", return_value=BOARD) as require_board,
+    patch("src.pages.routes._silence_active", return_value=False) as silence_active,
+    patch("src.pages.routes._board_is_paused", return_value=False) as board_is_paused,
+):
+    # 1. GET /pages
+    listed = call(routes.list_pages())
+    assert listed.total == 1, listed
+    assert listed.pages[0].name == "Decoupled", listed
+
+    # 2. GET /pages/current-display
+    current = call(routes.get_current_display())
+    assert current.page_id == "page:abc", current
+    assert current.template == sample.template, current
+
+    # 3. POST /pages
+    created = call(routes.create_page(PageCreate(name="Decoupled", type="template", template=["DECOUPLED"])))
+    assert created.id == "page:abc", created
+
+    # 4. GET /pages/{page_id}
+    fetched = call(routes.get_page("page:abc"))
+    assert fetched.id == "page:abc", fetched
+
+    # 5. PUT /pages/{page_id}
+    updated = call(routes.update_page("page:abc", PageUpdate(name="Renamed")))
+    assert updated.page.id == "page:abc", updated
+    assert updated.incompatible_references == [], updated
+
+    # 6. DELETE /pages/{page_id}
+    deleted = call(routes.delete_page("page:abc"))
+    assert deleted.id == "page:abc", deleted
+
+    # 7. GET /pages/{page_id}/share
+    shared = call(routes.get_page_share_string("page:abc"))
+    assert shared.share_string == share_string, shared
+
+    # 8. POST /pages/import/preview
+    previewed = call(routes.preview_page_import(PageImportRequest(share_string=share_string)))
+    assert previewed["name"] == "Decoupled", previewed
+
+    # 9. POST /pages/import
+    imported = call(routes.import_page(PageImportRequest(share_string=share_string)))
+    assert imported.id == "page:abc", imported
+
+    # 10. GET /staff-picks
+    picks = call(routes.list_staff_picks())
+    assert isinstance(picks, list) and picks, picks
+    assert all("share_string" not in p for p in picks), picks
+
+    # 11. GET /staff-picks/{pick_id}/share
+    pick_share = call(routes.get_staff_pick_share(picks[0]["id"]))
+    assert isinstance(pick_share.share_string, str) and pick_share.share_string, pick_share
+
+    # 12. POST /pages/{page_id}/preview
+    preview = call(routes.preview_page("page:abc", force_refresh=True))
+    assert preview.lines == ["DECOUPLED", ""], preview
+
+    # 13. POST /pages/preview/batch
+    batch = call(routes.preview_pages_batch(PagePreviewBatchRequest(page_ids=["page:abc"])))
+    assert batch.total == 1 and batch.successful == 1, batch
+
+    # 14. GET /pages/cache/stats
+    stats = call(routes.get_page_cache_stats())
+    assert stats.cached_pages == ["page:abc"], stats
+
+    # 15. POST /pages/cache/clear
+    cleared = call(routes.clear_page_cache(PageCacheClearRequest(page_id="page:abc")))
+    assert cleared.page_id == "page:abc", cleared
+
+    # 16. POST /pages/{page_id}/send — the deepest handler: board lookup, the
+    # silence and pause guards, dimension resolution and the board render.
+    sent = call(routes.send_page("page:abc", payload=PageSendRequest(target="board", board_id="board-1")))
+    assert sent.sent_to_board is True, sent
+    assert sent.board_id == "board-1", sent
+
+# Not vacuous: every handler really drove its collaborator. A handler that
+# silently returned a canned value would fail here even though its assertion
+# above passed.
+page_service.list_pages.assert_called_once()
+page_service.create_page.assert_called()
+page_service.update_page.assert_called_once()
+page_service.delete_page.assert_called_once_with("page:abc")
+page_service.preview_page.assert_called()
+page_service.preview_pages_batch.assert_called_once()
+page_service.get_cache_stats.assert_called_once()
+page_service.invalidate_preview_cache.assert_called_once_with("page:abc")
+settings_service.get_active_page_id.assert_called()
+settings_service.get_transition_settings.assert_called_once()
+schedule_service.get_active_page_id.assert_not_called()  # schedule mode is off
+require_board.assert_called_once_with("board-1")
+silence_active.assert_called_once_with("board-1")
+board_is_paused.assert_called_once_with("board-1")
+board_client.render.assert_called_once()
+
+assert "src.api_server" not in sys.modules, (
+    "a pages handler imported src.api_server — the call-time seam regrew"
+)
+print("DECOUPLED")
+"""
+
+
+def test_pages_router_serves_every_route_without_importing_api_server():
+    result = subprocess.run(
+        [sys.executable, "-c", SCRIPT],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    assert "DECOUPLED" in result.stdout
+
+
+def test_pages_router_source_declares_no_api_server_import():
+    """A static backstop over every branch, not just the exercised ones.
+
+    The subprocess test above can only catch a seam on a code path it drives.
+    This walks the module's AST, so an ``import api_server`` hidden inside a
+    rarely-taken ``except`` branch fails the build too.
+    """
+    import ast
+
+    tree = ast.parse((REPO_ROOT / "src" / "pages" / "routes.py").read_text())
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            offenders += [a.name for a in node.names if "api_server" in a.name]
+        elif isinstance(node, ast.ImportFrom) and "api_server" in (node.module or ""):
+            offenders.append(node.module)
+
+    assert offenders == [], f"src/pages/routes.py imports api_server: {offenders}"

--- a/tests/test_persistence_round_trip.py
+++ b/tests/test_persistence_round_trip.py
@@ -95,8 +95,9 @@ def _create_page(client: TestClient, name: str = "Restart Survivor") -> dict:
             "duration_seconds": 42,
         },
     )
-    assert response.status_code == 200, response.text
-    return response.json()["page"]
+    # 201 + the bare page since the Phase 2 conventions pass.
+    assert response.status_code == 201, response.text
+    return response.json()
 
 
 def _create_schedule(client: TestClient, page_id: str) -> dict:

--- a/tests/test_response_shape_goldens.py
+++ b/tests/test_response_shape_goldens.py
@@ -288,8 +288,9 @@ def _seed_page(client: TestClient, name: str, first_line: str) -> str:
             "template": [first_line, "", "", "", "", ""],
         },
     )
-    assert response.status_code == 200, response.text
-    return response.json()["page"]["id"]
+    # 201 + the bare page since the Phase 2 conventions pass on this domain.
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
 
 
 MISSING_ID = "00000000-dead-beef-0000-000000000000"
@@ -378,7 +379,9 @@ def test_pages_response_shapes():
 
     # send: service unavailable, bad target, missing page, and a ui-only
     # success (never touches a board client).
-    with patch("src.api_server.get_service", return_value=None):
+    # POST /pages/{id}/send resolves the DisplayService accessor through
+    # src/pages/routes.py since the Phase 2 conventions pass.
+    with patch("src.pages.routes.get_service", return_value=None):
         rec.hit("send_page_no_service", "POST", "/pages/{page_id}/send", path_params={"page_id": page_id})
     rec.hit(
         "send_page_bad_target",
@@ -389,7 +392,7 @@ def test_pages_response_shapes():
     )
     mock_service = Mock()
     mock_service.vb_client = Mock()
-    with patch("src.api_server.get_service", return_value=mock_service):
+    with patch("src.pages.routes.get_service", return_value=mock_service):
         rec.hit(
             "send_page_missing",
             "POST",

--- a/tests/test_schedules_contract.py
+++ b/tests/test_schedules_contract.py
@@ -80,8 +80,10 @@ def _seed_page(client: TestClient, name: str, first_line: str) -> str:
             "template": [first_line, "", "", "", "", ""],
         },
     )
-    assert response.status_code == 200, response.text
-    return response.json()["page"]["id"]
+    # RE-PINNED (pages slice): POST /pages now returns 201 with the created
+    # page as a bare body, replacing the 200 + {"page": {...}} envelope.
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
 
 
 @pytest.fixture

--- a/tests/test_silence_per_board_call_sites.py
+++ b/tests/test_silence_per_board_call_sites.py
@@ -72,10 +72,13 @@ class TestApiSendGuards:
         """POST /send-message drives the primary board's client (issue #1788)."""
         service = MagicMock()
         service.vb_client.render.return_value = (True, True)
+        settings = _settings()
         with (
             _board_aware_silence(),
             patch("src.api_server.get_service", return_value=service),
-            patch("src.api_server.get_settings_service", return_value=_settings()),
+            patch("src.api_server.get_settings_service", return_value=settings),
+            # The send guards moved to src/board_guards.py (Phase 2 slice 3).
+            patch("src.board_guards.get_settings_service", return_value=settings),
         ):
             response = client.post("/send-message", json={"text": "HELLO"})
 
@@ -85,9 +88,12 @@ class TestApiSendGuards:
         service.vb_client.render.assert_not_called()
 
     def test_send_welcome_message_respects_the_primary_boards_window(self, client):
+        settings = _settings()
         with (
             _board_aware_silence(),
-            patch("src.api_server.get_settings_service", return_value=_settings()),
+            patch("src.api_server.get_settings_service", return_value=settings),
+            # The send guards moved to src/board_guards.py (Phase 2 slice 3).
+            patch("src.board_guards.get_settings_service", return_value=settings),
             patch("src.board_client.BoardClient") as board_client,
         ):
             board_client.return_value.render.return_value = (True, True)
@@ -102,18 +108,24 @@ class TestApiSendGuards:
         page = MagicMock(transition_strategy=None, transition_interval_ms=None, transition_step_size=None)
         page_service = MagicMock()
         page_service.get_page.return_value = page
-        page_service.preview_page.return_value = MagicMock(available=True, error=None)
+        # ``formatted`` is a real string now that PageSendResponse types the
+        # body — a bare MagicMock no longer serializes.
+        page_service.preview_page.return_value = MagicMock(available=True, error=None, formatted="HELLO")
         service = MagicMock()
         board_client = MagicMock()
         board_client.render.return_value = (True, True)
         service.get_board_client.return_value = board_client
 
+        settings = _settings(primary=LOUD_BOARD)
+        # POST /pages/{id}/send is served by src/pages/routes.py, which since
+        # Phase 2 slice 3 binds its collaborators at import time — so the stubs
+        # go where that module looks them up, not on api_server.
         with (
             _board_aware_silence(),
-            patch("src.api_server.get_page_service", return_value=page_service),
-            patch("src.api_server.get_settings_service", return_value=_settings(primary=LOUD_BOARD)),
-            patch("src.api_server.get_service", return_value=service),
-            patch("src.api_server._find_board", return_value=BOARDS[0]),
+            patch("src.pages.routes.get_page_service", return_value=page_service),
+            patch("src.pages.routes.get_settings_service", return_value=settings),
+            patch("src.pages.routes.get_service", return_value=service),
+            patch("src.pages.routes._require_board", return_value=BOARDS[0]),
         ):
             response = client.post(f"/pages/page-1/send?board_id={SILENCED_BOARD}")
 

--- a/tests/test_silence_schedule_per_board_api.py
+++ b/tests/test_silence_schedule_per_board_api.py
@@ -70,11 +70,16 @@ def silence_store():
 @pytest.fixture
 def boards():
     """Two boards of different sizes registered with the settings service."""
-    with patch("src.api_server.get_settings_service") as mock_get:
+    with (
+        patch("src.api_server.get_settings_service") as mock_get,
+        # _require_board lives in src/board_guards.py since Phase 2 slice 3.
+        patch("src.board_guards.get_settings_service") as guard_get,
+    ):
         svc = Mock()
         svc.get_board_settings.return_value = Mock(boards=[FLAGSHIP, NOTE])
         svc.get_primary_board_id.return_value = FLAGSHIP["id"]
         mock_get.return_value = svc
+        guard_get.return_value = svc
         yield svc
 
 

--- a/web/app/routes/pages._index.tsx
+++ b/web/app/routes/pages._index.tsx
@@ -86,9 +86,9 @@ export function ImportPageDialog({ open, onOpenChange }: { open: boolean; onOpen
     mutationFn: () => api.importPage(shareString.trim()),
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.pages, refetchType: "active" });
-      toast.success(t("toastImported", { name: data.page.name }));
+      toast.success(t("toastImported", { name: data.name }));
       onOpenChange(false);
-      push(`/pages/edit/${data.page.id}`, { transitionType: "slide-up" });
+      push(`/pages/edit/${data.id}`, { transitionType: "slide-up" });
     },
     onError: (err: Error) => {
       toast.error(err.message);

--- a/web/app/routes/picks.tsx
+++ b/web/app/routes/picks.tsx
@@ -52,8 +52,8 @@ function PickCard({ pick, enabledPluginIds }: { pick: StaffPick; enabledPluginId
     },
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.pages, refetchType: "active" });
-      toast.success(t("toastImported", { name: data.page.name }));
-      push(`/pages/edit/${data.page.id}`, { transitionType: "slide-up" });
+      toast.success(t("toastImported", { name: data.name }));
+      push(`/pages/edit/${data.id}`, { transitionType: "slide-up" });
     },
     onError: (err: Error) => {
       toast.error(err.message);

--- a/web/src/__tests__/api-extended.test.ts
+++ b/web/src/__tests__/api-extended.test.ts
@@ -138,7 +138,7 @@ describe("API Extended Tests", () => {
       server.use(
         http.put(`${API_BASE}/pages/:id`, async ({ request }) => {
           capturedBody = await request.json();
-          return HttpResponse.json({ status: "success", page: { ...capturedBody, id: "page-1" } });
+          return HttpResponse.json({ page: { ...capturedBody, id: "page-1" }, incompatible_references: [] });
         }),
       );
 
@@ -148,7 +148,8 @@ describe("API Extended Tests", () => {
 
     it("deletePage sends DELETE", async () => {
       const result = await api.deletePage("page-1");
-      expect(result.status).toBe("success");
+      // The envelope's "status" is gone; the deleted id is the contract now.
+      expect(result.id).toBe("page-1");
     });
 
     it("previewPage sends POST", async () => {
@@ -176,10 +177,10 @@ describe("API Extended Tests", () => {
         http.post(`${API_BASE}/pages/:id/send`, ({ request }) => {
           capturedUrl = request.url;
           return HttpResponse.json({
-            status: "success",
             page_id: "page-1",
             message: "sent",
             sent_to_board: true,
+            paused: false,
             target: "both",
           });
         }),
@@ -1137,10 +1138,10 @@ describe("Per-board boardId params (issue #1244)", () => {
       http.post(`${API_BASE}/pages/:id/send`, ({ request }) => {
         capturedUrl = request.url;
         return HttpResponse.json({
-          status: "success",
           page_id: "page-1",
           message: "sent",
           sent_to_board: true,
+          paused: false,
           target: "board",
         });
       }),

--- a/web/src/__tests__/api.test.ts
+++ b/web/src/__tests__/api.test.ts
@@ -24,8 +24,8 @@ describe("API Contract Tests", () => {
 
       const result = await api.createPage(page);
 
-      expect(result.status).toBe("success");
-      expect(result.page).toBeDefined();
+      // 201 with the bare page since the Phase 2 conventions pass.
+      expect(result.id).toBeDefined();
       expect(requestStore.lastPageCreate).toEqual(page);
       expect(requestStore.lastPageCreate?.type).toBe("single");
       expect(requestStore.lastPageCreate?.display_type).toBe("weather");
@@ -47,7 +47,7 @@ describe("API Contract Tests", () => {
 
       const result = await api.createPage(page);
 
-      expect(result.status).toBe("success");
+      expect(result.id).toBeDefined();
       expect(requestStore.lastPageCreate).toEqual(page);
       expect(requestStore.lastPageCreate?.type).toBe("composite");
       expect(requestStore.lastPageCreate?.rows).toHaveLength(3);
@@ -69,7 +69,7 @@ describe("API Contract Tests", () => {
 
       const result = await api.createPage(page);
 
-      expect(result.status).toBe("success");
+      expect(result.id).toBeDefined();
       expect(requestStore.lastPageCreate?.type).toBe("template");
       expect(requestStore.lastPageCreate?.template).toHaveLength(6);
       expect(requestStore.lastPageCreate?.template?.[0]).toBe("{{weather.temperature}}");
@@ -103,7 +103,7 @@ describe("API Contract Tests", () => {
     it("sendPage returns send result", async () => {
       const result = await api.sendPage("page-1");
 
-      expect(result.status).toBe("success");
+      // The {"status": "success"} key is gone; the 200 carries that.
       expect(result.page_id).toBe("page-1");
       expect(typeof result.sent_to_board).toBe("boolean");
     });

--- a/web/src/__tests__/compose-dialog.test.tsx
+++ b/web/src/__tests__/compose-dialog.test.tsx
@@ -138,7 +138,7 @@ describe("ComposePageDialog", () => {
       ),
       http.post(`${API_BASE}/pages`, () => {
         pageCreated = true;
-        return HttpResponse.json({ status: "success", page: { id: "p", name: "x" } });
+        return HttpResponse.json({ id: "p", name: "x" }, { status: 201 });
       }),
     );
 
@@ -157,7 +157,7 @@ describe("ComposePageDialog", () => {
     server.use(
       http.post(`${API_BASE}/pages`, async ({ request }) => {
         capturedPage = (await request.json()) as Record<string, unknown>;
-        return HttpResponse.json({ status: "success", page: { id: "p1", name: "Saved" } });
+        return HttpResponse.json({ id: "p1", name: "Saved" }, { status: 201 });
       }),
       http.post(`${API_BASE}/settings/temporary-override`, () => {
         overrideSent = true;

--- a/web/src/__tests__/import-page-dialog.test.tsx
+++ b/web/src/__tests__/import-page-dialog.test.tsx
@@ -131,9 +131,9 @@ describe("ImportPageDialog", () => {
     server.use(
       http.post(`${API_BASE}/pages/import`, async ({ request }) => {
         capturedBody = (await request.json()) as Record<string, unknown>;
-        return HttpResponse.json({
-          status: "success",
-          page: {
+        // 201 + the bare page since the Phase 2 conventions pass.
+        return HttpResponse.json(
+          {
             id: "imported-page-1",
             name: "Shared Page",
             type: "template",
@@ -142,7 +142,8 @@ describe("ImportPageDialog", () => {
             duration_seconds: 300,
             created_at: new Date().toISOString(),
           },
-        });
+          { status: 201 },
+        );
       }),
     );
 

--- a/web/src/__tests__/live-output.test.tsx
+++ b/web/src/__tests__/live-output.test.tsx
@@ -120,17 +120,15 @@ describe("Live Output Mode", () => {
       sent_to_board: true,
       board_id: "board-1",
     });
+    // createPage answers the bare page since the Phase 2 conventions pass.
     vi.mocked(api.createPage).mockResolvedValue({
-      status: "success",
-      page: {
-        id: "test-page-id",
-        name: "Test Page",
-        type: "template",
-        device_type: "flagship",
-        template: ["", "", "", "", "", ""],
-        duration_seconds: 300,
-        created_at: new Date().toISOString(),
-      },
+      id: "test-page-id",
+      name: "Test Page",
+      type: "template",
+      device_type: "flagship",
+      template: ["", "", "", "", "", ""],
+      duration_seconds: 300,
+      created_at: new Date().toISOString(),
     });
     vi.mocked(api.getBoardSettings).mockResolvedValue(defaultBoardSettings);
     vi.mocked(api.forceRefresh).mockResolvedValue({
@@ -328,17 +326,15 @@ describe("Live Output - Board Selector Interaction", () => {
       status: "success",
       message: "Display force-refreshed successfully",
     });
+    // createPage answers the bare page since the Phase 2 conventions pass.
     vi.mocked(api.createPage).mockResolvedValue({
-      status: "success",
-      page: {
-        id: "test-page-id",
-        name: "Test Page",
-        type: "template",
-        device_type: "flagship",
-        template: ["", "", "", "", "", ""],
-        duration_seconds: 300,
-        created_at: new Date().toISOString(),
-      },
+      id: "test-page-id",
+      name: "Test Page",
+      type: "template",
+      device_type: "flagship",
+      template: ["", "", "", "", "", ""],
+      duration_seconds: 300,
+      created_at: new Date().toISOString(),
     });
   });
 
@@ -399,17 +395,15 @@ describe("Live Output - Auto-timeout", () => {
       status: "success",
       message: "Display force-refreshed successfully",
     });
+    // createPage answers the bare page since the Phase 2 conventions pass.
     vi.mocked(api.createPage).mockResolvedValue({
-      status: "success",
-      page: {
-        id: "test-page-id",
-        name: "Test Page",
-        type: "template",
-        device_type: "flagship",
-        template: ["", "", "", "", "", ""],
-        duration_seconds: 300,
-        created_at: new Date().toISOString(),
-      },
+      id: "test-page-id",
+      name: "Test Page",
+      type: "template",
+      device_type: "flagship",
+      template: ["", "", "", "", "", ""],
+      duration_seconds: 300,
+      created_at: new Date().toISOString(),
     });
   });
 

--- a/web/src/__tests__/mocks/handlers.ts
+++ b/web/src/__tests__/mocks/handlers.ts
@@ -506,10 +506,8 @@ export const handlers = [
       duration_seconds: body.duration_seconds ?? 300,
       created_at: new Date().toISOString(),
     };
-    return HttpResponse.json({
-      status: "success",
-      page: newPage,
-    });
+    // 201 + the bare page since the Phase 2 conventions pass.
+    return HttpResponse.json(newPage, { status: 201 });
   }),
 
   http.put(`${API_BASE}/pages/:id`, async ({ request, params }) => {
@@ -521,14 +519,18 @@ export const handlers = [
       ...body,
       updated_at: new Date().toISOString(),
     };
-    return HttpResponse.json({
-      status: "success",
-      page: updatedPage,
-    });
+    return HttpResponse.json({ page: updatedPage, incompatible_references: [] });
   }),
 
-  http.delete(`${API_BASE}/pages/:id`, () => {
-    return HttpResponse.json({ status: "success", message: "Page deleted" });
+  http.delete(`${API_BASE}/pages/:id`, ({ params }) => {
+    return HttpResponse.json({
+      id: params.id,
+      message: "Page deleted",
+      default_page_created: false,
+      new_page_id: null,
+      active_page_updated: false,
+      new_active_page_id: null,
+    });
   }),
 
   http.post(`${API_BASE}/pages/:id/preview`, ({ params }) => {
@@ -643,7 +645,7 @@ export const handlers = [
       duration_seconds: 300,
       created_at: new Date().toISOString(),
     };
-    return HttpResponse.json({ status: "success", page: newPage });
+    return HttpResponse.json(newPage, { status: 201 });
   }),
 
   http.post(`${API_BASE}/pages/import/preview`, async ({ request }) => {
@@ -663,10 +665,10 @@ export const handlers = [
   http.post(`${API_BASE}/pages/:id/send`, ({ params }) => {
     const { id } = params;
     return HttpResponse.json({
-      status: "success",
       page_id: id,
       message: "Page sent",
       sent_to_board: true,
+      paused: false,
       target: "board",
     });
   }),

--- a/web/src/__tests__/new-components.test.tsx
+++ b/web/src/__tests__/new-components.test.tsx
@@ -77,8 +77,9 @@ describe("PageBuilder", () => {
       duration_seconds: 300,
       created_at: "2024-01-01T00:00:00Z",
     };
-    vi.mocked(api.createPage).mockResolvedValue({ status: "success", page: savedPage });
-    vi.mocked(api.updatePage).mockResolvedValue({ status: "success", page: savedPage });
+    // createPage answers the bare page; updatePage keeps { page, refs }.
+    vi.mocked(api.createPage).mockResolvedValue(savedPage);
+    vi.mocked(api.updatePage).mockResolvedValue({ page: savedPage, incompatible_references: [] });
   });
 
   afterEach(() => {

--- a/web/src/__tests__/page-builder-device-switch.test.tsx
+++ b/web/src/__tests__/page-builder-device-switch.test.tsx
@@ -150,7 +150,6 @@ describe("Page editor board-size switching", () => {
     const user = userEvent.setup();
     vi.mocked(api.getPage).mockResolvedValue(existingFlagshipPage);
     vi.mocked(api.updatePage).mockResolvedValue({
-      status: "success",
       page: { ...existingFlagshipPage, device_type: "note" },
       incompatible_references: [],
     });
@@ -185,7 +184,6 @@ describe("Page editor board-size switching", () => {
     const user = userEvent.setup();
     vi.mocked(api.getPage).mockResolvedValue(existingNotePage);
     vi.mocked(api.updatePage).mockResolvedValue({
-      status: "success",
       page: { ...existingNotePage, device_type: "flagship" },
       incompatible_references: [],
     });
@@ -215,7 +213,6 @@ describe("Page editor board-size switching", () => {
     const onClose = vi.fn();
     vi.mocked(api.getPage).mockResolvedValue(existingFlagshipPage);
     vi.mocked(api.updatePage).mockResolvedValue({
-      status: "success",
       page: { ...existingFlagshipPage, device_type: "note" },
       incompatible_references: [
         { board_id: "board-1", board_name: "Kitchen", surface: "schedule", schedule_id: "sched-1" },

--- a/web/src/__tests__/page-builder-new-page-invalidation.test.tsx
+++ b/web/src/__tests__/page-builder-new-page-invalidation.test.tsx
@@ -54,9 +54,11 @@ describe("PageBuilder — saving a new page", () => {
     localStorage.clear();
     server.use(
       http.post(`${API_BASE}/pages`, async () => {
-        return HttpResponse.json({
-          status: "success",
-          page: {
+        // 201 + the bare page since the Phase 2 conventions pass. This test is
+        // the #1586 regression guard: the id the builder invalidates on must be
+        // the one the create response carried.
+        return HttpResponse.json(
+          {
             id: NEW_PAGE_ID,
             name: "Fresh Page",
             type: "template",
@@ -65,7 +67,8 @@ describe("PageBuilder — saving a new page", () => {
             duration_seconds: 300,
             created_at: new Date().toISOString(),
           },
-        });
+          { status: 201 },
+        );
       }),
     );
   });

--- a/web/src/__tests__/page-builder-transition-picker.test.tsx
+++ b/web/src/__tests__/page-builder-transition-picker.test.tsx
@@ -76,8 +76,8 @@ function captureUpdate(): { body: Record<string, unknown> | null } {
     http.put(`${API_BASE}/pages/page-1`, async ({ request }) => {
       captured.body = (await request.json()) as Record<string, unknown>;
       return HttpResponse.json({
-        status: "success",
         page: { id: "page-1", name: "Weather Page", type: "template", device_type: "flagship" },
+        incompatible_references: [],
       });
     }),
   );

--- a/web/src/components/page-builder.tsx
+++ b/web/src/components/page-builder.tsx
@@ -95,6 +95,7 @@ import type {
   DeviceType,
   LineAlignment,
   LineMetadata,
+  Page,
   PageCreate,
   PageType,
   PageUpdate,
@@ -480,32 +481,35 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
             deviceTypeRef.current === "note_array"
               ? { notes_wide: notesWideRef.current, notes_tall: notesTallRef.current }
               : {};
-          let result: { page: { id: string } };
-          if (pageId) {
-            result = await api.updatePage(pageId, {
-              name: nameRef.current,
-              device_type: deviceTypeRef.current,
-              template: cleanedLines,
-              line_metadata: metadata,
-              ...noteArrayDims,
-            });
-          } else {
-            result = await api.createPage({
-              name: nameRef.current,
-              type: "template" as PageType,
-              device_type: deviceTypeRef.current,
-              template: cleanedLines,
-              line_metadata: metadata,
-              ...noteArrayDims,
-            });
-          }
+          // The two endpoints no longer share a shape: PUT answers
+          // { page, incompatible_references }, POST answers the bare page at
+          // 201. Narrow to the saved page here so everything below reads one
+          // thing.
+          const saved: Page = pageId
+            ? (
+                await api.updatePage(pageId, {
+                  name: nameRef.current,
+                  device_type: deviceTypeRef.current,
+                  template: cleanedLines,
+                  line_metadata: metadata,
+                  ...noteArrayDims,
+                })
+              ).page
+            : await api.createPage({
+                name: nameRef.current,
+                type: "template" as PageType,
+                device_type: deviceTypeRef.current,
+                template: cleanedLines,
+                line_metadata: metadata,
+                ...noteArrayDims,
+              });
           // Invalidate the pages list and this page's preview, but don't close.
           queryClient.invalidateQueries({ queryKey: queryKeys.pages, refetchType: "active" });
           queryClient.invalidateQueries({
-            queryKey: queryKeys.pagePreview(result.page.id),
+            queryKey: queryKeys.pagePreview(saved.id),
             refetchType: "active",
           });
-          return { id: result.page.id };
+          return { id: saved.id };
         } catch {
           return null;
         }
@@ -972,8 +976,11 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
 
   // Save mutation
   const saveMutation = useMutation({
-    // Create and update share the `{ status, page }` envelope; only update can
-    // carry `incompatible_references`, which is optional on the shared type.
+    // Since the Phase 2 conventions pass the two endpoints answer differently:
+    // PUT gives `{ page, incompatible_references }`, POST gives the bare page
+    // at 201. Both are normalized to PageUpdateResponse here so `onSuccess`
+    // reads one shape — a create simply reports no stale references, which is
+    // true: a brand-new page cannot have any.
     mutationFn: async (): Promise<PageUpdateResponse> => {
       const { cleanedLines, metadata } = processLinesWithPrefixes(templateLines, lineAlignments, lineWrapEnabled);
       if (pageId) {
@@ -999,14 +1006,14 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
           transition_strategy: transitionStrategy,
           ...(deviceType === "note_array" ? { notes_wide: notesWide, notes_tall: notesTall } : {}),
         };
-        return api.createPage(payload);
+        const created = await api.createPage(payload);
+        return { page: created, incompatible_references: [] };
       }
     },
     onSuccess: (data) => {
-      // Both POST /pages and PUT /pages/{id} answer with `{ status, page }`,
-      // so the saved id is `data.page.id` — reading `data.id` here was always
-      // undefined and silently skipped every id-keyed cleanup below when
-      // creating a new page (issue #1586).
+      // The saved page is always `data.page` after the normalization in
+      // mutationFn — reading `data.id` here was undefined and silently skipped
+      // every id-keyed cleanup below when creating a new page (issue #1586).
       const targetPageId = pageId || data.page.id;
 
       // Clear draft on successful save
@@ -1045,7 +1052,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
       // it no longer fits. Non-blocking — the save already succeeded and
       // nothing is auto-removed.
       const incompatibleRefs = data.incompatible_references;
-      if (incompatibleRefs && incompatibleRefs.length > 0) {
+      if (incompatibleRefs.length > 0) {
         const list = incompatibleRefs
           .map(
             (ref) =>

--- a/web/src/lib/api/pages.ts
+++ b/web/src/lib/api/pages.ts
@@ -5,12 +5,15 @@ import { fetchApi } from "./core";
 import type { DeviceType, LineMetadata, PageType, RowConfig } from "./shared";
 
 export interface PageDeleteResponse {
-  status: string;
+  /** The id of the page that was deleted. */
+  id: string;
   message: string;
   default_page_created: boolean;
-  new_page_id?: string;
+  /** Set (non-null) only when `default_page_created` is true. */
+  new_page_id?: string | null;
   active_page_updated: boolean;
-  new_active_page_id?: string;
+  /** Set (non-null) only when `active_page_updated` is true. */
+  new_active_page_id?: string | null;
 }
 
 // Active page settings
@@ -120,10 +123,9 @@ export interface IncompatibleReference {
 }
 
 export interface PageUpdateResponse {
-  status: string;
   page: Page;
-  /** Present iff the update changed the page's size (may be empty). */
-  incompatible_references?: IncompatibleReference[];
+  /** Always present; empty unless the update changed the page's size. */
+  incompatible_references: IncompatibleReference[];
 }
 
 export interface StaffPickPlugin {
@@ -164,10 +166,11 @@ export interface PagePreviewBatchResponse {
 }
 
 export interface PageSendResponse {
-  status: string;
   page_id: string;
   message: string;
   sent_to_board: boolean;
+  /** True when the send was skipped because the target board is paused. */
+  paused: boolean;
   target: string;
   board_id?: string | null;
 }
@@ -204,8 +207,9 @@ export const pagesApi = {
   getPages: () => fetchApi<PagesResponse>("/pages"),
   getCurrentDisplay: () => fetchApi<CurrentDisplayResponse>("/pages/current-display"),
   getPage: (pageId: string) => fetchApi<Page>(`/pages/${pageId}`),
+  /** 201 with the created page itself — no envelope. */
   createPage: (page: PageCreate) =>
-    fetchApi<{ status: string; page: Page }>("/pages", {
+    fetchApi<Page>("/pages", {
       method: "POST",
       body: JSON.stringify(page),
     }),
@@ -230,8 +234,9 @@ export const pagesApi = {
     return fetchApi<PageSendResponse>(`/pages/${pageId}/send${qs ? `?${qs}` : ""}`, { method: "POST" });
   },
   getPageShareString: (pageId: string) => fetchApi<{ share_string: string }>(`/pages/${pageId}/share`),
+  /** 201 with the created page itself — no envelope, same as createPage. */
   importPage: (shareString: string) =>
-    fetchApi<{ status: string; page: Page }>("/pages/import", {
+    fetchApi<Page>("/pages/import", {
       method: "POST",
       body: JSON.stringify({ share_string: shareString }),
     }),

--- a/web/tests/ai.spec.ts
+++ b/web/tests/ai.spec.ts
@@ -674,8 +674,8 @@ test.describe("AI", () => {
         },
       });
       expect(pageRes.ok(), await pageRes.text()).toBe(true);
-      // POST /pages wraps the page: {status, page: {...}}.
-      const pageId = (await pageRes.json()).page.id as string;
+      // POST /pages answers 201 with the bare page.
+      const pageId = (await pageRes.json()).id as string;
       expect(pageId, "page id missing from POST /pages response").toBeTruthy();
 
       const before = await (await request.get(`${API_URL}/schedules`)).json();

--- a/web/tests/api-extended.spec.ts
+++ b/web/tests/api-extended.spec.ts
@@ -84,7 +84,7 @@ test.describe("API – Pages (extended)", () => {
       }),
     });
     const data = await res.json();
-    testPageId = data.page.id;
+    testPageId = data.id;
   });
 
   test.afterAll(async () => {
@@ -109,7 +109,9 @@ test.describe("API – Pages (extended)", () => {
     });
     expect(res.ok).toBe(true);
     const data = await res.json();
-    expect(data.status).toBe("success");
+    // The {"status": "success"} key is gone; the page is the payload.
+    expect(data.page.name).toBe("Updated Page Name");
+    expect(data.incompatible_references).toEqual([]);
   });
 
   test("can preview a page", async () => {
@@ -129,7 +131,8 @@ test.describe("API – Pages (extended)", () => {
     });
     expect(res.ok).toBe(true);
     const data = await res.json();
-    expect(data).toHaveProperty("status");
+    // "status" is gone from the send body since the Phase 2 conventions pass.
+    expect(data).toHaveProperty("sent_to_board");
     expect(data).toHaveProperty("page_id");
   });
 
@@ -166,7 +169,7 @@ test.describe("API – Schedules (extended)", () => {
       }),
     });
     const pData = await pRes.json();
-    pageId = pData.page.id;
+    pageId = pData.id;
 
     const sRes = await fetch(`${API()}/schedules`, {
       method: "POST",
@@ -364,7 +367,7 @@ test.describe("API – Settings (extended)", () => {
       }),
     });
     const pData = await pRes.json();
-    const pageId = pData.page.id;
+    const pageId = pData.id;
 
     const setRes = await fetch(`${API()}/settings/active-page`, {
       method: "PUT",

--- a/web/tests/api.spec.ts
+++ b/web/tests/api.spec.ts
@@ -126,8 +126,9 @@ test.describe("API – Pages", () => {
     });
     expect(createRes.ok).toBe(true);
     const created = await createRes.json();
-    expect(created.status).toBe("success");
-    const pageId = created.page.id;
+    // 201 + the bare page since the Phase 2 conventions pass.
+    expect(createRes.status).toBe(201);
+    const pageId = created.id;
     expect(pageId).toBeTruthy();
 
     // Delete
@@ -136,7 +137,8 @@ test.describe("API – Pages", () => {
     });
     expect(deleteRes.ok).toBe(true);
     const deleted = await deleteRes.json();
-    expect(deleted.status).toBe("success");
+    // The envelope's "status" is gone; the deleted id is the contract now.
+    expect(deleted.id).toBe(pageId);
   });
 });
 
@@ -180,7 +182,7 @@ test.describe("API – Schedules", () => {
         }),
       });
       const createdPage = await createPageRes.json();
-      pageId = createdPage.page.id;
+      pageId = createdPage.id;
     }
 
     // Create a schedule

--- a/web/tests/board-discovery-offline.spec.ts
+++ b/web/tests/board-discovery-offline.spec.ts
@@ -346,7 +346,8 @@ test.describe("Board Offline — Send Error Handling", () => {
     // Accept any non-crash response (200 with sent_to_board=false or 4xx/5xx with detail)
     expect(res.status).not.toBe(502);
     const data = await res.json();
-    expect(data).toHaveProperty("status");
+    // Either the send result or an error body — never an empty/garbled reply.
+    expect(data.sent_to_board !== undefined || data.detail !== undefined).toBe(true);
   });
 
   test("send-message to offline board returns an error status", async () => {
@@ -415,7 +416,9 @@ test.describe("Board Offline — Send Error Handling", () => {
     });
     expect(res.ok).toBe(true);
     const data = await res.json();
-    expect(data.status).toBe("success");
+    // "status" is gone from the send body since the Phase 2 conventions pass —
+    // the 200 says it. A ui-only send never touches the board.
+    expect(data.sent_to_board).toBe(false);
   });
 });
 

--- a/web/tests/draw-mode-demo.spec.ts
+++ b/web/tests/draw-mode-demo.spec.ts
@@ -223,7 +223,7 @@ test("pencil draw mode on an 8x8 note array", async ({ page }) => {
     }),
   });
   expect(pageRes.ok).toBe(true);
-  const pageId = (await pageRes.json()).page.id;
+  const pageId = (await pageRes.json()).id;
 
   // --- Open the editor: the 24×120 preview fills the card ---
   await page.goto(`/pages/edit/${pageId}`);

--- a/web/tests/draw-mode.spec.ts
+++ b/web/tests/draw-mode.spec.ts
@@ -335,7 +335,7 @@ test.describe("Draw mode", () => {
       }),
     });
     expect(pageRes.ok).toBe(true);
-    const pageId = (await pageRes.json()).page.id;
+    const pageId = (await pageRes.json()).id;
 
     await gotoEditPage(page, pageId);
     await enterDrawMode(page);
@@ -422,7 +422,7 @@ test.describe("Draw mode", () => {
       }),
     });
     expect(pageRes.ok).toBe(true);
-    const pageId = (await pageRes.json()).page.id;
+    const pageId = (await pageRes.json()).id;
 
     await gotoEditPage(page, pageId);
     await enterDrawMode(page);

--- a/web/tests/generate-screenshots.spec.ts
+++ b/web/tests/generate-screenshots.spec.ts
@@ -138,7 +138,7 @@ async function createPage(name: string, template: string[]): Promise<string> {
   });
   if (!res.ok) throw new Error(`createPage failed: ${res.status}`);
   const data = await res.json();
-  return data.page.id;
+  return data.id;
 }
 
 async function createCollection(name: string, pageIds: string[], intervalSeconds = 30): Promise<string> {

--- a/web/tests/helpers.ts
+++ b/web/tests/helpers.ts
@@ -380,7 +380,7 @@ export async function createPage(
   });
   if (!res.ok) throw new Error(`createPage failed: ${res.status}`);
   const data = await res.json();
-  return data.page.id;
+  return data.id;
 }
 
 /** Create a Note page (3 lines, 15 cols) and return its ID. */

--- a/web/tests/note-array-local.spec.ts
+++ b/web/tests/note-array-local.spec.ts
@@ -69,7 +69,7 @@ async function createArrayPage(name: string, template: string[]): Promise<string
   });
   if (!res.ok) throw new Error(`createArrayPage failed: ${res.status} ${await res.text()}`);
   const data = await res.json();
-  return data.page.id;
+  return data.id;
 }
 
 async function sendPageToBoard(pageId: string): Promise<void> {

--- a/web/tests/note-array-output.spec.ts
+++ b/web/tests/note-array-output.spec.ts
@@ -91,7 +91,7 @@ async function createArrayPage(name: string, token: string, notesWide: number, n
   });
   if (!res.ok) throw new Error(`createArrayPage failed: ${res.status} ${await res.text()}`);
   const data = await res.json();
-  return data.page.id;
+  return data.id;
 }
 
 /** Configure the fleet: optionally a flagship (mock port 7000) + one array. */

--- a/web/tests/note-multiboard-extended.spec.ts
+++ b/web/tests/note-multiboard-extended.spec.ts
@@ -208,7 +208,8 @@ test.describe("Note Display — 3×15 Grid Enforcement", () => {
 
     expect(res.ok).toBe(true);
     const data = await res.json();
-    expect(data.status).toBe("success");
+    // "status" is gone from the send body since the Phase 2 conventions pass.
+    expect(data.sent_to_board).toBe(false);
   });
 });
 

--- a/web/tests/note-pages.spec.ts
+++ b/web/tests/note-pages.spec.ts
@@ -68,7 +68,7 @@ test.describe("Note pages – API", () => {
       }),
     });
     expect(res.ok).toBe(true);
-    const { page: created } = await res.json();
+    const created = await res.json();
     expect(created.device_type).toBe("note");
     expect(created.template).toHaveLength(3);
     expect(created.template[0]).toBe("LINE ONE");
@@ -497,7 +497,7 @@ test.describe("Note pages – Alignment", () => {
       }),
     });
     expect(createRes.ok).toBe(true);
-    const { page: created } = await createRes.json();
+    const created = await createRes.json();
 
     // Send it to the mock board
     const sendRes = await fetch(`${API_URL}/pages/${created.id}/send?target=board`, { method: "POST" });
@@ -553,7 +553,7 @@ test.describe("Note pages – Alignment", () => {
       }),
     });
     expect(createRes.ok).toBe(true);
-    const { page: created } = await createRes.json();
+    const created = await createRes.json();
 
     const sendRes = await fetch(`${API_URL}/pages/${created.id}/send?target=board`, { method: "POST" });
     expect(sendRes.ok).toBe(true);

--- a/web/tests/pages-crud.spec.ts
+++ b/web/tests/pages-crud.spec.ts
@@ -63,7 +63,7 @@ test.describe("Pages CRUD", () => {
     });
     expect(createRes.ok).toBe(true);
     const created = await createRes.json();
-    const pageId = created.page.id;
+    const pageId = created.id;
 
     // Navigate to pages
     await page.goto("/pages");
@@ -104,16 +104,16 @@ test.describe("Pages CRUD", () => {
     });
     expect(createRes.ok).toBe(true);
     const created = await createRes.json();
-    expect(created.page.device_type).toBe("flagship");
+    expect(created.device_type).toBe("flagship");
 
     // List endpoint also returns device_type
     const listRes = await fetch(`${API_URL}/pages`);
     const listData = await listRes.json();
-    const found = listData.pages.find((p: { id: string }) => p.id === created.page.id);
+    const found = listData.pages.find((p: { id: string }) => p.id === created.id);
     expect(found).toBeDefined();
     expect(found.device_type).toBe("flagship");
 
-    await fetch(`${API_URL}/pages/${created.page.id}`, { method: "DELETE" });
+    await fetch(`${API_URL}/pages/${created.id}`, { method: "DELETE" });
   });
 
   test("can create a Note page with 3 lines", async () => {
@@ -130,15 +130,15 @@ test.describe("Pages CRUD", () => {
     });
     expect(createRes.ok).toBe(true);
     const created = await createRes.json();
-    expect(created.page.device_type).toBe("note");
-    expect(created.page.template).toHaveLength(3);
+    expect(created.device_type).toBe("note");
+    expect(created.template).toHaveLength(3);
 
     // Verify via GET
-    const getRes = await fetch(`${API_URL}/pages/${created.page.id}`);
+    const getRes = await fetch(`${API_URL}/pages/${created.id}`);
     expect(getRes.ok).toBe(true);
     const getData = await getRes.json();
     expect(getData.device_type).toBe("note");
 
-    await fetch(`${API_URL}/pages/${created.page.id}`, { method: "DELETE" });
+    await fetch(`${API_URL}/pages/${created.id}`, { method: "DELETE" });
   });
 });

--- a/web/tests/regression/dashboard.spec.ts
+++ b/web/tests/regression/dashboard.spec.ts
@@ -42,7 +42,7 @@ async function createPageAuthed(name: string, template: string[] = ["TEST", "", 
   });
   if (!res.ok) throw new Error(`createPage failed: ${res.status} ${await res.text()}`);
   const data = await res.json();
-  return data.page.id;
+  return data.id;
 }
 
 /** Sorted ids of every saved page, for before/after comparison. */

--- a/web/tests/regression/multi-board-e2e.spec.ts
+++ b/web/tests/regression/multi-board-e2e.spec.ts
@@ -60,7 +60,7 @@ async function createFlagshipPage(name: string, token: string): Promise<string> 
   });
   if (!res.ok) throw new Error(`createFlagshipPage failed: ${res.status} ${await res.text()}`);
   const data = await res.json();
-  return data.page.id;
+  return data.id;
 }
 
 /** Create a note_array page sized to ARRAY_NOTES_WIDE x ARRAY_NOTES_TALL and return its id. */
@@ -80,7 +80,7 @@ async function createArrayPage(name: string, token: string): Promise<string> {
   });
   if (!res.ok) throw new Error(`createArrayPage failed: ${res.status} ${await res.text()}`);
   const data = await res.json();
-  return data.page.id;
+  return data.id;
 }
 
 /** Configure a Flagship board ("Kitchen") + a Note Array board ("Office"), both manual mode. */

--- a/web/tests/regression/pages-import-dialog.spec.ts
+++ b/web/tests/regression/pages-import-dialog.spec.ts
@@ -212,9 +212,10 @@ test.describe("regression: pages.import-dialog", () => {
     await dialog.getByRole("button", { name: "Import", exact: true }).click();
     const resp = await importResponse;
     expect(resp.ok()).toBe(true);
-    const body = (await resp.json()) as { status: string; page: { id: string; name: string } };
-    expect(body.status).toBe("success");
-    const newPageId = body.page.id;
+    // 201 + the bare page since the Phase 2 conventions pass.
+    const body = (await resp.json()) as { id: string; name: string };
+    expect(resp.status()).toBe(201);
+    const newPageId = body.id;
 
     // Dialog auto-closes on success.
     await expect(dialog).toBeHidden({ timeout: 15_000 });

--- a/web/tests/regression/picks.spec.ts
+++ b/web/tests/regression/picks.spec.ts
@@ -285,12 +285,11 @@ test.describe("regression: picks.card", () => {
     await page.route("**/api/pages/import", async (route) => {
       await gate;
       await route.fulfill({
-        status: 200,
+        // 201 + the bare page, matching POST /pages/import since the Phase 2
+        // conventions pass — picks.tsx reads `data.name` straight off it.
+        status: 201,
         contentType: "application/json",
-        body: JSON.stringify({
-          status: "ok",
-          page: { id: "imported-1", name: "Import Pending Pick" },
-        }),
+        body: JSON.stringify({ id: "imported-1", name: "Import Pending Pick" }),
       });
     });
 

--- a/web/tests/schedule-crud.spec.ts
+++ b/web/tests/schedule-crud.spec.ts
@@ -47,7 +47,7 @@ async function ensurePage(): Promise<string> {
     }),
   });
   const created = await createRes.json();
-  return created.page.id;
+  return created.id;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Phase 2 slice 3 — the **pages** domain (16 routes), following the seven-step recipe the collections pilot (#1891) established. Base is `next-rebuild`.

## 1. Contract pinned by value, before any change

`tests/test_pages_contract.py` (38 tests) was written and run **green against unmodified `next-rebuild`**, covering all 16 routes and their 4xx/5xx bodies. `tests/golden/responses/pages.json` already records key sets and type names, but a shape golden cannot see a wrong page id, a template whose lines got reordered, a `sent_to_board` that flipped, or an error string that stopped naming the missing resource. Those are exactly the regressions this conversion could introduce, so they got pinned first (commit 1, alone).

## 2. The ratchet, flipped red

Adding `"pages"` to `converted_domains` before touching the code:

```
FAILED test_converted_domains_declare_response_models
  DELETE /pages/{page_id}: no response_model= declared
  GET /pages/cache/stats: no response_model= declared
  GET /pages/current-display: no response_model= declared
  GET /pages/{page_id}/share: no response_model= declared
  GET /pages/{page_id}: no response_model= declared
  GET /pages: no response_model= declared
  GET /staff-picks/{pick_id}/share: no response_model= declared
  GET /staff-picks: no response_model= declared
  POST /pages/cache/clear: no response_model= declared
  POST /pages/import/preview: no response_model= declared
  POST /pages/import: no response_model= declared
  POST /pages/preview/batch: no response_model= declared
  POST /pages/{page_id}/preview: no response_model= declared
  POST /pages/{page_id}/send: no response_model= declared
  POST /pages: no response_model= declared
  PUT /pages/{page_id}: no response_model= declared

FAILED test_converted_domains_use_typed_request_bodies
  POST /pages/cache/clear: body param `request` is annotated `dict` — use a Pydantic model
  POST /pages/preview/batch: body param `request` is annotated `dict` — use a Pydantic model
  POST /pages/{page_id}/send: body param `payload` is annotated `dict | None` — use a Pydantic model

FAILED test_converted_domains_declare_error_responses
  (the same 16 routes: "declares no 4xx in responses=")

3 failed, 18 passed
```

`no_200_on_failure` was already clean. All four rules are green now, with three checked-in `declared_errors` exceptions — `GET /pages`, `GET /pages/cache/stats`, `GET /staff-picks` genuinely have no 4xx of their own (an empty instance is an empty list; a missing `picks.json` degrades to `[]`; cache stats always exist), and the middleware's app-wide 401 is not a route's contract to declare.

**`/pages/ai/*` is not in this slice.** Confirmed against the live route table: those three routes are `@app.post`/`@app.get` with **no tags**, so the ratchet's tag-based domain resolution does not pull them in. No exception entry needed — they move with the AI domain later, along with the semaphore/SSE machinery they share.

## 3. Contract changes (goldens re-recorded in the same commit)

| Route | Before | After |
|---|---|---|
| `POST /pages` | 200 `{status, page}` | **201** bare page |
| `POST /pages/import` | 200 `{status, page}` | **201** bare page |
| `PUT /pages/{id}` | `{status, page, incompatible_references?}` | `{page, incompatible_references}` (always present, empty unless the size changed) |
| `DELETE /pages/{id}` | `{status, message, ...}` | `{id, message, ...}` |
| `POST /pages/{id}/send` | `{status, ...}` | `{...}` — the 200 already said it |
| `POST /pages/cache/clear` | `{status, message}` | `{message, page_id}` |
| `POST /pages/preview/batch` | hand-rolled **400** on non-list `page_ids` | FastAPI's standard **422** |

`tests/golden/responses/pages.json` shows exactly those changes and nothing else — read line by line. The other four domains' goldens are byte-identical.

## 4. Domain-specific work

**`clear_page_cache` no longer reaches a private.** It called `page_service._invalidate_cache()`, which the conventions doc bans ("Routes never touch another object's `_private` members"). Added `PageService.invalidate_preview_cache()`; the private method stays as the internal write-path hook the mutators use.

**`POST /pages/import` no longer reports our faults as the caller's.** It wrapped the whole create in `except Exception -> 422`, so a storage failure was reported to the user as "Invalid share string" — pointing them at the one thing that was fine. Now the decoder and `PageCreate` validation answer 422, a `ValueError` from the service is the 400 it always was, and anything else propagates as a 500. Fail-first, observed with the catch-all restored:

```
FAILED test_import_reports_an_internal_storage_failure_as_500_not_422
E   Failed: DID NOT RAISE RuntimeError
FAILED test_import_reports_a_rejected_page_as_400
E   assert 422 == 400
FAILED test_import_reports_share_contents_pydantic_rejects_as_422
E   assert False
E    +  where False = "1 validation error for PageCreate\nname\n  String should have at
         least 1 character [type=string_too_short, ...]".startswith('Invalid share string — ')
```

The `asyncio.to_thread` work on `/pages/current-display`, both preview routes, and the bounded send pool (#1826 / #1878) is preserved verbatim.

## 5. Seam retirement — 13 call-time imports, the second-heaviest router

Ten collaborators had a canonical home to import from at module load. Three did not, so they got one:

- **`src/board_guards.py`** — `_find_board`, `_require_board`, `_board_dims`, `_board_is_paused`, `_silence_active`. Pure functions over settings/config with no dependency on the app object.
- **`src/display_runtime.py`** — the `DisplayService` singleton (`get_service`, `peek_service`, `_service`, `_service_lock`). The background-thread lifecycle (`_service_running`, `run_service_background`, `start_service`, `stop_service`) stays in `api_server`: that is server lifecycle, not an accessor, and `test_service_lifecycle.py` owns it.
- `_reject_plugin_strategy_when_beta_off` moved into `src/pages/routes.py` — these three handlers were its only callers, ever.

`src.api_server` imports all of them, so its own handlers and the tests aimed at those handlers keep working. **Test patches were repointed only where the handler under test actually moved**; each `src.api_server.<name>` site was checked before touching it, and the ones in `test_temporary_override*.py` were left alone (those drive `/settings/*` and `/schedules/*`, not pages routes). Shared fixtures in `test_api_extended.py` / `test_api_coverage.py` now patch both modules, because both genuinely resolve their own binding.

Two test mocks were tightened rather than assertions weakened: a `DisplayResult` with `raw=None` and one with a MagicMock `formatted` were never realistic (the dataclass declares `dict[str, Any]` and `str`), and the response models now say so.

### `tests/test_pages_decoupled.py`, mutation-proven

The subprocess test imports the router in a fresh interpreter, drives **all sixteen handlers** end to end against stubs patched at `src.pages.routes.<name>`, asserts each stub really was driven, and then asserts `src.api_server` never entered `sys.modules`. An AST walk backstops branches the subprocess does not reach.

| Mutation | `..._without_importing_api_server` | `..._source_declares_no_api_server_import` |
|---|---|---|
| call-time `from src.api_server import get_page_service` in an **exercised** handler | FAIL | FAIL |
| the same import hidden in an **unexercised** `except` branch | pass | FAIL |
| `clear_page_cache` stops calling `invalidate_preview_cache` | FAIL (`Expected 'invalidate_preview_cache' to be called once. Called 0 times.`) | pass |
| `send_page` skips the silence guard | FAIL | pass |

(The contract test bites on the same mutations: `clear_page_cache` also killed two `test_pages_contract.py` cases, and dropping `find_incompatible_references` killed `test_page_retarget.py::test_size_change_returns_incompatible_references`.)

## 6. Web lockstep — the widest of any slice so far

**This is the calibration datum for the remaining slices: ~18 web files + 17 Playwright specs, versus 4 files for collections.** Collections' client discarded every mutation body; pages' does not — the page builder, compose dialog, import dialog and picks page all read them into UI state.

`page-builder.tsx` needed a real change, not a find-and-replace: its save mutation typed **both** branches as `PageUpdateResponse`, and create/update stop sharing a shape. Both are normalized in `mutationFn` so `onSuccess` still reads `data.page.id` — that read is the fix for #1586, whose only guard is `page-builder-new-page-invalidation.test.tsx`, updated in the same commit. The imperative AI `save()` handle had the same union and got the same treatment.

`web/tests/helpers.ts:createPage` carries 31 of the Playwright specs on its own; the remaining 16 do inline POSTs and were updated individually. Every `.ok` / `resp.ok()` assertion survives 201 unchanged; only the explicit `data.status` reads and `.page.id` unwraps needed edits.

`POST /pages/cache/clear` turned out to have **zero** web consumers.

## 7. Verification

| Check | Result |
|---|---|
| Full pytest suite | **1 failed, 5912 passed, 1 skipped** — strict superset of the `origin/next-rebuild` baseline (1 failed, 5869 passed, 1 skipped). +43 = 41 new contract tests + 2 decoupling tests. |
| The one failure | `test_check_image_formats.py::TestRepositoryIsClean` — the documented worktree-environmental failure (`git ls-files` in a worktree), present on the baseline too. |
| Data-dir leaks | **Zero**, with an explicit host dir mounted over `/app/data` (the image's `VOLUME /app/data` otherwise hides writes). |
| Conventions ratchet | 21/21 green with `pages` in `converted_domains`. |
| Other domains' goldens | Byte-identical. |
| Route-inventory golden | Unchanged. |
| web | `tsc --noEmit` clean · vitest **1621 passed / 7 skipped** · prettier clean · eslint clean |
| ruff 0.16.5 | `check` + `format --check` clean |

## Note for the merge order

`src/api_errors.py` is added here **byte-identical** to the copy in #1891 (collections), which has not landed yet. An add/add of identical content merges cleanly; if #1891 lands first this file simply already exists. The `converted_domains` list is the only other expected conflict — resolve by keeping both entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP
