### PR TITLE
feat(plugins): Phase 2 slice 4 — conventions, service layering, off-loop plugin data, web lockstep

### DIFF
--- a/docs/internal/reference/API_CONVENTIONS.md
+++ b/docs/internal/reference/API_CONVENTIONS.md
@@ -25,7 +25,7 @@ It is a **ratchet**: it only checks domains listed in
 
 ```json
 {
-  "converted_domains": ["collections"],
+  "converted_domains": ["collections", "plugins"],
   "exceptions": [
     {
       "route": "POST /plugins/{plugin_id}/options/{options_id}",
@@ -35,6 +35,13 @@ It is a **ratchet**: it only checks domains listed in
   ]
 }
 ```
+
+**`declared_errors` and 503-only routes.** The rule asks for a *4xx*, so a
+route whose only failure is a dependency outage (`503`) records an exception
+rather than inventing a client error it cannot raise. Declare the 503 in
+`responses=` anyway — the exception explains why there is no 4xx, it does not
+excuse leaving the failure undocumented. Seven `/plugins` routes are in this
+position because `_require_plugin_system()` is their only failure path.
 
 **Opting a domain in.** Append the domain's router tag (the `<domain>` in
 `APIRouter(tags=[<domain>])`) to `converted_domains` — in the same PR that
@@ -60,7 +67,16 @@ manifest entry; the cost of a false negative is a shipped 200-on-failure.
 - **Bare bodies.** Return the resource (or list) itself — no `{"status":
   "success", "data": ...}` envelopes. `{"status": ...}` wrappers on existing
   endpoints are grandfathered until their domain's conventions pass; new
-  endpoints never add one.
+  endpoints never add one. The one endpoint that keeps its wrapper past its
+  own conventions pass is `POST /plugins/{id}/receive`: it is a webhook target
+  for third-party systems this repo does not control and cannot update in
+  lockstep, so "deprecation, never deletion" applies to it literally.
+- **Derived or masked payloads get their own wire model.** Aliasing the
+  storage model (`CollectionResponse = Collection`) is honest only when the
+  two really are the same object. `GET /plugins/{id}` assembles its body from
+  four collaborators and masks every secret in it, so it declares
+  `PluginDetail` instead — conflating the masked shape with the stored shape
+  is what let the #1743 masking regression through.
 - **`response_model` on every endpoint.** The route declares its Pydantic
   response model; no untyped `dict` returns. This is what keeps the TS client
   (`web/src/lib/api/`) honest — `/check-types` compares against these models.
@@ -116,6 +132,14 @@ response (CodeQL also enforces this).
 - Routes never touch another object's `_private` members — that is the
   service's job (see `PluginService.mask_config` / `clear_update_status` for
   the pattern).
+- **Services raise domain errors; routers map them to status codes.** A
+  service that raises `fastapi.HTTPException` has an opinion about HTTP it is
+  not entitled to, and it forces every non-HTTP caller (MCP tools, chat ops,
+  background tasks) to import a web framework to catch its failures. The
+  pattern: define the domain's exceptions in `src/<domain>/errors.py` with no
+  status codes on them, and put one `_STATUS_BY_ERROR` table in
+  `src/<domain>/routes.py` (see `src/plugins/`). `PluginService` was the one
+  service that broke this — 25 raise sites, fixed in the plugins slice.
 - During extraction, moved handlers resolve api_server-patched names at call
   time (the `src/mqtt/commands.py` pattern) so existing test patch targets
   stay live. Follow-up: migrate patch targets to the service modules, then

--- a/src/api_errors.py
+++ b/src/api_errors.py
@@ -36,9 +36,14 @@ _DESCRIPTIONS: dict[int, str] = {
     400: "Invalid request — the payload references something that does not exist or violates a rule.",
     403: "Forbidden.",
     404: "Resource not found.",
+    405: "The resource exists but does not implement this operation.",
     409: "Conflict — duplicate id, or a resource pinned by the environment.",
     422: "Request body failed validation.",
+    429: "Rate-limited — the same request arrived again too quickly.",
+    501: "The resource declares this capability but does not implement it.",
+    502: "An upstream the server called on your behalf failed.",
     503: "A required dependency is unavailable.",
+    504: "An upstream the server called on your behalf did not answer in time.",
 }
 
 

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import contextlib
-import hashlib
 import json
 import logging
 import logging.handlers
@@ -57,14 +56,17 @@ from .collections.service import (  # noqa: E402
 )
 from .config import Config  # noqa: E402
 
-# Patch seams (issues #1756/#1757): no handler left in this module calls
-# unmask_sensitive_values / reset_display_service / reset_template_engine, but
-# the extracted routers resolve them through `src.api_server` at call time so
-# tests that patch `src.api_server.<name>` keep working.
-from .config_manager import get_config_manager, unmask_sensitive_values  # noqa: E402, F401
+# ``unmask_sensitive_values`` / ``reset_display_service`` /
+# ``reset_template_engine`` used to be imported here purely as patch seams for
+# the extracted plugins router (#1757). That router binds them from their
+# canonical homes now (Phase 2 slice 4) and was their last consumer, so the
+# three re-exports are gone rather than left as patch targets that steer
+# nothing.
+from .config_manager import get_config_manager  # noqa: E402
 from .devices import classify_dimensions, resolve_dimensions  # noqa: E402
 from .display_runtime import get_service, peek_service  # noqa: E402
 from .displays.service import get_display_service, reset_display_service  # noqa: E402, F401
+from .main import DisplayService  # noqa: E402
 from .network.wifi import WiFiError, get_wifi_service  # noqa: E402
 from .pages.service import (  # noqa: E402
     check_ref_board_compatibility,
@@ -81,7 +83,7 @@ from .paths import get_data_dir  # noqa: E402
 from .schedules.service import get_schedule_service  # noqa: E402, F401
 from .settings.service import VALID_OUTPUT_TARGETS, VALID_STRATEGIES, get_settings_service  # noqa: E402
 from .settings.service import temporary_override_payload as _temporary_override_payload  # noqa: E402
-from .templates.engine import get_template_engine, reset_template_engine  # noqa: E402, F401
+from .templates.engine import get_template_engine  # noqa: E402
 from .templates.expressions import function_signatures  # noqa: E402
 from .text_to_board import text_to_board_array  # noqa: E402
 from .time_service import reset_time_service  # noqa: E402
@@ -7322,274 +7324,22 @@ async def get_home_assistant_entities():
 # Plugin API Endpoints
 # =============================================================================
 
-# Import plugin system
-try:
+# The plugin router, the availability flag, and the whole remote-options
+# runtime (13 names, ~260 lines) moved into ``src/plugins/`` in Phase 2
+# slice 4. They are deliberately NOT re-exported here: nothing in this module
+# uses them any more, and leaving a binding behind would advertise a patch
+# target that no longer steers anything. Patch
+# ``src.plugins.routes.<name>`` / ``src.plugins.options_runtime.<name>``.
+#
+# ``PLUGIN_SYSTEM_AVAILABLE`` is the exception — this module's own handlers
+# still branch on it, so the name stays bound here and is patched here for
+# them.
+from .plugins.routes import PLUGIN_SYSTEM_AVAILABLE  # noqa: E402
+
+if PLUGIN_SYSTEM_AVAILABLE:  # pragma: no branch - False needs a broken install
     from .plugins import get_plugin_registry
-
-    PLUGIN_SYSTEM_AVAILABLE = True
-except ImportError:
-    PLUGIN_SYSTEM_AVAILABLE = False
+else:  # pragma: no cover
     get_plugin_registry = None
-
-
-# ── Plugin remote options ────────────────────────────────────────────────────
-
-# Hard ceiling on how many options core will hand to the browser, whatever the
-# plugin returns. A picker that renders 50k rows wedges the settings dialog.
-PLUGIN_OPTIONS_MAX_RETURNED = 1000
-PLUGIN_OPTIONS_DEFAULT_CACHE_SECONDS = 300
-
-# Display-string ceilings, enforced by core rather than trusted to the plugin.
-# Different fields get different room because the picker gives them different
-# room. Over-long strings are trimmed, never a reason to drop the choice.
-PLUGIN_OPTIONS_MAX_LABEL_CHARS = 200
-PLUGIN_OPTIONS_MAX_DESCRIPTION_CHARS = 200
-PLUGIN_OPTIONS_MAX_PREVIEW_CHARS = 120
-PLUGIN_OPTIONS_MAX_GROUP_CHARS = 80
-
-# A continuation token is opaque to core, but it still has to fit back into a
-# request, and it is one more thing a plugin can make arbitrarily large.
-PLUGIN_OPTIONS_MAX_CURSOR_CHARS = 512
-
-PLUGIN_OPTIONS_MAX_PAYLOAD_BYTES = 512 * 1024
-
-# Wall-clock budget for one options lookup. Longer than a plugin's own HTTP
-# timeout should be, short enough that a stuck picker gives up while the
-# settings dialog is still open.
-PLUGIN_OPTIONS_TIMEOUT_SECONDS = 20.0
-
-# How many options lookups may occupy worker threads at once. See
-# _bounded_options_call for why this is not just politeness.
-PLUGIN_OPTIONS_MAX_CONCURRENCY = 4
-_PLUGIN_OPTIONS_SEMAPHORE = asyncio.Semaphore(PLUGIN_OPTIONS_MAX_CONCURRENCY)
-
-
-async def _bounded_options_call(work: Any, timeout: float) -> Any:
-    """Run blocking *work* on a worker thread with a hard wall-clock deadline.
-
-    ``asyncio.wait_for`` cancels the *await*, never the thread. A plugin that
-    hangs on a socket keeps its worker forever no matter what we do here, so
-    the semaphore is released from the task's done-callback — when the thread
-    genuinely finishes — rather than when we stop waiting for it.
-
-    That ordering is the whole point. Releasing on timeout would let four hung
-    lookups free their slots, the next four start fresh threads, and so on
-    until the default executor is exhausted and *every* other
-    ``asyncio.to_thread`` caller in the process starves behind a plugin nobody
-    is even waiting on. Holding the slot until the thread returns caps the
-    damage at ``PLUGIN_OPTIONS_MAX_CONCURRENCY`` threads.
-    """
-    await _PLUGIN_OPTIONS_SEMAPHORE.acquire()
-    task = asyncio.ensure_future(asyncio.to_thread(work))
-
-    def _release(finished: Any) -> None:
-        _PLUGIN_OPTIONS_SEMAPHORE.release()
-        if not finished.cancelled():
-            # Retrieve any exception so a lookup that fails after we gave up
-            # does not surface as "exception was never retrieved".
-            finished.exception()
-
-    task.add_done_callback(_release)
-    # shield() so the timeout abandons the wait without cancelling the task —
-    # cancelling it would drop the done-callback's release on the floor.
-    return await asyncio.wait_for(asyncio.shield(task), timeout)
-
-
-# Answers are cached per (plugin instance, provider, effective config, query)
-# so that typing in a search box does not hammer an upstream API. Bounded so a
-# long-lived process cannot accumulate one entry per keystroke forever.
-PLUGIN_OPTIONS_CACHE_MAX_ENTRIES = 512
-_PLUGIN_OPTIONS_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
-_plugin_options_cache_lock = threading.Lock()
-
-
-def _config_fingerprint(config: dict[str, Any]) -> str:
-    """Return a stable digest of an effective plugin config.
-
-    Two installs of the same plugin with different credentials must never read
-    each other's cached options, and the digest keeps the secrets themselves
-    out of the cache key. ``default=str`` because a config may legitimately
-    hold values JSON does not know (e.g. a datetime from a draft form).
-    """
-    blob = json.dumps(config, sort_keys=True, default=str)
-    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
-
-
-def _plugin_options_cache_key(
-    plugin_id: str,
-    options_id: str,
-    config_digest: str,
-    body: Any,  # PluginOptionsRequestBody (moved to src/plugins/routes.py); duck-typed here
-    limit: int,
-) -> str:
-    """Build the cache key for one options question.
-
-    ``plugin_id`` is the *full* key, instance label included: ``weather:home``
-    and ``weather:cabin`` are different installs with different configs and
-    must never share an entry.
-    """
-    blob = json.dumps(
-        {
-            "plugin_id": plugin_id,
-            "options_id": options_id,
-            "config": config_digest,
-            "parent": body.parent,
-            "query": body.query,
-            "limit": limit,
-            "cursor": body.cursor,
-        },
-        sort_keys=True,
-        default=str,
-    )
-    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
-
-
-def _plugin_options_cache_get(key: str) -> tuple[float, dict[str, Any]] | None:
-    """Return the ``(stored_at, payload)`` entry for *key*, fresh or not."""
-    with _plugin_options_cache_lock:
-        return _PLUGIN_OPTIONS_CACHE.get(key)
-
-
-def _plugin_options_cache_put(key: str, payload: dict[str, Any]) -> None:
-    """Store *payload* under *key*, evicting the oldest entry when full."""
-    with _plugin_options_cache_lock:
-        if key not in _PLUGIN_OPTIONS_CACHE and len(_PLUGIN_OPTIONS_CACHE) >= PLUGIN_OPTIONS_CACHE_MAX_ENTRIES:
-            oldest = min(_PLUGIN_OPTIONS_CACHE, key=lambda k: _PLUGIN_OPTIONS_CACHE[k][0])
-            _PLUGIN_OPTIONS_CACHE.pop(oldest, None)
-        _PLUGIN_OPTIONS_CACHE[key] = (time.monotonic(), payload)
-
-
-def _stale_options_payload(cache_key: str, reason: str) -> dict[str, Any] | None:
-    """Return the last good answer for *cache_key*, flagged stale, or ``None``.
-
-    Expiry is deliberately ignored here. Once a lookup has failed, an old list
-    plus a visible "this may be out of date" is strictly better for the user
-    than an empty picker — they are usually re-opening a dialog to change one
-    unrelated field.
-    """
-    entry = _plugin_options_cache_get(cache_key)
-    if entry is None:
-        return None
-    return {**entry[1], "cached": True, "stale": True, "error": reason}
-
-
-# A cache-bypassing refresh is the one thing a user can trigger by hand that
-# reaches straight through to somebody else's API. One per second per question
-# is plenty for a Retry button and stops a stuck client from becoming a DoS.
-PLUGIN_OPTIONS_REFRESH_MIN_INTERVAL_SECONDS = 1.0
-_plugin_options_last_refresh: dict[str, float] = {}
-
-
-def _plugin_options_refresh_throttle(cache_key: str) -> None:
-    """Reject a forced refresh that lands too soon after the previous one.
-
-    Keyed per question rather than globally so a slow provider cannot lock out
-    refreshes for every other field in the dialog.
-    """
-    now = time.monotonic()
-    with _plugin_options_cache_lock:
-        previous = _plugin_options_last_refresh.get(cache_key, 0.0)
-        if previous and (now - previous) < PLUGIN_OPTIONS_REFRESH_MIN_INTERVAL_SECONDS:
-            raise HTTPException(
-                status_code=429,
-                detail="Options refresh is rate-limited. Please wait a moment and try again.",
-            )
-        _plugin_options_last_refresh[cache_key] = now
-        # Bounded alongside the cache it shadows.
-        if len(_plugin_options_last_refresh) > PLUGIN_OPTIONS_CACHE_MAX_ENTRIES:
-            oldest = min(_plugin_options_last_refresh, key=_plugin_options_last_refresh.get)  # type: ignore[arg-type]
-            _plugin_options_last_refresh.pop(oldest, None)
-
-
-def _declared_options_ids(manifest: Any) -> set[str]:
-    """Return the ``options_id``s this plugin's own manifest declares."""
-    from .plugins.manifest import collect_options_ids
-
-    if manifest is None:
-        return set()
-    return collect_options_ids(getattr(manifest, "settings_schema", None) or {})
-
-
-def _options_cache_seconds(manifest: Any, options_id: str) -> int:
-    """Return the cache TTL this provider declares, or the platform default."""
-    from .plugins.manifest import options_cache_seconds
-
-    declared = options_cache_seconds(getattr(manifest, "settings_schema", None) or {}, options_id)
-    return PLUGIN_OPTIONS_DEFAULT_CACHE_SECONDS if declared is None else declared
-
-
-def _truncate(text: Any, ceiling: int) -> str | None:
-    """Clip a plugin-supplied display string to *ceiling* characters."""
-    if text is None:
-        return None
-    return (text if isinstance(text, str) else str(text))[:ceiling]
-
-
-def _serialise_option(option: Any, plugin_id: str, options_id: str) -> dict[str, Any] | None:
-    """Render one plugin-supplied option, or ``None`` if it must be dropped.
-
-    Truncation rather than rejection for the display strings: a 10KB label
-    breaks the layout, but discarding the option would lose a choice the user
-    needs. ``value`` is the exception — it is written verbatim into
-    config.json, so a non-scalar there becomes an un-comparable blob that only
-    fails much later, somewhere unrelated.
-    """
-    value = getattr(option, "value", None)
-    if not isinstance(value, str | int | float | bool):
-        logger.warning(
-            "Plugin '%s' options provider '%s' returned an option with a non-scalar value (%s); dropping it",
-            plugin_id,
-            options_id,
-            type(value).__name__,
-        )
-        return None
-
-    return {
-        "value": value,
-        "label": _truncate(getattr(option, "label", None), PLUGIN_OPTIONS_MAX_LABEL_CHARS),
-        "description": _truncate(getattr(option, "description", None), PLUGIN_OPTIONS_MAX_DESCRIPTION_CHARS),
-        "group": _truncate(getattr(option, "group", None), PLUGIN_OPTIONS_MAX_GROUP_CHARS),
-        "preview": _truncate(getattr(option, "preview", None), PLUGIN_OPTIONS_MAX_PREVIEW_CHARS),
-        "disabled": bool(getattr(option, "disabled", False)),
-        "meta": getattr(option, "meta", None),
-    }
-
-
-def _serialise_options(options: Any, limit: int, plugin_id: str, options_id: str) -> tuple[list[dict[str, Any]], bool]:
-    """Return ``(sanitised_options, truncated)`` for one provider's answer."""
-    kept: list[dict[str, Any]] = []
-    truncated = False
-    for option in options or []:
-        if len(kept) >= limit:
-            truncated = True
-            break
-        rendered = _serialise_option(option, plugin_id, options_id)
-        if rendered is not None:
-            kept.append(rendered)
-    return kept, truncated
-
-
-def _fit_options_payload(payload: dict[str, Any]) -> dict[str, Any]:
-    """Trim *payload* in place until it fits the response byte budget.
-
-    A count ceiling is not a size ceiling: 1000 options each carrying a full
-    label, description, preview and group is most of a megabyte, and the
-    typical FiestaBoard talks to a Raspberry Pi over a home LAN.
-
-    Measured with ``json.dumps`` defaults, which are looser than the compact
-    separators FastAPI actually serialises with — so the real response is
-    always a little under whatever this accepts.
-    """
-    encoded = len(json.dumps(payload, default=str).encode("utf-8"))
-    while encoded > PLUGIN_OPTIONS_MAX_PAYLOAD_BYTES and payload["options"]:
-        # Drop proportionally to the overshoot so this converges in a couple
-        # of passes instead of one option at a time.
-        per_option = max(1, encoded // len(payload["options"]))
-        drop = max(1, min(len(payload["options"]), (encoded - PLUGIN_OPTIONS_MAX_PAYLOAD_BYTES) // per_option + 1))
-        del payload["options"][-drop:]
-        payload["has_more"] = True
-        encoded = len(json.dumps(payload, default=str).encode("utf-8"))
-    return payload
 
 
 # =============================================================================

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -66,7 +66,6 @@ from .config_manager import get_config_manager  # noqa: E402
 from .devices import classify_dimensions, resolve_dimensions  # noqa: E402
 from .display_runtime import get_service, peek_service  # noqa: E402
 from .displays.service import get_display_service, reset_display_service  # noqa: E402, F401
-from .main import DisplayService  # noqa: E402
 from .network.wifi import WiFiError, get_wifi_service  # noqa: E402
 from .pages.service import (  # noqa: E402
     check_ref_board_compatibility,

--- a/src/ops/executors.py
+++ b/src/ops/executors.py
@@ -16,7 +16,10 @@ behavior-preserving:
   and so importing this module never drags in ``api_server``.
 - Plugin mutations go through :class:`src.plugins.service.PluginService`
   (#1757/#1588): the registry holds live state, ConfigManager holds
-  ``config.json``, and only the service writes both.
+  ``config.json``, and only the service writes both. Since Phase 2 slice 4
+  that service raises :class:`src.plugins.errors.PluginError`, not a
+  transport exception, so the executors below catch the domain error and
+  flatten it with :func:`~src.ops.results.plugin_detail`.
 
 Unified semantics decided at #1764 (see the parity suite,
 ``tests/test_op_parity.py``):
@@ -41,7 +44,9 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from .results import err, ok, rest_detail, serialize
+from src.plugins.errors import PluginError
+
+from .results import err, ok, plugin_detail, rest_detail, serialize
 
 logger = logging.getLogger(__name__)
 
@@ -76,12 +81,10 @@ async def install_plugin(
     ``initial_config`` exists only on the chat grammar; when given it is
     applied through :func:`configure_plugin` after a successful enable.
     """
-    from fastapi import HTTPException
-
     try:
         await _plugin_service().install_from_registry(plugin_id)
-    except HTTPException as exc:
-        return err(f"Error installing plugin '{plugin_id}': {rest_detail(exc)}")
+    except PluginError as exc:
+        return err(f"Error installing plugin '{plugin_id}': {plugin_detail(exc)}")
     except Exception as exc:
         return err(f"Error installing plugin '{plugin_id}': {exc}")
 
@@ -101,12 +104,10 @@ async def install_plugin(
 
 def enable_plugin(plugin_id: str) -> dict[str, Any]:
     """Enable an installed but currently-disabled plugin."""
-    from fastapi import HTTPException
-
     try:
         _plugin_service().enable_plugin(plugin_id)
-    except HTTPException as exc:
-        return err(f"Error enabling plugin '{plugin_id}': {rest_detail(exc)}")
+    except PluginError as exc:
+        return err(f"Error enabling plugin '{plugin_id}': {plugin_detail(exc)}")
     except Exception as exc:
         return err(f"Error enabling plugin '{plugin_id}': {exc}")
 
@@ -115,12 +116,10 @@ def enable_plugin(plugin_id: str) -> dict[str, Any]:
 
 def disable_plugin(plugin_id: str) -> dict[str, Any]:
     """Disable an installed plugin without uninstalling it."""
-    from fastapi import HTTPException
-
     try:
         _plugin_service().disable_plugin(plugin_id)
-    except HTTPException as exc:
-        return err(f"Error disabling plugin '{plugin_id}': {rest_detail(exc)}")
+    except PluginError as exc:
+        return err(f"Error disabling plugin '{plugin_id}': {plugin_detail(exc)}")
     except Exception as exc:
         return err(f"Error disabling plugin '{plugin_id}': {exc}")
 
@@ -129,12 +128,10 @@ def disable_plugin(plugin_id: str) -> dict[str, Any]:
 
 def uninstall_plugin(plugin_id: str) -> dict[str, Any]:
     """Permanently remove an installed plugin. Irreversible."""
-    from fastapi import HTTPException
-
     try:
         _plugin_service().uninstall(plugin_id)
-    except HTTPException as exc:
-        return err(f"Error uninstalling plugin '{plugin_id}': {rest_detail(exc)}")
+    except PluginError as exc:
+        return err(f"Error uninstalling plugin '{plugin_id}': {plugin_detail(exc)}")
     except Exception as exc:
         return err(f"Error uninstalling plugin '{plugin_id}': {exc}")
 
@@ -148,8 +145,6 @@ def configure_plugin(plugin_id: str, config: dict[str, Any]) -> dict[str, Any]:
     fields (and never trips required-field validation on the keys it did
     not send). Pinned by tests/test_mcp_state_effects.py.
     """
-    from fastapi import HTTPException
-
     from src.config_manager import get_config_manager
 
     try:
@@ -159,8 +154,8 @@ def configure_plugin(plugin_id: str, config: dict[str, Any]) -> dict[str, Any]:
         existing = get_config_manager().get_plugin_config(plugin_id, include_env_overrides=False) or {}
         merged = {**existing, **config}
         masked = _plugin_service().update_plugin_config(plugin_id, merged)
-    except HTTPException as exc:
-        return err(f"Error configuring plugin '{plugin_id}': {rest_detail(exc)}")
+    except PluginError as exc:
+        return err(f"Error configuring plugin '{plugin_id}': {plugin_detail(exc)}")
     except Exception as exc:
         return err(f"Error configuring plugin '{plugin_id}': {exc}")
 
@@ -177,12 +172,10 @@ async def update_plugin(plugin_id: str) -> dict[str, Any]:
     #1741: goes through ``PluginService.apply_update`` — the shared,
     guarded path — never re-deriving its checks here.
     """
-    from fastapi import HTTPException
-
     try:
         await _plugin_service().apply_update(plugin_id)
-    except HTTPException as exc:
-        return err(f"Error updating plugin '{plugin_id}': {rest_detail(exc)}")
+    except PluginError as exc:
+        return err(f"Error updating plugin '{plugin_id}': {plugin_detail(exc)}")
     except Exception as exc:
         return err(f"Error updating plugin '{plugin_id}': {exc}")
 

--- a/src/ops/results.py
+++ b/src/ops/results.py
@@ -32,6 +32,20 @@ def rest_detail(exc: Any) -> str:
     return str(detail)
 
 
+def plugin_detail(exc: Any) -> str:
+    """Flatten a :class:`src.plugins.errors.PluginError` into one message.
+
+    ``PluginConfigInvalid`` carries per-field schema messages; every other
+    plugin error is just its string. The REST layer keeps the two apart
+    (a structured ``detail`` object); a chat or MCP answer is one line of
+    prose, so they join here.
+    """
+    errors = getattr(exc, "errors", None)
+    if errors:
+        return "; ".join(str(e) for e in errors)
+    return str(exc)
+
+
 def serialize(obj: Any) -> Any:
     """Convert Pydantic models / dataclasses / datetimes to JSON-compatible primitives.
 

--- a/src/plugins/errors.py
+++ b/src/plugins/errors.py
@@ -1,0 +1,77 @@
+"""Domain exceptions for the plugin subsystem (Phase 2 §2, slice 4).
+
+Every other service in the tree raises a domain error and lets its router
+decide the status code. ``PluginService`` was the exception: written during
+Phase 1, it raised ``fastapi.HTTPException`` at 25 sites, so the one service
+added while the layering rule was being written is the one that broke it. The
+2026-09 audit called that out; these classes are the fix.
+
+The rule this file exists to keep: **nothing here knows an HTTP status code.**
+The mapping from exception class to status lives in ``src/plugins/routes.py``
+(``_STATUS_BY_ERROR``), which is the only layer entitled to have an opinion
+about HTTP. The MCP/ops layer catches the same exceptions and renders them as
+its own error envelope without going near a status code at all.
+
+``PluginConfigInvalid`` is the one error carrying structured data: schema
+validation produces a *list* of per-field messages, and flattening it into one
+string at the raise site would throw away what the settings form needs to
+highlight the offending field.
+"""
+
+from __future__ import annotations
+
+
+class PluginError(Exception):
+    """Base for every failure the plugin domain reports to a caller.
+
+    ``str(exc)`` is the human-readable message, and it is the whole contract
+    for every subclass except :class:`PluginConfigInvalid`.
+    """
+
+
+class PluginNotFound(PluginError):
+    """No plugin (or plugin source) is installed under this id."""
+
+
+class PluginNotEnabled(PluginError):
+    """The plugin is installed but currently disabled."""
+
+
+class PluginConfigInvalid(PluginError):
+    """Configuration failed the manifest's settings schema.
+
+    Carries the per-field messages the registry produced so the settings form
+    can point at the field that is wrong, rather than showing one flattened
+    blob of text.
+    """
+
+    def __init__(self, message: str, errors: list[str]) -> None:
+        super().__init__(message)
+        self.errors = list(errors)
+
+
+class PluginOperationRejected(PluginError):
+    """The registry refused the operation and said why.
+
+    Enable/disable that returned False, an invalid instance label, an install
+    or uninstall the registry declined, a branch name that failed validation,
+    a plugin path outside the external plugins directory.
+    """
+
+
+class PluginOperationFailed(PluginError):
+    """The operation was legitimate but failed while running.
+
+    A git fetch that errored, a plugin that would not re-import after an
+    update. Distinct from :class:`PluginOperationRejected` because the caller
+    did nothing wrong — this is a server-side fault.
+    """
+
+
+class PluginOptionsThrottled(PluginError):
+    """A refresh of an options catalog came in faster than the throttle allows.
+
+    Lives here rather than as an ``HTTPException(429)`` inside the options
+    runtime for the same reason as everything else in this file: the runtime
+    does not get to pick status codes.
+    """

--- a/src/plugins/models.py
+++ b/src/plugins/models.py
@@ -1,0 +1,450 @@
+"""Wire models for the ``/plugins`` API (Phase 2 §2, slice 4).
+
+Why this domain does not alias its storage models the way ``collections``
+does. A collection is the same object on disk and on the wire, so
+``CollectionResponse = Collection`` is honest there. Nothing in the plugin
+domain works like that:
+
+* ``PluginDetail`` is **derived** — manifest fields, registry enablement,
+  config-manager state and page-service state, assembled per request;
+* its ``config`` is **masked** — every sensitive value is replaced by ``"***"``
+  on the way out, so the wire model is deliberately *not* the stored model;
+* ``env_overridden_keys`` exists only on the wire, and only to tell the client
+  which keys it is looking at a placeholder for.
+
+Aliasing a storage model here would have quietly declared the masked shape to
+be the stored shape — the same conflation that let the #1743 masking
+regression through. So the wire models are their own thing, and they say so.
+
+Open-ended payloads (``PluginSummary``, ``RegistryEntry``,
+``PluginManifestResponse``) set ``extra="allow"``: their contents are
+plugin-authored and a strict model would silently *delete* fields a plugin
+ships. The declared fields are the contract core knows about; the rest passes
+through untouched.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# ── Listing ─────────────────────────────────────────────────────────────────
+
+
+class PluginSummary(BaseModel):
+    """One row of ``GET /plugins``: registry metadata plus config status."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    name: str
+    version: str = "unknown"
+    description: str = ""
+    author: str = "Unknown"
+    enabled: bool = False
+    icon: str | None = None
+    category: str | None = None
+    #: "data" or "transition" — the UI hides the enable toggle for transition
+    #: plugins, which run whenever selected regardless of the flag.
+    plugin_type: str = "data"
+    fiestaboard_version: str = ""
+    source: dict[str, Any] | None = None
+    update_available: bool = False
+    update_blocked_reason: str = ""
+    supports_triggers: bool = False
+    instance_label: str | None = None
+    base_plugin_id: str | None = None
+    settings_schema: dict[str, Any] = Field(default_factory=dict)
+    #: Whether this plugin has a persisted configuration at all.
+    configured: bool = False
+    #: The stored configuration, **masked**. Never the raw secret.
+    config: dict[str, Any] = Field(default_factory=dict)
+
+
+class PluginListResponse(BaseModel):
+    """``GET /plugins``."""
+
+    plugins: list[PluginSummary]
+    plugin_system_enabled: bool
+    total: int
+    enabled_count: int
+
+
+# ── Variables ───────────────────────────────────────────────────────────────
+
+
+class AllPluginVariablesResponse(BaseModel):
+    """``GET /plugins/variables/all`` — the template editor's whole vocabulary."""
+
+    variables: dict[str, Any]
+    max_lengths: dict[str, Any]
+    plugin_system_enabled: bool
+
+
+class PluginVariablesResponse(BaseModel):
+    """``GET /plugins/{plugin_id}/variables``."""
+
+    plugin_id: str
+    variables: dict[str, Any]
+    max_lengths: dict[str, Any]
+    color_rules_schema: dict[str, Any]
+
+
+# ── Health ──────────────────────────────────────────────────────────────────
+
+
+class FetchBreakerStatus(BaseModel):
+    """One plugin's standing with the fetch circuit breaker.
+
+    The breaker landed with the pool-starvation fix (#1884) and had no way to
+    be observed until this slice: a plugin could be quarantined for minutes
+    while the UI showed nothing but stale variables.
+    """
+
+    consecutive_timeouts: int
+    quarantined: bool
+    cooldown_remaining_seconds: float
+
+
+class PluginErrorsResponse(BaseModel):
+    """``GET /plugins/errors`` — why a plugin is not contributing data.
+
+    Two independent reasons, deliberately in one payload because the UI asks
+    one question ("what is wrong with my plugins?"): ``errors`` holds
+    load-time failures (the plugin never imported), ``fetch_breakers`` holds
+    run-time ones (it imported fine and then stopped answering).
+    """
+
+    errors: dict[str, list[str]]
+    fetch_breakers: dict[str, FetchBreakerStatus] = Field(default_factory=dict)
+    plugin_system_enabled: bool
+
+
+# ── Marketplace registry ────────────────────────────────────────────────────
+
+
+class RegistryEntry(BaseModel):
+    """One entry of the curated plugin registry."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    name: str
+    description: str = ""
+    repository: str = ""
+    branch: str = ""
+    author: str = ""
+    fiestaboard_version: str = ""
+    icon: str = ""
+    category: str = ""
+    plugin_type: str = "data"
+    installed: bool = False
+    #: One-line board strip for the marketplace card, at most 15 tiles.
+    teaser: str = ""
+    #: Literal boards for the detail-page hero, one per declared shape.
+    previews: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class RegistryListResponse(BaseModel):
+    """``GET /plugins/registry``."""
+
+    entries: list[RegistryEntry]
+    plugin_system_enabled: bool
+
+
+class PluginUpdatesResponse(BaseModel):
+    """``GET /plugins/updates``.
+
+    ``blocked`` maps plugin ids to the reason an upstream commit was *not*
+    offered; those plugins appear in ``updates`` as ``False``, and the reason
+    is what lets the UI say so rather than looking stuck.
+    """
+
+    updates: dict[str, bool]
+    blocked: dict[str, str]
+
+
+class PluginUpdateCheckResponse(BaseModel):
+    """``POST /plugins/updates/check``."""
+
+    checked: int
+    updates_available: list[str]
+
+
+class PluginUpdatesApplyResponse(BaseModel):
+    """``POST /plugins/updates/apply`` — deliberately partial-success.
+
+    A bulk update of N plugins can succeed for some and fail for others;
+    collapsing that into one status code would throw away which was which.
+    """
+
+    updated: list[str]
+    failed: dict[str, str]
+    message: str
+
+
+# ── Detail ──────────────────────────────────────────────────────────────────
+
+
+class PluginInstanceInfo(BaseModel):
+    """One named instance of a plugin."""
+
+    model_config = ConfigDict(extra="allow")
+
+    label: str
+    key: str | None = None
+    enabled: bool = False
+    has_config: bool = False
+
+
+class PluginDetail(BaseModel):
+    """``GET /plugins/{plugin_id}`` — derived, masked, and its own model.
+
+    ``config`` is the **stored** configuration with sensitive values masked,
+    deliberately *without* the env-var overlay: this response feeds the
+    settings form, and any value baked in here comes straight back in the next
+    save, so serving the overlay would freeze env values into ``config.json``
+    (#1864 review). Which keys the environment currently controls is reported
+    separately in ``env_overridden_keys``, values excluded.
+    """
+
+    id: str
+    name: str
+    version: str
+    description: str = ""
+    author: str = ""
+    icon: str | None = None
+    category: str | None = None
+    plugin_type: str = "data"
+    enabled: bool
+    #: Stored config, masked. Never the raw secret, never the env value.
+    config: dict[str, Any]
+    #: Config keys whose live value currently comes from an env var. The
+    #: values themselves are deliberately NOT in ``config``.
+    env_overridden_keys: list[str]
+    settings_schema: dict[str, Any]
+    variables: dict[str, Any]
+    max_lengths: dict[str, Any]
+    env_vars: list[Any]
+    documentation: str | None = None
+    has_demo: bool
+    demo_page_id: str | None = None
+    instance_label: str | None = None
+    base_plugin_id: str | None = None
+    instances: list[PluginInstanceInfo]
+
+
+class PluginManifestResponse(BaseModel):
+    """``GET /plugins/{plugin_id}/manifest`` — the raw manifest, passed through.
+
+    Manifests are plugin-authored and open-ended, so this declares the fields
+    core relies on and lets everything else through untouched.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str | None = None
+    version: str | None = None
+    settings_schema: dict[str, Any] = Field(default_factory=dict)
+    variables: dict[str, Any] = Field(default_factory=dict)
+    max_lengths: dict[str, Any] = Field(default_factory=dict)
+
+
+# ── Config / enablement ─────────────────────────────────────────────────────
+
+
+class PluginConfigRequest(BaseModel):
+    """Body of ``PUT /plugins/{plugin_id}/config``.
+
+    ``config`` stays a free-form map on purpose: its schema is the *plugin's*
+    ``settings_schema``, validated by the registry against that manifest, and
+    a typed model here could only be a lie. It is also the field that carries
+    the ``"***"`` sentinel back from the settings form, which any tightening
+    would have to keep accepting.
+    """
+
+    config: dict[str, Any]
+
+
+class PluginConfigUpdateResponse(BaseModel):
+    """``PUT /plugins/{plugin_id}/config`` — the stored config, re-masked."""
+
+    plugin_id: str
+    config: dict[str, Any]
+
+
+class PluginEnablementResponse(BaseModel):
+    """``POST /plugins/{plugin_id}/enable`` and ``/disable``."""
+
+    plugin_id: str
+    enabled: bool
+
+
+# ── Data ────────────────────────────────────────────────────────────────────
+
+
+class PluginDataResponse(BaseModel):
+    """``GET /plugins/{plugin_id}/data``."""
+
+    plugin_id: str
+    available: bool
+    data: dict[str, Any] | None = None
+    formatted_lines: list[str] | None = None
+    error: str | None = None
+
+
+# ── Remote options ──────────────────────────────────────────────────────────
+
+
+class PluginOption(BaseModel):
+    """One selectable choice returned by a plugin's ``get_options()``."""
+
+    value: str | int | float | bool
+    label: str
+    description: str | None = None
+    group: str | None = None
+    preview: str | None = None
+    disabled: bool = False
+    meta: dict[str, Any] | None = None
+
+
+class PluginOptionsRequest(BaseModel):
+    """Body for ``POST /plugins/{plugin_id}/options/{options_id}``.
+
+    POST rather than GET on purpose: ``parent`` holds arbitrary JSON, and
+    ``draft_config`` carries credentials that must never reach a URL, an
+    access log, or browser history.
+    """
+
+    parent: dict[str, Any] = Field(default_factory=dict)
+    query: str = ""
+    limit: int = 200
+    cursor: str | None = None
+    refresh: bool = False
+    draft_config: dict[str, Any] = Field(default_factory=dict)
+
+
+class PluginOptionsResponse(BaseModel):
+    """``POST /plugins/{plugin_id}/options/{options_id}``.
+
+    ``error`` is a *hint*, not an incident: "no API key yet" is the expected
+    state while a settings form is still being filled in, so it rides along
+    with a 200 and the widget shows it inline next to the field. That is the
+    documented ``no_200_on_failure`` exception for this route.
+    """
+
+    plugin_id: str
+    options_id: str
+    options: list[PluginOption]
+    has_more: bool
+    cursor: str | None
+    total: int | None
+    error: str | None
+    cached: bool
+    stale: bool
+    cache_seconds: int
+
+
+# ── Demo pages ──────────────────────────────────────────────────────────────
+
+
+class PluginDemoPageResponse(BaseModel):
+    """``GET /plugins/{plugin_id}/demo-page``."""
+
+    exists: bool
+    page_id: str | None
+    has_demo_template: bool
+
+
+class PluginDemoPageCreateResponse(BaseModel):
+    """``POST /plugins/{plugin_id}/demo-page``.
+
+    ``recreated`` replaces the old ``status: "created" | "recreated"`` string:
+    the demo page is a singleton per plugin + device type, so a second call
+    replaces the first, and the caller needs the verb for its toast. A boolean
+    says that without a status envelope.
+    """
+
+    recreated: bool
+    page: dict[str, Any]
+
+
+# ── Instances ───────────────────────────────────────────────────────────────
+
+
+class PluginInstanceCreateRequest(BaseModel):
+    """Body of ``POST /plugins/{plugin_id}/instances``."""
+
+    label: str
+
+
+class PluginInstancesResponse(BaseModel):
+    """``GET /plugins/{plugin_id}/instances``."""
+
+    plugin_id: str
+    instances: list[PluginInstanceInfo]
+    total: int
+
+
+class PluginInstanceResponse(BaseModel):
+    """``POST``/``DELETE`` on ``/plugins/{plugin_id}/instances``.
+
+    ``instance_label`` is the *normalized* label — the one the registry holds
+    and the one ``{{plugin:label.field}}`` template references must use, which
+    is not always the string the caller sent.
+    """
+
+    plugin_id: str
+    instance_label: str
+    instance_key: str
+
+
+# ── Webhooks ────────────────────────────────────────────────────────────────
+
+
+class PluginReceiveResponse(BaseModel):
+    """``POST /plugins/{plugin_id}/receive``.
+
+    The ``status`` key survives the conventions pass on purpose: this endpoint
+    is a **webhook target for third-party systems** (CI pipelines, home
+    automations) that this repo does not control and cannot update in lockstep.
+    "Deprecation, never deletion" applies to it more literally than to any
+    browser-facing route. ``plugin_id`` is added so the ack names what it
+    acked.
+    """
+
+    status: Literal["ok"] = "ok"
+    plugin_id: str
+
+
+# ── Install / uninstall / update ────────────────────────────────────────────
+
+
+class ExternalPluginInstallRequest(BaseModel):
+    """Body of ``POST /plugins/install``."""
+
+    repository: str
+    plugin_id: str | None = None
+    branch: str = ""
+
+
+class PluginInstallResponse(BaseModel):
+    """``POST /plugins/install`` and ``POST /plugins/registry/{id}/install``."""
+
+    plugin_id: str
+    message: str
+
+
+class PluginUninstallResponse(BaseModel):
+    """``DELETE /plugins/{plugin_id}/uninstall``."""
+
+    plugin_id: str
+    message: str
+
+
+class PluginUpdateResponse(BaseModel):
+    """``POST /plugins/{plugin_id}/update``."""
+
+    plugin_id: str
+    message: str

--- a/src/plugins/options_runtime.py
+++ b/src/plugins/options_runtime.py
@@ -1,0 +1,292 @@
+"""Runtime for the plugin remote-options endpoint (Phase 2 §2, slice 4).
+
+Concurrency guard, response caches, refresh throttle and payload ceilings for
+``POST /plugins/{plugin_id}/options/{options_id}``. All of it grew up inside
+``src/api_server.py``, which meant the extracted plugins router could only
+reach it with a thirteen-name call-time ``from src.api_server import ...``
+inside the handler — the seam the 2026-09 audit counted going up 4.2x across
+Phase 1, and the reason serving one options lookup dragged the whole 10k-line
+app module back into the process.
+
+None of it touches the FastAPI app object, so it lives here instead
+(recipe addendum 7: give a homeless collaborator a real module rather than
+threading it through as a parameter). ``src.api_server`` re-imports every
+name, so anything patching ``src.api_server.<name>`` still binds; the router
+imports from here and is patched at ``src.plugins.options_runtime.<name>``.
+
+The two module-level caches are process-global by design — an options catalog
+is the same for every request — which is also why tests that care about cache
+state patch ``_PLUGIN_OPTIONS_CACHE`` / ``_plugin_options_last_refresh``
+rather than hoping for a cold start.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import threading
+import time
+from typing import Any
+
+from .errors import PluginOptionsThrottled
+
+logger = logging.getLogger(__name__)
+
+
+# ── Plugin remote options ────────────────────────────────────────────────────
+
+# Hard ceiling on how many options core will hand to the browser, whatever the
+# plugin returns. A picker that renders 50k rows wedges the settings dialog.
+PLUGIN_OPTIONS_MAX_RETURNED = 1000
+PLUGIN_OPTIONS_DEFAULT_CACHE_SECONDS = 300
+
+# Display-string ceilings, enforced by core rather than trusted to the plugin.
+# Different fields get different room because the picker gives them different
+# room. Over-long strings are trimmed, never a reason to drop the choice.
+PLUGIN_OPTIONS_MAX_LABEL_CHARS = 200
+PLUGIN_OPTIONS_MAX_DESCRIPTION_CHARS = 200
+PLUGIN_OPTIONS_MAX_PREVIEW_CHARS = 120
+PLUGIN_OPTIONS_MAX_GROUP_CHARS = 80
+
+# A continuation token is opaque to core, but it still has to fit back into a
+# request, and it is one more thing a plugin can make arbitrarily large.
+PLUGIN_OPTIONS_MAX_CURSOR_CHARS = 512
+
+PLUGIN_OPTIONS_MAX_PAYLOAD_BYTES = 512 * 1024
+
+# Wall-clock budget for one options lookup. Longer than a plugin's own HTTP
+# timeout should be, short enough that a stuck picker gives up while the
+# settings dialog is still open.
+PLUGIN_OPTIONS_TIMEOUT_SECONDS = 20.0
+
+# How many options lookups may occupy worker threads at once. See
+# _bounded_options_call for why this is not just politeness.
+PLUGIN_OPTIONS_MAX_CONCURRENCY = 4
+_PLUGIN_OPTIONS_SEMAPHORE = asyncio.Semaphore(PLUGIN_OPTIONS_MAX_CONCURRENCY)
+
+
+async def _bounded_options_call(work: Any, timeout: float) -> Any:
+    """Run blocking *work* on a worker thread with a hard wall-clock deadline.
+
+    ``asyncio.wait_for`` cancels the *await*, never the thread. A plugin that
+    hangs on a socket keeps its worker forever no matter what we do here, so
+    the semaphore is released from the task's done-callback — when the thread
+    genuinely finishes — rather than when we stop waiting for it.
+
+    That ordering is the whole point. Releasing on timeout would let four hung
+    lookups free their slots, the next four start fresh threads, and so on
+    until the default executor is exhausted and *every* other
+    ``asyncio.to_thread`` caller in the process starves behind a plugin nobody
+    is even waiting on. Holding the slot until the thread returns caps the
+    damage at ``PLUGIN_OPTIONS_MAX_CONCURRENCY`` threads.
+    """
+    await _PLUGIN_OPTIONS_SEMAPHORE.acquire()
+    task = asyncio.ensure_future(asyncio.to_thread(work))
+
+    def _release(finished: Any) -> None:
+        _PLUGIN_OPTIONS_SEMAPHORE.release()
+        if not finished.cancelled():
+            # Retrieve any exception so a lookup that fails after we gave up
+            # does not surface as "exception was never retrieved".
+            finished.exception()
+
+    task.add_done_callback(_release)
+    # shield() so the timeout abandons the wait without cancelling the task —
+    # cancelling it would drop the done-callback's release on the floor.
+    return await asyncio.wait_for(asyncio.shield(task), timeout)
+
+
+# Answers are cached per (plugin instance, provider, effective config, query)
+# so that typing in a search box does not hammer an upstream API. Bounded so a
+# long-lived process cannot accumulate one entry per keystroke forever.
+PLUGIN_OPTIONS_CACHE_MAX_ENTRIES = 512
+_PLUGIN_OPTIONS_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
+_plugin_options_cache_lock = threading.Lock()
+
+
+def _config_fingerprint(config: dict[str, Any]) -> str:
+    """Return a stable digest of an effective plugin config.
+
+    Two installs of the same plugin with different credentials must never read
+    each other's cached options, and the digest keeps the secrets themselves
+    out of the cache key. ``default=str`` because a config may legitimately
+    hold values JSON does not know (e.g. a datetime from a draft form).
+    """
+    blob = json.dumps(config, sort_keys=True, default=str)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def _plugin_options_cache_key(
+    plugin_id: str,
+    options_id: str,
+    config_digest: str,
+    body: Any,  # PluginOptionsRequestBody (moved to src/plugins/routes.py); duck-typed here
+    limit: int,
+) -> str:
+    """Build the cache key for one options question.
+
+    ``plugin_id`` is the *full* key, instance label included: ``weather:home``
+    and ``weather:cabin`` are different installs with different configs and
+    must never share an entry.
+    """
+    blob = json.dumps(
+        {
+            "plugin_id": plugin_id,
+            "options_id": options_id,
+            "config": config_digest,
+            "parent": body.parent,
+            "query": body.query,
+            "limit": limit,
+            "cursor": body.cursor,
+        },
+        sort_keys=True,
+        default=str,
+    )
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def _plugin_options_cache_get(key: str) -> tuple[float, dict[str, Any]] | None:
+    """Return the ``(stored_at, payload)`` entry for *key*, fresh or not."""
+    with _plugin_options_cache_lock:
+        return _PLUGIN_OPTIONS_CACHE.get(key)
+
+
+def _plugin_options_cache_put(key: str, payload: dict[str, Any]) -> None:
+    """Store *payload* under *key*, evicting the oldest entry when full."""
+    with _plugin_options_cache_lock:
+        if key not in _PLUGIN_OPTIONS_CACHE and len(_PLUGIN_OPTIONS_CACHE) >= PLUGIN_OPTIONS_CACHE_MAX_ENTRIES:
+            oldest = min(_PLUGIN_OPTIONS_CACHE, key=lambda k: _PLUGIN_OPTIONS_CACHE[k][0])
+            _PLUGIN_OPTIONS_CACHE.pop(oldest, None)
+        _PLUGIN_OPTIONS_CACHE[key] = (time.monotonic(), payload)
+
+
+def _stale_options_payload(cache_key: str, reason: str) -> dict[str, Any] | None:
+    """Return the last good answer for *cache_key*, flagged stale, or ``None``.
+
+    Expiry is deliberately ignored here. Once a lookup has failed, an old list
+    plus a visible "this may be out of date" is strictly better for the user
+    than an empty picker — they are usually re-opening a dialog to change one
+    unrelated field.
+    """
+    entry = _plugin_options_cache_get(cache_key)
+    if entry is None:
+        return None
+    return {**entry[1], "cached": True, "stale": True, "error": reason}
+
+
+# A cache-bypassing refresh is the one thing a user can trigger by hand that
+# reaches straight through to somebody else's API. One per second per question
+# is plenty for a Retry button and stops a stuck client from becoming a DoS.
+PLUGIN_OPTIONS_REFRESH_MIN_INTERVAL_SECONDS = 1.0
+_plugin_options_last_refresh: dict[str, float] = {}
+
+
+def _plugin_options_refresh_throttle(cache_key: str) -> None:
+    """Reject a forced refresh that lands too soon after the previous one.
+
+    Keyed per question rather than globally so a slow provider cannot lock out
+    refreshes for every other field in the dialog.
+    """
+    now = time.monotonic()
+    with _plugin_options_cache_lock:
+        previous = _plugin_options_last_refresh.get(cache_key, 0.0)
+        if previous and (now - previous) < PLUGIN_OPTIONS_REFRESH_MIN_INTERVAL_SECONDS:
+            raise PluginOptionsThrottled("Options refresh is rate-limited. Please wait a moment and try again.")
+        _plugin_options_last_refresh[cache_key] = now
+        # Bounded alongside the cache it shadows.
+        if len(_plugin_options_last_refresh) > PLUGIN_OPTIONS_CACHE_MAX_ENTRIES:
+            oldest = min(_plugin_options_last_refresh, key=_plugin_options_last_refresh.get)  # type: ignore[arg-type]
+            _plugin_options_last_refresh.pop(oldest, None)
+
+
+def _declared_options_ids(manifest: Any) -> set[str]:
+    """Return the ``options_id``s this plugin's own manifest declares."""
+    from .manifest import collect_options_ids
+
+    if manifest is None:
+        return set()
+    return collect_options_ids(getattr(manifest, "settings_schema", None) or {})
+
+
+def _options_cache_seconds(manifest: Any, options_id: str) -> int:
+    """Return the cache TTL this provider declares, or the platform default."""
+    from .manifest import options_cache_seconds
+
+    declared = options_cache_seconds(getattr(manifest, "settings_schema", None) or {}, options_id)
+    return PLUGIN_OPTIONS_DEFAULT_CACHE_SECONDS if declared is None else declared
+
+
+def _truncate(text: Any, ceiling: int) -> str | None:
+    """Clip a plugin-supplied display string to *ceiling* characters."""
+    if text is None:
+        return None
+    return (text if isinstance(text, str) else str(text))[:ceiling]
+
+
+def _serialise_option(option: Any, plugin_id: str, options_id: str) -> dict[str, Any] | None:
+    """Render one plugin-supplied option, or ``None`` if it must be dropped.
+
+    Truncation rather than rejection for the display strings: a 10KB label
+    breaks the layout, but discarding the option would lose a choice the user
+    needs. ``value`` is the exception — it is written verbatim into
+    config.json, so a non-scalar there becomes an un-comparable blob that only
+    fails much later, somewhere unrelated.
+    """
+    value = getattr(option, "value", None)
+    if not isinstance(value, str | int | float | bool):
+        logger.warning(
+            "Plugin '%s' options provider '%s' returned an option with a non-scalar value (%s); dropping it",
+            plugin_id,
+            options_id,
+            type(value).__name__,
+        )
+        return None
+
+    return {
+        "value": value,
+        "label": _truncate(getattr(option, "label", None), PLUGIN_OPTIONS_MAX_LABEL_CHARS),
+        "description": _truncate(getattr(option, "description", None), PLUGIN_OPTIONS_MAX_DESCRIPTION_CHARS),
+        "group": _truncate(getattr(option, "group", None), PLUGIN_OPTIONS_MAX_GROUP_CHARS),
+        "preview": _truncate(getattr(option, "preview", None), PLUGIN_OPTIONS_MAX_PREVIEW_CHARS),
+        "disabled": bool(getattr(option, "disabled", False)),
+        "meta": getattr(option, "meta", None),
+    }
+
+
+def _serialise_options(options: Any, limit: int, plugin_id: str, options_id: str) -> tuple[list[dict[str, Any]], bool]:
+    """Return ``(sanitised_options, truncated)`` for one provider's answer."""
+    kept: list[dict[str, Any]] = []
+    truncated = False
+    for option in options or []:
+        if len(kept) >= limit:
+            truncated = True
+            break
+        rendered = _serialise_option(option, plugin_id, options_id)
+        if rendered is not None:
+            kept.append(rendered)
+    return kept, truncated
+
+
+def _fit_options_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Trim *payload* in place until it fits the response byte budget.
+
+    A count ceiling is not a size ceiling: 1000 options each carrying a full
+    label, description, preview and group is most of a megabyte, and the
+    typical FiestaBoard talks to a Raspberry Pi over a home LAN.
+
+    Measured with ``json.dumps`` defaults, which are looser than the compact
+    separators FastAPI actually serialises with — so the real response is
+    always a little under whatever this accepts.
+    """
+    encoded = len(json.dumps(payload, default=str).encode("utf-8"))
+    while encoded > PLUGIN_OPTIONS_MAX_PAYLOAD_BYTES and payload["options"]:
+        # Drop proportionally to the overshoot so this converges in a couple
+        # of passes instead of one option at a time.
+        per_option = max(1, encoded // len(payload["options"]))
+        drop = max(1, min(len(payload["options"]), (encoded - PLUGIN_OPTIONS_MAX_PAYLOAD_BYTES) // per_option + 1))
+        del payload["options"][-drop:]
+        payload["has_more"] = True
+        encoded = len(json.dumps(payload, default=str).encode("utf-8"))
+    return payload

--- a/src/plugins/routes.py
+++ b/src/plugins/routes.py
@@ -1,58 +1,192 @@
-"""FastAPI router for the ``/plugins`` endpoint family (issue #1757).
+"""FastAPI router for the ``/plugins`` endpoint family.
 
-Handlers moved from ``src/api_server.py``. Names that still live in
-``api_server`` — ``PLUGIN_SYSTEM_AVAILABLE``, the service getters, the reset
-callables, and the plugin-options machinery/state that the test-suite
-monkeypatches as ``src.api_server.<name>`` — are imported *inside* each
-handler so they resolve through the api_server module at call time. A
-module-level import would both create an import cycle (api_server imports
-this router) and detach the handlers from those patches (the #1756 pattern).
+Handlers moved out of ``src/api_server.py`` in #1757; Phase 2 slice 4 then
+applied ``docs/internal/reference/API_CONVENTIONS.md`` to them and retired the
+call-time ``from src.api_server import ...`` seams the move left behind.
 
-Orchestration (mutate → persist → reset-display → reset-template-engine) and
-the private-member reaches (``ConfigManager._mask_sensitive``,
-``PluginRegistry._update_status``) live in
-:class:`src.plugins.service.PluginService`; the handlers here stay thin.
+Collaborators now resolve from their canonical homes at **module import
+time**, so this module never loads ``src.api_server``
+(``tests/test_plugins_decoupled.py`` asserts that in a fresh interpreter).
+Tests that need to stub a collaborator patch it where this module binds it —
+``src.plugins.routes.<name>`` — not ``src.api_server.<name>``.
+
+Where the collaborators went, for the reader chasing a patch target:
+
+===========================================  ==================================
+Was                                          Now
+===========================================  ==================================
+``api_server.get_plugin_registry``           ``src.plugins``
+``api_server.get_config_manager``            ``src.config_manager``
+``api_server.unmask_sensitive_values``       ``src.config_manager``
+``api_server.get_page_service``              ``src.pages.service``
+``api_server.get_settings_service``          ``src.settings.service``
+``api_server.get_template_engine``           ``src.templates.engine``
+``api_server.reset_template_engine``         ``src.templates.engine``
+``api_server.reset_display_service``         ``src.displays.service``
+``api_server.PLUGIN_SYSTEM_AVAILABLE``       ``src.plugins.routes`` (defined
+                                             here; api_server imports it)
+the 13 ``PLUGIN_OPTIONS_*`` names            ``src.plugins.options_runtime``
+                                             (new)
+===========================================  ==================================
+
+**Error translation lives here, and only here.** ``PluginService`` raises the
+domain exceptions in :mod:`src.plugins.errors`; ``_STATUS_BY_ERROR`` below is
+the single table mapping them to status codes, applied by the
+``@plugin_errors_to_http`` decorator on every handler that can reach the
+service. Phase 1 had the service raising ``fastapi.HTTPException`` at 25
+sites, which made it the one service in the tree that knew about HTTP.
 """
 
 from __future__ import annotations
 
 import asyncio
+import functools
 import json
 import logging
-from typing import Any
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar
 
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel, Field
 
+from src.api_errors import errors
+from src.config_manager import get_config_manager, unmask_sensitive_values
+from src.displays.service import reset_display_service
+from src.pages.service import get_page_service
+from src.settings.service import get_settings_service
+from src.templates.engine import get_template_engine, reset_template_engine
+
+from .errors import (
+    PluginConfigInvalid,
+    PluginError,
+    PluginNotEnabled,
+    PluginNotFound,
+    PluginOperationFailed,
+    PluginOperationRejected,
+    PluginOptionsThrottled,
+)
+from .models import (
+    AllPluginVariablesResponse,
+    ExternalPluginInstallRequest,
+    PluginConfigRequest,
+    PluginConfigUpdateResponse,
+    PluginDataResponse,
+    PluginDemoPageCreateResponse,
+    PluginDemoPageResponse,
+    PluginDetail,
+    PluginEnablementResponse,
+    PluginErrorsResponse,
+    PluginInstallResponse,
+    PluginInstanceCreateRequest,
+    PluginInstanceResponse,
+    PluginInstancesResponse,
+    PluginListResponse,
+    PluginManifestResponse,
+    PluginOptionsRequest,
+    PluginOptionsResponse,
+    PluginReceiveResponse,
+    PluginSummary,
+    PluginUninstallResponse,
+    PluginUpdateCheckResponse,
+    PluginUpdateResponse,
+    PluginUpdatesApplyResponse,
+    PluginUpdatesResponse,
+    PluginVariablesResponse,
+    RegistryListResponse,
+)
+from .options_runtime import (
+    PLUGIN_OPTIONS_MAX_CURSOR_CHARS,
+    PLUGIN_OPTIONS_MAX_RETURNED,
+    PLUGIN_OPTIONS_TIMEOUT_SECONDS,
+    _bounded_options_call,
+    _config_fingerprint,
+    _declared_options_ids,
+    _fit_options_payload,
+    _options_cache_seconds,
+    _plugin_options_cache_get,
+    _plugin_options_cache_key,
+    _plugin_options_cache_put,
+    _plugin_options_refresh_throttle,
+    _serialise_options,
+    _stale_options_payload,
+    _truncate,
+)
 from .service import PluginService
+
+try:  # pragma: no cover - the except arm needs a broken install to reach
+    from . import get_plugin_registry
+
+    PLUGIN_SYSTEM_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    PLUGIN_SYSTEM_AVAILABLE = False
+    get_plugin_registry = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["plugins"])
 
 
+# ── Error translation ───────────────────────────────────────────────────────
+
+#: The single place a plugin-domain failure becomes a status code. Ordered
+#: most-specific first, because ``PluginError`` is the catch-all base.
+_STATUS_BY_ERROR: tuple[tuple[type[PluginError], int], ...] = (
+    (PluginNotFound, 404),
+    (PluginNotEnabled, 400),
+    (PluginConfigInvalid, 400),
+    (PluginOptionsThrottled, 429),
+    (PluginOperationRejected, 400),
+    (PluginOperationFailed, 500),
+)
+
+_T = TypeVar("_T")
+
+
+def _as_http(exc: PluginError) -> HTTPException:
+    """Translate a domain error into the HTTP failure the API serves."""
+    status = next((code for kind, code in _STATUS_BY_ERROR if isinstance(exc, kind)), 400)
+    if isinstance(exc, PluginConfigInvalid):
+        # The one structured detail in this domain: schema validation produces
+        # per-field messages and the settings form highlights the field that
+        # is wrong. ``message`` is present because API_CONVENTIONS.md requires
+        # a dict detail to carry one — an ``errors``-only body was the exact
+        # anti-pattern the doc bans.
+        return HTTPException(status_code=status, detail={"message": str(exc), "errors": exc.errors})
+    return HTTPException(status_code=status, detail=str(exc))
+
+
+def plugin_errors_to_http(handler: Callable[..., Awaitable[_T]]) -> Callable[..., Awaitable[_T]]:
+    """Map :class:`~src.plugins.errors.PluginError` onto ``HTTPException``.
+
+    Applied to every handler that can reach ``PluginService`` so the service
+    never has to know a status code. ``functools.wraps`` keeps the wrapped
+    signature visible to FastAPI's dependency resolution and to the
+    conventions ratchet, which unwraps before reading handler source.
+    """
+
+    @functools.wraps(handler)
+    async def wrapper(*args: Any, **kwargs: Any) -> _T:
+        try:
+            return await handler(*args, **kwargs)
+        except PluginError as exc:
+            raise _as_http(exc) from exc
+
+    return wrapper
+
+
 def _require_plugin_system() -> None:
     """503 unless the plugin system imported successfully at startup."""
-    from src.api_server import PLUGIN_SYSTEM_AVAILABLE  # patched-in-tests seam — see module docstring
-
     if not PLUGIN_SYSTEM_AVAILABLE:
         raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
 
 def _plugin_service() -> PluginService:
-    """Build a PluginService wired to api_server's (possibly patched) seams.
+    """Build a PluginService wired to this module's collaborator bindings.
 
-    The collaborators are resolved through ``src.api_server`` at call time so
-    the suite's ``patch("src.api_server.<name>")`` targets keep steering the
-    service exactly as they steered the inline handlers.
+    Resolved through the module globals so a test can steer the service by
+    patching ``src.plugins.routes.get_plugin_registry`` (and friends) — one
+    seam per collaborator, in the module that uses it.
     """
-    from src.api_server import (  # patched-in-tests seam — see module docstring
-        get_config_manager,
-        get_plugin_registry,
-        reset_display_service,
-        reset_template_engine,
-    )
-
     return PluginService(
         registry=get_plugin_registry(),
         config_manager=get_config_manager(),
@@ -61,158 +195,127 @@ def _plugin_service() -> PluginService:
     )
 
 
-class PluginConfigRequest(BaseModel):
-    """Request body for plugin configuration updates."""
-
-    config: dict[str, Any]
+# ── Listing and cross-plugin reads ──────────────────────────────────────────
 
 
-class PluginEnableRequest(BaseModel):
-    """Request body for enabling/disabling a plugin."""
-
-    enabled: bool
-
-
-@router.get("/plugins")
-async def list_plugins():
-    """
-    List all available plugins.
-
-    Returns plugins with their status, metadata, and whether they're enabled.
-    """
+@router.get(
+    "/plugins",
+    response_model=PluginListResponse,
+    responses=errors(503),
+)
+async def list_plugins() -> PluginListResponse:
+    """List all available plugins with their status, metadata and masked config."""
     _require_plugin_system()
-    from src.api_server import get_config_manager, get_plugin_registry  # patched-in-tests seam
 
     registry = get_plugin_registry()
     plugins = registry.list_plugins()
 
-    # Add configuration status (masked)
     config_manager = get_config_manager()
     service = _plugin_service()
     for plugin in plugins:
         plugin_config = config_manager.get_plugin_config(plugin["id"])
-        if plugin_config:
-            plugin["configured"] = True
-            # Add masked config
-            plugin["config"] = service.mask_config(plugin_config)
-        else:
-            plugin["configured"] = False
-            plugin["config"] = {}
+        plugin["configured"] = bool(plugin_config)
+        plugin["config"] = service.mask_config(plugin_config)
 
-    return {
-        "plugins": plugins,
-        "plugin_system_enabled": True,
-        "total": len(plugins),
-        "enabled_count": sum(1 for p in plugins if p.get("enabled", False)),
-    }
-
-
-@router.get("/plugins/variables/all")
-async def get_all_plugin_variables():
-    """
-    Get all template variables from enabled plugins.
-
-    Returns a combined view of all variables for the template editor.
-    """
-    from src.api_server import (  # patched-in-tests seam — see module docstring
-        PLUGIN_SYSTEM_AVAILABLE,
-        get_plugin_registry,
-        get_template_engine,
+    return PluginListResponse(
+        plugins=[PluginSummary.model_validate(p) for p in plugins],
+        plugin_system_enabled=True,
+        total=len(plugins),
+        enabled_count=sum(1 for p in plugins if p.get("enabled", False)),
     )
 
+
+@router.get("/plugins/variables/all", response_model=AllPluginVariablesResponse)
+async def get_all_plugin_variables() -> AllPluginVariablesResponse:
+    """Every template variable exposed by the plugin system, for the editor."""
     if not PLUGIN_SYSTEM_AVAILABLE:
-        # Fall back to legacy variables
+        # Fall back to legacy variables rather than failing: the template
+        # editor still has a vocabulary without the plugin system.
         template_engine = get_template_engine()
-        return {
-            "variables": template_engine.get_available_variables(),
-            "max_lengths": template_engine.get_variable_max_lengths(),
-            "plugin_system_enabled": False,
-        }
+        return AllPluginVariablesResponse(
+            variables=template_engine.get_available_variables(),
+            max_lengths=template_engine.get_variable_max_lengths(),
+            plugin_system_enabled=False,
+        )
 
     registry = get_plugin_registry()
-
-    return {
-        "variables": registry.get_all_variables(),
-        "max_lengths": registry.get_all_max_lengths(),
-        "plugin_system_enabled": True,
-    }
-
-
-@router.get("/plugins/errors")
-async def get_plugin_errors():
-    """
-    Get any plugin load errors.
-
-    Returns errors from plugins that failed to load.
-    """
-    from src.api_server import PLUGIN_SYSTEM_AVAILABLE, get_plugin_registry  # patched-in-tests seam
-
-    if not PLUGIN_SYSTEM_AVAILABLE:
-        return {"errors": {}, "plugin_system_enabled": False}
-
-    registry = get_plugin_registry()
-
-    return {"errors": registry.get_load_errors(), "plugin_system_enabled": True}
-
-
-@router.get("/plugins/registry")
-async def list_registry_plugins():
-    """
-    List all plugins available in the curated plugin registry.
-
-    Returns registry entries with their installation status.
-    """
-    _require_plugin_system()
-    from src.api_server import get_plugin_registry  # patched-in-tests seam — see module docstring
-
-    registry = get_plugin_registry()
-
-    return {
-        "entries": registry.get_registry_entries(),
-        "plugin_system_enabled": True,
-    }
-
-
-@router.get("/plugins/updates")
-async def get_plugin_updates():
-    """
-    Return cached update availability for all installed external plugins.
-
-    Results are refreshed by a background task every 6 hours.  Call
-    ``POST /plugins/updates/check`` to trigger an immediate check.
-
-    ``blocked`` maps plugin ids to the reason an upstream commit was *not*
-    offered — currently only "the incoming manifest needs a newer FiestaBoard
-    core".  Those plugins appear in ``updates`` as ``False``; the reason is
-    what lets the UI say so rather than looking stuck.
-    """
-    _require_plugin_system()
-    from src.api_server import get_plugin_registry  # patched-in-tests seam — see module docstring
-
-    registry = get_plugin_registry()
-    return {
-        "updates": registry.get_update_status(),
-        "blocked": registry.get_update_blocked_reasons(),
-    }
-
-
-@router.get("/plugins/{plugin_id}")
-async def get_plugin(plugin_id: str):
-    """
-    Get details for a specific plugin.
-
-    Returns the plugin's manifest, configuration, and status.
-    """
-    _require_plugin_system()
-    from src.api_server import (  # patched-in-tests seam — see module docstring
-        get_config_manager,
-        get_page_service,
-        get_plugin_registry,
+    return AllPluginVariablesResponse(
+        variables=registry.get_all_variables(),
+        max_lengths=registry.get_all_max_lengths(),
+        plugin_system_enabled=True,
     )
+
+
+@router.get("/plugins/errors", response_model=PluginErrorsResponse)
+async def get_plugin_errors() -> PluginErrorsResponse:
+    """Report why plugins are not contributing data.
+
+    Two independent failure modes in one payload, because the UI asks one
+    question. ``errors`` is load time — the plugin never imported.
+    ``fetch_breakers`` is run time — it imported fine and then stopped
+    answering, so the circuit breaker (#1884) stopped submitting it. The
+    breaker has existed since the pool-starvation fix and until this slice was
+    unobservable: a plugin could sit quarantined for minutes while the UI
+    showed nothing but stale variables.
+    """
+    if not PLUGIN_SYSTEM_AVAILABLE:
+        return PluginErrorsResponse(errors={}, fetch_breakers={}, plugin_system_enabled=False)
+
+    registry = get_plugin_registry()
+    return PluginErrorsResponse(
+        errors=registry.get_load_errors(),
+        fetch_breakers=registry.get_fetch_breaker_status(),
+        plugin_system_enabled=True,
+    )
+
+
+@router.get(
+    "/plugins/registry",
+    response_model=RegistryListResponse,
+    responses=errors(503),
+)
+async def list_registry_plugins() -> RegistryListResponse:
+    """List every plugin in the curated registry, with its installation status."""
+    _require_plugin_system()
+
+    registry = get_plugin_registry()
+    return RegistryListResponse(entries=registry.get_registry_entries(), plugin_system_enabled=True)
+
+
+@router.get(
+    "/plugins/updates",
+    response_model=PluginUpdatesResponse,
+    responses=errors(503),
+)
+async def get_plugin_updates() -> PluginUpdatesResponse:
+    """Cached update availability for all installed external plugins.
+
+    Refreshed by a background task every 6 hours; call
+    ``POST /plugins/updates/check`` to trigger an immediate check.
+    """
+    _require_plugin_system()
+
+    registry = get_plugin_registry()
+    return PluginUpdatesResponse(
+        updates=registry.get_update_status(),
+        blocked=registry.get_update_blocked_reasons(),
+    )
+
+
+# ── One plugin ──────────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/plugins/{plugin_id}",
+    response_model=PluginDetail,
+    responses=errors(404, 503),
+)
+async def get_plugin(plugin_id: str) -> PluginDetail:
+    """Manifest, configuration and status for one plugin."""
+    _require_plugin_system()
 
     registry = get_plugin_registry()
     manifest = registry.get_manifest(plugin_id)
-
     if not manifest:
         raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
 
@@ -220,12 +323,11 @@ async def get_plugin(plugin_id: str):
     # the settings form, and any value baked in here comes straight back in
     # the next save — serving the overlay would freeze env values into
     # config.json (#1864 review). Which keys are currently env-controlled is
-    # reported separately in env_overridden_keys.
+    # reported separately in env_overridden_keys, values excluded.
     config_manager = get_config_manager()
     plugin_config = config_manager.get_plugin_config(plugin_id, include_env_overrides=False)
     env_overridden_keys = sorted(config_manager.get_plugin_env_overrides(plugin_id)) if plugin_config else []
 
-    # Check for demo page (use flagship as the representative for backwards compat)
     has_demo = manifest.demo is not None
     demo_page_id = None
     if has_demo:
@@ -236,124 +338,114 @@ async def get_plugin(plugin_id: str):
         if demo_page:
             demo_page_id = demo_page.id
 
-    # Instance information
     base_id, instance_label = registry.parse_instance_key(plugin_id)
     instances = registry.list_instances(base_id) if not instance_label else []
 
-    return {
-        "id": plugin_id,
-        "name": manifest.name,
-        "version": manifest.version,
-        "description": manifest.description,
-        "author": manifest.author,
-        "icon": manifest.icon,
-        "category": manifest.category,
-        # "data" or "transition" -- the UI hides the enable toggle for
-        # transition plugins, which run whenever selected regardless of it.
-        "plugin_type": manifest.plugin_type,
-        "enabled": registry.is_enabled(plugin_id),
-        "config": _plugin_service().mask_config(plugin_config),
-        # Config keys whose live value currently comes from an env var (the
-        # values themselves are deliberately NOT in "config").
-        "env_overridden_keys": env_overridden_keys,
-        "settings_schema": manifest.settings_schema,
-        "variables": manifest.raw.get("variables", {}),
-        "max_lengths": manifest.max_lengths,
-        "env_vars": manifest.env_vars,
-        "documentation": manifest.documentation,
-        "has_demo": has_demo,
-        "demo_page_id": demo_page_id,
-        "instance_label": instance_label,
-        "base_plugin_id": base_id,
-        "instances": instances,
-    }
+    return PluginDetail(
+        id=plugin_id,
+        name=manifest.name,
+        version=manifest.version,
+        description=manifest.description,
+        author=manifest.author,
+        icon=manifest.icon,
+        category=manifest.category,
+        plugin_type=manifest.plugin_type,
+        enabled=registry.is_enabled(plugin_id),
+        config=_plugin_service().mask_config(plugin_config),
+        env_overridden_keys=env_overridden_keys,
+        settings_schema=manifest.settings_schema,
+        variables=manifest.raw.get("variables", {}),
+        max_lengths=manifest.max_lengths,
+        env_vars=manifest.env_vars,
+        documentation=manifest.documentation,
+        has_demo=has_demo,
+        demo_page_id=demo_page_id,
+        instance_label=instance_label,
+        base_plugin_id=base_id,
+        instances=instances,
+    )
 
 
-@router.get("/plugins/{plugin_id}/manifest")
-async def get_plugin_manifest(plugin_id: str):
-    """
-    Get the full manifest for a plugin.
-
-    Returns the raw manifest data for UI rendering.
-    """
+@router.get(
+    "/plugins/{plugin_id}/manifest",
+    response_model=PluginManifestResponse,
+    responses=errors(404, 503),
+)
+async def get_plugin_manifest(plugin_id: str) -> PluginManifestResponse:
+    """The full raw manifest, for UI rendering."""
     _require_plugin_system()
-    from src.api_server import get_plugin_registry  # patched-in-tests seam — see module docstring
 
     registry = get_plugin_registry()
     manifest = registry.get_manifest(plugin_id)
-
     if not manifest:
         raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
 
-    return manifest.raw
+    return PluginManifestResponse.model_validate(manifest.raw)
 
 
-@router.put("/plugins/{plugin_id}/config")
-async def update_plugin_config(plugin_id: str, request: PluginConfigRequest):
-    """
-    Update configuration for a plugin.
+@router.put(
+    "/plugins/{plugin_id}/config",
+    response_model=PluginConfigUpdateResponse,
+    responses=errors(400, 404, 503),
+)
+@plugin_errors_to_http
+async def update_plugin_config(plugin_id: str, request: PluginConfigRequest) -> PluginConfigUpdateResponse:
+    """Validate, persist and apply a plugin's configuration.
 
-    Args:
-        plugin_id: Plugin identifier
-        request: Configuration to apply
-
-    Example body:
-    {
-        "config": {
-            "api_key": "your-api-key",
-            "location": "San Francisco, CA",
-            "refresh_seconds": 300
-        }
-    }
+    A sensitive field posted back as ``"***"`` resolves to the stored secret;
+    see ``PluginService.update_plugin_config`` and
+    ``tests/test_plugins_contract.py`` for the whole round-trip contract.
     """
     _require_plugin_system()
 
     masked = _plugin_service().update_plugin_config(plugin_id, request.config)
-
-    return {
-        "status": "success",
-        "plugin_id": plugin_id,
-        "config": masked,
-    }
+    return PluginConfigUpdateResponse(plugin_id=plugin_id, config=masked)
 
 
-@router.post("/plugins/{plugin_id}/enable")
-async def enable_plugin(plugin_id: str):
-    """
-    Enable a plugin.
-
-    Enables the plugin in both the registry and persists to config.
-    """
+@router.post(
+    "/plugins/{plugin_id}/enable",
+    response_model=PluginEnablementResponse,
+    responses=errors(400, 404, 503),
+)
+@plugin_errors_to_http
+async def enable_plugin(plugin_id: str) -> PluginEnablementResponse:
+    """Enable a plugin in the registry and persist the flag to config."""
     _require_plugin_system()
 
     _plugin_service().enable_plugin(plugin_id)
+    return PluginEnablementResponse(plugin_id=plugin_id, enabled=True)
 
-    return {"status": "success", "plugin_id": plugin_id, "enabled": True}
 
-
-@router.post("/plugins/{plugin_id}/disable")
-async def disable_plugin(plugin_id: str):
-    """
-    Disable a plugin.
-
-    Disables the plugin in both the registry and persists to config.
-    """
+@router.post(
+    "/plugins/{plugin_id}/disable",
+    response_model=PluginEnablementResponse,
+    responses=errors(400, 404, 503),
+)
+@plugin_errors_to_http
+async def disable_plugin(plugin_id: str) -> PluginEnablementResponse:
+    """Disable a plugin in the registry and persist the flag to config."""
     _require_plugin_system()
 
     _plugin_service().disable_plugin(plugin_id)
+    return PluginEnablementResponse(plugin_id=plugin_id, enabled=False)
 
-    return {"status": "success", "plugin_id": plugin_id, "enabled": False}
 
+@router.get(
+    "/plugins/{plugin_id}/data",
+    response_model=PluginDataResponse,
+    responses=errors(400, 404, 503),
+)
+async def get_plugin_data(plugin_id: str) -> PluginDataResponse:
+    """Fetch current data from a plugin.
 
-@router.get("/plugins/{plugin_id}/data")
-async def get_plugin_data(plugin_id: str):
-    """
-    Fetch current data from a plugin.
-
-    Returns the plugin's latest data, formatted output, and status.
+    ``fetch_plugin_data`` makes network calls, so it runs on a worker thread.
+    Inline it seized the single event loop for the whole fetch — the API,
+    every board and ``GET /health`` stopped answering until the plugin's
+    upstream replied. This handler was the last one still doing that; the
+    comment in ``options_runtime`` that used to name it as the bad example is
+    now obsolete, and ``tests/test_plugin_data_event_loop.py`` keeps it so.
     """
     _require_plugin_system()
-    from src.api_server import get_plugin_registry  # patched-in-tests seam — see module docstring
 
     registry = get_plugin_registry()
 
@@ -363,91 +455,57 @@ async def get_plugin_data(plugin_id: str):
     if not registry.is_enabled(plugin_id):
         raise HTTPException(status_code=400, detail=f"Plugin not enabled: {plugin_id}")
 
-    result = registry.fetch_plugin_data(plugin_id)
+    result = await asyncio.to_thread(registry.fetch_plugin_data, plugin_id)
 
-    # Return 503 when plugin data is unavailable (e.g. not configured, auth failure)
-    # so monitoring (Grafana) and request log show it as an error for triage
+    # 503 when plugin data is unavailable (not configured, auth failure) so
+    # monitoring and the request log show it as an error for triage.
     if not result.available:
         raise HTTPException(status_code=503, detail=result.error or "Plugin data not available")
 
-    return {
-        "plugin_id": plugin_id,
-        "available": result.available,
-        "data": result.data,
-        "formatted_lines": result.formatted_lines,
-        "error": result.error,
-    }
+    return PluginDataResponse(
+        plugin_id=plugin_id,
+        available=result.available,
+        data=result.data,
+        formatted_lines=result.formatted_lines,
+        error=result.error,
+    )
 
 
-@router.get("/plugins/{plugin_id}/variables")
-async def get_plugin_variables(plugin_id: str):
-    """
-    Get template variables exposed by a plugin.
-
-    Returns the variables schema for use in the template editor.
-    """
+@router.get(
+    "/plugins/{plugin_id}/variables",
+    response_model=PluginVariablesResponse,
+    responses=errors(404, 503),
+)
+async def get_plugin_variables(plugin_id: str) -> PluginVariablesResponse:
+    """The variables schema a plugin exposes, for the template editor."""
     _require_plugin_system()
-    from src.api_server import get_plugin_registry  # patched-in-tests seam — see module docstring
 
     registry = get_plugin_registry()
     manifest = registry.get_manifest(plugin_id)
-
     if not manifest:
         raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
 
-    return {
-        "plugin_id": plugin_id,
-        "variables": manifest.raw.get("variables", {}),
-        "max_lengths": manifest.max_lengths,
-        "color_rules_schema": manifest.raw.get("color_rules_schema", {}),
-    }
-
-
-class PluginOptionsRequestBody(BaseModel):
-    """Body for ``POST /plugins/{plugin_id}/options/{options_id}``.
-
-    POST rather than GET on purpose: ``parent`` holds arbitrary JSON, and
-    ``draft_config`` carries credentials that must never reach a URL, an
-    access log, or browser history.
-    """
-
-    parent: dict[str, Any] = Field(default_factory=dict)
-    query: str = ""
-    limit: int = 200
-    cursor: str | None = None
-    refresh: bool = False
-    draft_config: dict[str, Any] = Field(default_factory=dict)
-
-
-@router.post("/plugins/{plugin_id}/options/{options_id}")
-async def get_plugin_options_endpoint(plugin_id: str, options_id: str, body: PluginOptionsRequestBody):
-    """Browse a plugin's upstream catalog to populate one settings field."""
-    import time
-
-    # Deliberately api_server's logger, not this module's: the never-log-a-
-    # draft-credential contract is pinned by a caplog test listening on the
-    # "src.api_server" logger (test_plugin_options_route.py).
-    from src.api_server import (  # patched-in-tests seam — the options caches/limits are api_server module state
-        PLUGIN_OPTIONS_MAX_CURSOR_CHARS,
-        PLUGIN_OPTIONS_MAX_RETURNED,
-        PLUGIN_OPTIONS_TIMEOUT_SECONDS,
-        _bounded_options_call,
-        _config_fingerprint,
-        _declared_options_ids,
-        _fit_options_payload,
-        _options_cache_seconds,
-        _plugin_options_cache_get,
-        _plugin_options_cache_key,
-        _plugin_options_cache_put,
-        _plugin_options_refresh_throttle,
-        _serialise_options,
-        _stale_options_payload,
-        _truncate,
-        get_plugin_registry,
-        logger,
-        unmask_sensitive_values,
+    return PluginVariablesResponse(
+        plugin_id=plugin_id,
+        variables=manifest.raw.get("variables", {}),
+        max_lengths=manifest.max_lengths,
+        color_rules_schema=manifest.raw.get("color_rules_schema", {}),
     )
 
+
+# ── Remote options ──────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/plugins/{plugin_id}/options/{options_id}",
+    response_model=PluginOptionsResponse,
+    responses=errors(400, 404, 429, 501, 502, 503, 504),
+)
+@plugin_errors_to_http
+async def get_plugin_options_endpoint(
+    plugin_id: str, options_id: str, body: PluginOptionsRequest
+) -> PluginOptionsResponse:
+    """Browse a plugin's upstream catalog to populate one settings field."""
     from .base import OptionsRequest, OptionsUnavailable
 
     _require_plugin_system()
@@ -514,12 +572,11 @@ async def get_plugin_options_endpoint(plugin_id: str, options_id: str, body: Plu
     elif cache_seconds > 0:
         entry = _plugin_options_cache_get(cache_key)
         if entry is not None and (time.monotonic() - entry[0]) < cache_seconds:
-            return {**entry[1], "cached": True, "stale": False}
+            return PluginOptionsResponse.model_validate({**entry[1], "cached": True, "stale": False})
 
     try:
         # Never call the plugin inline: get_options() makes network calls, and
-        # blocking the event loop here would stall every other request in the
-        # process. (GET /plugins/{id}/data still does this; do not copy it.)
+        # blocking the event loop here would stall every other request.
         result = await _bounded_options_call(
             lambda: registry.get_plugin_options(plugin_id, options_id, request, draft_config=draft_config),
             PLUGIN_OPTIONS_TIMEOUT_SECONDS,
@@ -528,7 +585,7 @@ async def get_plugin_options_endpoint(plugin_id: str, options_id: str, body: Plu
         logger.warning("Options provider '%s' timed out for plugin '%s'", options_id, plugin_id)
         stale = _stale_options_payload(cache_key, reason=f"Options provider '{options_id}' timed out")
         if stale is not None:
-            return stale
+            return PluginOptionsResponse.model_validate(stale)
         raise HTTPException(
             status_code=504,
             detail=f"Options provider '{options_id}' timed out",
@@ -544,8 +601,10 @@ async def get_plugin_options_endpoint(plugin_id: str, options_id: str, body: Plu
     except OptionsUnavailable as e:
         # Deliberately a 200. "No API key yet" is the *expected* state while
         # the user is still filling the form in; the widget shows the reason
-        # inline next to the field instead of a failed-request toast.
-        return _envelope(error=str(e))
+        # inline next to the field instead of a failed-request toast. This is
+        # the documented no_200_on_failure exception in
+        # tests/conventions_manifest.json.
+        return PluginOptionsResponse.model_validate(_envelope(error=str(e)))
     except Exception as e:
         # The traceback (with the plugin's raw error text) is already in the
         # server log; the client gets a static message so plugin exceptions
@@ -553,7 +612,7 @@ async def get_plugin_options_endpoint(plugin_id: str, options_id: str, body: Plu
         logger.exception("Options provider '%s' failed for plugin '%s'", options_id, plugin_id)
         stale = _stale_options_payload(cache_key, reason="Options provider failed")
         if stale is not None:
-            return stale
+            return PluginOptionsResponse.model_validate(stale)
         raise HTTPException(status_code=502, detail="Options provider failed") from e
 
     options, truncated = _serialise_options(result.options, limit, plugin_id, options_id)
@@ -570,7 +629,7 @@ async def get_plugin_options_endpoint(plugin_id: str, options_id: str, body: Plu
     if cache_seconds > 0:
         _plugin_options_cache_put(cache_key, payload)
 
-    return payload
+    return PluginOptionsResponse.model_validate(payload)
 
 
 # ── Plugin Demo Pages ────────────────────────────────────────────────────────
@@ -584,8 +643,6 @@ def _resolve_demo_device_type(demo: dict) -> str:
     any device_type the plugin supports, then to "flagship" as a last
     resort. See issue #942.
     """
-    from src.api_server import get_settings_service  # patched-in-tests seam — see module docstring
-
     configured: list[str] = []
     try:
         board_settings = get_settings_service().get_board_settings()
@@ -604,15 +661,14 @@ def _resolve_demo_device_type(demo: dict) -> str:
     return "flagship"
 
 
-@router.get("/plugins/{plugin_id}/demo-page")
-async def get_plugin_demo_page(plugin_id: str, device_type: str = "flagship"):
-    """
-    Check whether a demo page exists for this plugin and device type.
-
-    Returns ``exists: true`` and the page id when one is found.
-    """
+@router.get(
+    "/plugins/{plugin_id}/demo-page",
+    response_model=PluginDemoPageResponse,
+    responses=errors(404, 503),
+)
+async def get_plugin_demo_page(plugin_id: str, device_type: str = "flagship") -> PluginDemoPageResponse:
+    """Whether a demo page exists for this plugin and device type."""
     _require_plugin_system()
-    from src.api_server import get_page_service, get_plugin_registry  # patched-in-tests seam
 
     registry = get_plugin_registry()
     manifest = registry.get_manifest(plugin_id)
@@ -620,39 +676,33 @@ async def get_plugin_demo_page(plugin_id: str, device_type: str = "flagship"):
         raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
 
     if manifest.demo is None:
-        return {"exists": False, "page_id": None, "has_demo_template": False}
+        return PluginDemoPageResponse(exists=False, page_id=None, has_demo_template=False)
 
     has_demo_template = device_type in manifest.demo
-    page_service = get_page_service()
-    demo_page = page_service.get_demo_page(plugin_id, device_type=device_type)
-    return {
-        "exists": demo_page is not None,
-        "page_id": demo_page.id if demo_page else None,
-        "has_demo_template": has_demo_template,
-    }
+    demo_page = get_page_service().get_demo_page(plugin_id, device_type=device_type)
+    return PluginDemoPageResponse(
+        exists=demo_page is not None,
+        page_id=demo_page.id if demo_page else None,
+        has_demo_template=has_demo_template,
+    )
 
 
-@router.post("/plugins/{plugin_id}/demo-page")
-async def create_plugin_demo_page(plugin_id: str, device_type: str | None = None):
-    """
-    Create (or recreate) the demo page for a plugin and device type.
+@router.post(
+    "/plugins/{plugin_id}/demo-page",
+    response_model=PluginDemoPageCreateResponse,
+    status_code=201,
+    responses=errors(400, 404, 503),
+)
+async def create_plugin_demo_page(plugin_id: str, device_type: str | None = None) -> PluginDemoPageCreateResponse:
+    """Create (or recreate) the demo page for a plugin and device type.
 
-    When *device_type* is omitted, it is resolved from the configured board
-    settings (the first device type listed under Settings → Hardware), so a
-    Note board does not silently get a Flagship-sized demo page (issue #942).
-    If the plugin does not ship a demo template for the configured device,
-    we fall back to any device type it does support.
-
-    The demo page is a singleton per plugin + device type -- calling this endpoint
-    when a demo page already exists for that device type will delete the old one
-    and create a fresh copy.
+    When *device_type* is omitted it is resolved from the configured board
+    settings, so a Note board does not silently get a Flagship-sized demo page
+    (issue #942). The demo page is a singleton per plugin + device type: a
+    second call deletes the old one and creates a fresh copy, which is what
+    ``recreated`` reports.
     """
     _require_plugin_system()
-    from src.api_server import (  # patched-in-tests seam — see module docstring
-        get_config_manager,
-        get_page_service,
-        get_plugin_registry,
-    )
 
     registry = get_plugin_registry()
     manifest = registry.get_manifest(plugin_id)
@@ -674,12 +724,9 @@ async def create_plugin_demo_page(plugin_id: str, device_type: str | None = None
             detail=f"Plugin '{plugin_id}' has no demo template for device type '{resolved_device_type}'.",
         )
 
-    # Check that required settings are configured
-    settings_schema = manifest.settings_schema
-    required_fields = settings_schema.get("required", [])
+    required_fields = manifest.settings_schema.get("required", [])
     if required_fields:
-        config_manager = get_config_manager()
-        plugin_config = config_manager.get_plugin_config(plugin_id) or {}
+        plugin_config = get_config_manager().get_plugin_config(plugin_id) or {}
         missing = [f for f in required_fields if f != "enabled" and not plugin_config.get(f)]
         if missing:
             raise HTTPException(
@@ -688,116 +735,88 @@ async def create_plugin_demo_page(plugin_id: str, device_type: str | None = None
                 f"Configure them first before creating a demo page.",
             )
 
-    page_service = get_page_service()
-    page, recreated = page_service.create_demo_page(plugin_id, demo_schema)
-
-    return {
-        "status": "recreated" if recreated else "created",
-        "page": page.model_dump(),
-    }
+    page, recreated = get_page_service().create_demo_page(plugin_id, demo_schema)
+    return PluginDemoPageCreateResponse(recreated=recreated, page=page.model_dump())
 
 
 # ── Plugin Instances ────────────────────────────────────────────────────────
 
 
-class PluginInstanceCreateRequest(BaseModel):
-    """Request body for creating a new plugin instance."""
-
-    label: str
-
-
-@router.get("/plugins/{plugin_id}/instances")
-async def list_plugin_instances(plugin_id: str):
-    """
-    List all instances of a plugin.
-
-    Returns the instances (excluding the base) for the given plugin.
-    """
+@router.get(
+    "/plugins/{plugin_id}/instances",
+    response_model=PluginInstancesResponse,
+    responses=errors(404, 503),
+)
+async def list_plugin_instances(plugin_id: str) -> PluginInstancesResponse:
+    """List all instances of a plugin (excluding the base)."""
     _require_plugin_system()
-    from src.api_server import get_plugin_registry  # patched-in-tests seam — see module docstring
 
     registry = get_plugin_registry()
-
-    # Resolve base plugin id (strip instance label if present)
     base_id, _ = registry.parse_instance_key(plugin_id)
 
     if not registry.get_plugin(base_id):
         raise HTTPException(status_code=404, detail=f"Plugin not found: {base_id}")
 
     instances = registry.list_instances(base_id)
-
-    return {
-        "plugin_id": base_id,
-        "instances": instances,
-        "total": len(instances),
-    }
+    return PluginInstancesResponse(plugin_id=base_id, instances=instances, total=len(instances))
 
 
-@router.post("/plugins/{plugin_id}/instances")
-async def create_plugin_instance(plugin_id: str, request: PluginInstanceCreateRequest):
-    """
-    Create a new instance of a plugin.
+@router.post(
+    "/plugins/{plugin_id}/instances",
+    response_model=PluginInstanceResponse,
+    status_code=201,
+    responses=errors(400, 404, 503),
+)
+@plugin_errors_to_http
+async def create_plugin_instance(plugin_id: str, request: PluginInstanceCreateRequest) -> PluginInstanceResponse:
+    """Create a new instance of a plugin.
 
-    The new instance starts disabled with an empty configuration.
-    It can be configured and enabled independently via the standard
-    plugin config/enable endpoints using the compound key
-    ``{plugin_id}:{label}``.
+    The new instance starts disabled with an empty configuration and is
+    configured and enabled independently through the standard endpoints using
+    the compound key ``{plugin_id}:{label}``.
     """
     _require_plugin_system()
-    from src.api_server import get_plugin_registry  # patched-in-tests seam — see module docstring
 
-    service = _plugin_service()
-    base_id, compound_key = service.create_instance(plugin_id, request.label)
+    base_id, compound_key = _plugin_service().create_instance(plugin_id, request.label)
 
     # Report the normalized label — that is the instance the registry holds and
     # the one `{{plugin:label.field}}` template references must use.
     _, instance_label = get_plugin_registry().parse_instance_key(compound_key)
 
-    return {
-        "status": "success",
-        "plugin_id": base_id,
-        "instance_label": instance_label,
-        "instance_key": compound_key,
-        "message": f"Instance '{instance_label}' created for plugin '{base_id}'.",
-    }
+    return PluginInstanceResponse(plugin_id=base_id, instance_label=instance_label, instance_key=compound_key)
 
 
-@router.delete("/plugins/{plugin_id}/instances/{instance_label}")
-async def delete_plugin_instance(plugin_id: str, instance_label: str):
-    """
-    Delete a plugin instance.
-
-    Removes the instance from the registry and its persisted configuration.
-    """
+@router.delete(
+    "/plugins/{plugin_id}/instances/{instance_label}",
+    response_model=PluginInstanceResponse,
+    responses=errors(400, 404, 503),
+)
+@plugin_errors_to_http
+async def delete_plugin_instance(plugin_id: str, instance_label: str) -> PluginInstanceResponse:
+    """Remove an instance from the registry and delete its persisted config."""
     _require_plugin_system()
 
     base_id, compound_key = _plugin_service().delete_instance(plugin_id, instance_label)
-
-    return {
-        "status": "success",
-        "plugin_id": base_id,
-        "instance_label": instance_label,
-        "instance_key": compound_key,
-        "message": f"Instance '{instance_label}' of plugin '{base_id}' deleted.",
-    }
+    return PluginInstanceResponse(plugin_id=base_id, instance_label=instance_label, instance_key=compound_key)
 
 
-@router.post("/plugins/{plugin_id}/receive")
-async def receive_plugin_payload(plugin_id: str, request: Request):
-    """
-    Push a JSON payload to a plugin.
+# ── Webhooks ────────────────────────────────────────────────────────────────
 
-    Allows external systems (CI pipelines, automations, etc.) to push data to
-    plugins that support incoming webhooks.  The plugin's ``receive_payload``
-    method is called with the parsed body, the raw request headers, and the
-    raw body bytes (for HMAC verification).
 
-    Returns 404 when the plugin is not found, 400 when it is not enabled or
-    the body is not valid JSON, 403 when the plugin rejects the request due to
-    a signature mismatch, and 405 when the plugin does not support receive.
+@router.post(
+    "/plugins/{plugin_id}/receive",
+    response_model=PluginReceiveResponse,
+    responses=errors(400, 403, 404, 405, 503),
+)
+async def receive_plugin_payload(plugin_id: str, request: Request) -> PluginReceiveResponse:
+    """Push a JSON payload to a plugin.
+
+    Lets external systems (CI pipelines, automations) push data to plugins
+    that support incoming webhooks. The plugin's ``receive_payload`` is called
+    with the parsed body, the raw headers, and the raw bytes for HMAC
+    verification.
     """
     _require_plugin_system()
-    from src.api_server import get_plugin_registry  # patched-in-tests seam — see module docstring
 
     registry = get_plugin_registry()
     plugin = registry.get_plugin(plugin_id)
@@ -826,24 +845,21 @@ async def receive_plugin_payload(plugin_id: str, request: Request):
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    return {"status": "ok"}
+    return PluginReceiveResponse(plugin_id=plugin_id)
 
 
 # ── External Plugin Management ──────────────────────────────────────────────
 
 
-class ExternalPluginInstallRequest(BaseModel):
-    """Request body for installing an external plugin."""
-
-    repository: str
-    plugin_id: str | None = None
-    branch: str = ""
-
-
-@router.post("/plugins/registry/{plugin_id}/install")
-async def install_registry_plugin(plugin_id: str):
-    """
-    Install a plugin from the curated registry by its id.
+@router.post(
+    "/plugins/registry/{plugin_id}/install",
+    response_model=PluginInstallResponse,
+    status_code=201,
+    responses=errors(400, 503),
+)
+@plugin_errors_to_http
+async def install_registry_plugin(plugin_id: str) -> PluginInstallResponse:
+    """Install a plugin from the curated registry by its id.
 
     The install shells out to ``git`` (up to 120 s) and then imports the
     plugin package, so it runs in a worker thread — inline it would seize the
@@ -852,24 +868,23 @@ async def install_registry_plugin(plugin_id: str):
     _require_plugin_system()
 
     await _plugin_service().install_from_registry(plugin_id)
-
-    return {
-        "status": "success",
-        "plugin_id": plugin_id,
-        "message": f"Plugin '{plugin_id}' installed from registry.",
-    }
+    return PluginInstallResponse(plugin_id=plugin_id, message=f"Plugin '{plugin_id}' installed from registry.")
 
 
-@router.post("/plugins/install")
-async def install_external_plugin(request: ExternalPluginInstallRequest):
-    """
-    Install a plugin from a public git repository URL.
+@router.post(
+    "/plugins/install",
+    response_model=PluginInstallResponse,
+    status_code=201,
+    responses=errors(400, 503),
+)
+@plugin_errors_to_http
+async def install_external_plugin(request: ExternalPluginInstallRequest) -> PluginInstallResponse:
+    """Install a plugin from a public git repository URL.
 
-    The repository does not need to follow the ``fiestaboard-plugin--``
-    naming convention (that requirement only applies to registry plugins).
-
-    The clone runs in a worker thread so a slow or unreachable remote cannot
-    block the event loop (#1750).
+    The repository does not need to follow the ``fiestaboard-plugin--`` naming
+    convention (that only applies to registry plugins). The clone runs in a
+    worker thread so a slow or unreachable remote cannot block the event loop
+    (#1750).
     """
     _require_plugin_system()
 
@@ -878,81 +893,73 @@ async def install_external_plugin(request: ExternalPluginInstallRequest):
         plugin_id=request.plugin_id,
         branch=request.branch,
     )
-
-    return {
-        "status": "success",
-        "plugin_id": pid,
-        "message": f"Plugin '{pid}' installed from {request.repository}.",
-    }
+    return PluginInstallResponse(plugin_id=pid, message=f"Plugin '{pid}' installed from {request.repository}.")
 
 
-@router.delete("/plugins/{plugin_id}/uninstall")
-async def uninstall_external_plugin(plugin_id: str):
-    """
-    Uninstall an external (non-built-in) plugin.
-
-    Built-in plugins shipped with FiestaBoard cannot be uninstalled.
-    """
+@router.delete(
+    "/plugins/{plugin_id}/uninstall",
+    response_model=PluginUninstallResponse,
+    responses=errors(400, 404, 503),
+)
+@plugin_errors_to_http
+async def uninstall_external_plugin(plugin_id: str) -> PluginUninstallResponse:
+    """Uninstall an external plugin. Built-ins cannot be uninstalled."""
     _require_plugin_system()
 
     _plugin_service().uninstall(plugin_id)
-
-    return {
-        "status": "success",
-        "plugin_id": plugin_id,
-        "message": f"Plugin '{plugin_id}' has been uninstalled.",
-    }
+    return PluginUninstallResponse(plugin_id=plugin_id, message=f"Plugin '{plugin_id}' has been uninstalled.")
 
 
-@router.post("/plugins/updates/check")
-async def trigger_plugin_update_check():
-    """
-    Trigger an immediate update check for all external plugins.
+@router.post(
+    "/plugins/updates/check",
+    response_model=PluginUpdateCheckResponse,
+    responses=errors(503),
+)
+async def trigger_plugin_update_check() -> PluginUpdateCheckResponse:
+    """Trigger an immediate update check for all external plugins.
 
-    Runs ``git ls-remote`` against each external plugin's origin in a thread
-    pool so the event loop is not blocked.
+    Runs ``git ls-remote`` against each external plugin's origin on a worker
+    thread so the event loop is not blocked.
     """
     _require_plugin_system()
-    from src.api_server import get_plugin_registry  # patched-in-tests seam — see module docstring
 
     registry = get_plugin_registry()
-    loop = asyncio.get_event_loop()
-    results = await loop.run_in_executor(None, registry.check_for_updates)
-    plugins_with_updates = [pid for pid, has_update in results.items() if has_update]
-    return {
-        "checked": len(results),
-        "updates_available": plugins_with_updates,
-    }
+    results = await asyncio.to_thread(registry.check_for_updates)
+    return PluginUpdateCheckResponse(
+        checked=len(results),
+        updates_available=[pid for pid, has_update in results.items() if has_update],
+    )
 
 
-@router.post("/plugins/{plugin_id}/update")
-async def update_plugin(plugin_id: str):
-    """
-    Fetch the latest commits for an external plugin from its remote and reload it.
-
-    Built-in plugins cannot be updated via this endpoint.
-    """
+@router.post(
+    "/plugins/{plugin_id}/update",
+    response_model=PluginUpdateResponse,
+    responses=errors(400, 404, 503),
+)
+@plugin_errors_to_http
+async def update_plugin(plugin_id: str) -> PluginUpdateResponse:
+    """Fetch the latest commits for an external plugin and reload it."""
     _require_plugin_system()
 
     await _plugin_service().apply_update(plugin_id)
-
-    return {
-        "status": "success",
-        "plugin_id": plugin_id,
-        "message": f"Plugin '{plugin_id}' has been updated and reloaded.",
-    }
+    return PluginUpdateResponse(plugin_id=plugin_id, message=f"Plugin '{plugin_id}' has been updated and reloaded.")
 
 
-@router.post("/plugins/updates/apply")
-async def apply_all_plugin_updates():
-    """
-    Fetch and reload all external plugins that have a pending update.
+@router.post(
+    "/plugins/updates/apply",
+    response_model=PluginUpdatesApplyResponse,
+    responses=errors(503),
+)
+@plugin_errors_to_http
+async def apply_all_plugin_updates() -> PluginUpdatesApplyResponse:
+    """Fetch and reload every external plugin with a pending update.
 
     Uses the cached update status from the last check — call
-    ``POST /plugins/updates/check`` first if you want a fresh scan before
-    applying.  Returns 200 even when some plugins fail so the caller can
-    inspect partial results.
+    ``POST /plugins/updates/check`` first for a fresh scan. Deliberately
+    answers 200 with partial results when some plugins fail: collapsing an
+    N-plugin bulk update into one status code would throw away which
+    succeeded.
     """
     _require_plugin_system()
 
-    return await _plugin_service().apply_all_updates()
+    return PluginUpdatesApplyResponse.model_validate(await _plugin_service().apply_all_updates())

--- a/src/plugins/service.py
+++ b/src/plugins/service.py
@@ -21,10 +21,13 @@ Collaborators resolve in one of two ways:
   ``src.plugins.get_plugin_registry`` / ``src.config_manager
   .get_config_manager`` used by the MCP suite stay live.
 
-Error contract: methods raise :class:`fastapi.HTTPException` with exactly the
-status codes and details the REST handlers used to raise inline, so both the
-HTTP layer (which lets them propagate) and the MCP layer (which catches them
-and formats ``exc.detail``) keep their observable behavior.
+Error contract: methods raise the domain exceptions in
+:mod:`src.plugins.errors` and know nothing about HTTP. Phase 1 had this
+service raising a FastAPI transport exception at 25 sites — the one service in
+the tree that knew a status code, and the layering violation the 2026-09 audit
+called out. The REST router owns the mapping now
+(``src/plugins/routes.py::_STATUS_BY_ERROR``); the MCP/ops layer catches the
+same exceptions and renders its own envelope without going near a status code.
 """
 
 from __future__ import annotations
@@ -36,9 +39,14 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from fastapi import HTTPException
-
 from src.config_manager import unmask_sensitive_values
+
+from .errors import (
+    PluginConfigInvalid,
+    PluginNotFound,
+    PluginOperationFailed,
+    PluginOperationRejected,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -54,12 +62,9 @@ def sanitize_optional_plugin_id(plugin_id: str | None) -> str | None:
     if plugin_id is None:
         return None
     if not isinstance(plugin_id, str) or not plugin_id:
-        raise HTTPException(status_code=400, detail="plugin_id must be a non-empty string")
+        raise PluginOperationRejected("plugin_id must be a non-empty string")
     if not _PLUGIN_ID_RE.fullmatch(plugin_id):
-        raise HTTPException(
-            status_code=400,
-            detail="plugin_id may contain only lowercase letters, digits, and underscores",
-        )
+        raise PluginOperationRejected("plugin_id may contain only lowercase letters, digits, and underscores")
     return plugin_id
 
 
@@ -147,7 +152,7 @@ class PluginService:
         """
         registry = self.registry
         if not registry.get_plugin(plugin_id):
-            raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
+            raise PluginNotFound(f"Plugin not found: {plugin_id}")
 
         # Resolve the "***" placeholders before anything sees the payload.
         # Config goes out masked, so any client that echoes back what it read
@@ -168,7 +173,7 @@ class PluginService:
         errors = registry.set_plugin_config(plugin_id, config)
         if errors:
             logger.error(f"Plugin '{plugin_id}' config validation failed: {errors}")
-            raise HTTPException(status_code=400, detail={"errors": errors})
+            raise PluginConfigInvalid(f"Configuration for '{plugin_id}' failed validation.", errors)
 
         # Save to config file
         config_manager.set_plugin_config(plugin_id, config)
@@ -201,10 +206,10 @@ class PluginService:
         """Enable a plugin in the registry and persist the flag to config."""
         registry = self.registry
         if not registry.get_plugin(plugin_id):
-            raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
+            raise PluginNotFound(f"Plugin not found: {plugin_id}")
 
         if not registry.enable_plugin(plugin_id):
-            raise HTTPException(status_code=400, detail=f"Failed to enable plugin: {plugin_id}")
+            raise PluginOperationRejected(f"Failed to enable plugin: {plugin_id}")
 
         self.config_manager.enable_plugin(plugin_id)
         self.reset_runtime()
@@ -215,10 +220,10 @@ class PluginService:
         """Disable a plugin in the registry and persist the flag to config."""
         registry = self.registry
         if not registry.get_plugin(plugin_id):
-            raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
+            raise PluginNotFound(f"Plugin not found: {plugin_id}")
 
         if not registry.disable_plugin(plugin_id):
-            raise HTTPException(status_code=400, detail=f"Failed to disable plugin: {plugin_id}")
+            raise PluginOperationRejected(f"Failed to disable plugin: {plugin_id}")
 
         self.config_manager.disable_plugin(plugin_id)
         self.reset_runtime()
@@ -240,11 +245,11 @@ class PluginService:
         base_id, _ = registry.parse_instance_key(plugin_id)
 
         if not registry.get_plugin(base_id):
-            raise HTTPException(status_code=404, detail=f"Plugin not found: {base_id}")
+            raise PluginNotFound(f"Plugin not found: {base_id}")
 
         errors = registry.create_instance(base_id, label)
         if errors:
-            raise HTTPException(status_code=400, detail="; ".join(errors))
+            raise PluginOperationRejected("; ".join(errors))
 
         compound_key = registry.make_instance_key(base_id, label)
 
@@ -290,7 +295,7 @@ class PluginService:
 
         errors = registry.delete_instance(base_id, instance_label)
         if errors:
-            raise HTTPException(status_code=400, detail="; ".join(errors))
+            raise PluginOperationRejected("; ".join(errors))
 
         compound_key = registry.make_instance_key(base_id, instance_label)
 
@@ -318,7 +323,7 @@ class PluginService:
         registry = self.registry
         errors = await asyncio.to_thread(registry.install_from_registry, plugin_id)
         if errors:
-            raise HTTPException(status_code=400, detail="; ".join(errors))
+            raise PluginOperationRejected("; ".join(errors))
 
     async def install_from_git(self, repository: str, plugin_id: str | None = None, branch: str = "") -> str:
         """Install a plugin from a public git repository URL; returns its id.
@@ -332,7 +337,7 @@ class PluginService:
 
             _ok, _err = _validate_git_ref(safe_branch)
             if not _ok:
-                raise HTTPException(status_code=400, detail=_err)
+                raise PluginOperationRejected(_err)
 
         safe_plugin_id = sanitize_optional_plugin_id(plugin_id)
 
@@ -344,7 +349,7 @@ class PluginService:
             branch=safe_branch,
         )
         if errors:
-            raise HTTPException(status_code=400, detail="; ".join(errors))
+            raise PluginOperationRejected("; ".join(errors))
 
         # Derive the final plugin id
         pid = safe_plugin_id
@@ -365,7 +370,7 @@ class PluginService:
 
         errors = registry.uninstall_external_plugin(plugin_id)
         if errors:
-            raise HTTPException(status_code=400, detail="; ".join(errors))
+            raise PluginOperationRejected("; ".join(errors))
 
         # Purge persisted configs for both the base plugin and every named
         # instance. The base-id delete is critical: without it the v2→v3
@@ -379,9 +384,10 @@ class PluginService:
     def _validated_update_path(self, plugin_id: str) -> None:
         """Guard an external plugin's local path before letting it near git.
 
-        404 when the plugin has no source at all; 400 for built-ins, missing
-        paths, paths outside the external plugins directory, and non-repos —
-        exactly the checks the REST handler applied inline.
+        :class:`PluginNotFound` when the plugin has no source at all;
+        :class:`PluginOperationRejected` for built-ins, missing paths, paths
+        outside the external plugins directory, and non-repos — exactly the
+        checks the REST handler applied inline, minus the status codes.
         """
         import os as _os
 
@@ -390,19 +396,13 @@ class PluginService:
         source = self.registry.get_plugin_source(plugin_id)
 
         if source is None:
-            raise HTTPException(status_code=404, detail=f"Plugin '{plugin_id}' not found.")
+            raise PluginNotFound(f"Plugin '{plugin_id}' not found.")
 
         if source.source_type == "builtin":
-            raise HTTPException(
-                status_code=400,
-                detail=f"Plugin '{plugin_id}' is a built-in plugin and cannot be updated this way.",
-            )
+            raise PluginOperationRejected(f"Plugin '{plugin_id}' is a built-in plugin and cannot be updated this way.")
 
         if not source.local_path:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Plugin '{plugin_id}' has no local path for updating.",
-            )
+            raise PluginOperationRejected(f"Plugin '{plugin_id}' has no local path for updating.")
 
         # Verify the plugin's local_path is within the external plugins
         # directory before updating, as a defence-in-depth check.
@@ -411,15 +411,12 @@ class PluginService:
         try:
             _common = _os.path.commonpath([_ext_root, _real_local])
         except ValueError:
-            raise HTTPException(status_code=400, detail="Invalid plugin path.") from None
+            raise PluginOperationRejected("Invalid plugin path.") from None
         if _common != _ext_root or _real_local == _ext_root:
-            raise HTTPException(status_code=400, detail="Invalid plugin path.")
+            raise PluginOperationRejected("Invalid plugin path.")
 
         if not (_real_local and (Path(_real_local) / ".git").is_dir()):
-            raise HTTPException(
-                status_code=400,
-                detail=f"Plugin '{plugin_id}' is not a git repository.",
-            )
+            raise PluginOperationRejected(f"Plugin '{plugin_id}' is not a git repository.")
 
     async def apply_update(self, plugin_id: str) -> None:
         """Fetch the latest commits for an external plugin and reload it."""
@@ -435,13 +432,13 @@ class PluginService:
         # update (#1750).
         ok, err = await asyncio.to_thread(clone_or_update_repo, "", plugin_id, external_dir=get_external_plugins_dir())
         if not ok:
-            raise HTTPException(status_code=500, detail=f"Update failed: {err}")
+            raise PluginOperationFailed(f"Update failed: {err}")
 
         reloaded = await asyncio.to_thread(registry.reload_plugin, plugin_id)
         if reloaded is None:
             errors = registry.get_load_errors().get(plugin_id, [])
             detail = "; ".join(errors) if errors else "Plugin failed to reload after update."
-            raise HTTPException(status_code=500, detail=detail)
+            raise PluginOperationFailed(detail)
 
         self.clear_update_status(plugin_id)
 

--- a/tests/conventions_manifest.json
+++ b/tests/conventions_manifest.json
@@ -4,6 +4,7 @@
     "ai",
     "collections",
     "pages",
+    "plugins",
     "schedules",
     "system"
   ],
@@ -22,6 +23,31 @@
       "route": "GET /pages/cache/stats",
       "rule": "declared_errors",
       "reason": "Reports in-memory preview-cache occupancy, which always exists — an empty cache is a valid answer, not an error. Nothing it reads can be missing or unauthorized at the route level."
+    },
+    {
+      "route": "GET /plugins",
+      "rule": "declared_errors",
+      "reason": "The only failure path is the 503 raised by _require_plugin_system() when the plugin package did not import — a dependency outage, not a client error. It is declared in responses=; there is no 4xx to declare because no request to this route can be wrong."
+    },
+    {
+      "route": "GET /plugins/errors",
+      "rule": "declared_errors",
+      "reason": "The endpoint whose job is to report failures cannot itself fail: with the plugin system down it answers plugin_system_enabled=false and empty maps, which is the correct answer, not an error."
+    },
+    {
+      "route": "GET /plugins/registry",
+      "rule": "declared_errors",
+      "reason": "The only failure path is the 503 raised by _require_plugin_system() when the plugin package did not import — a dependency outage, not a client error. It is declared in responses=; there is no 4xx to declare because no request to this route can be wrong."
+    },
+    {
+      "route": "GET /plugins/updates",
+      "rule": "declared_errors",
+      "reason": "The only failure path is the 503 raised by _require_plugin_system() when the plugin package did not import — a dependency outage, not a client error. It is declared in responses=; there is no 4xx to declare because no request to this route can be wrong."
+    },
+    {
+      "route": "GET /plugins/variables/all",
+      "rule": "declared_errors",
+      "reason": "Has no failure path at all: with the plugin system down it falls back to the template engine's own variables rather than erroring, because the template editor still has a vocabulary without plugins."
     },
     {
       "route": "GET /schedules",
@@ -62,6 +88,21 @@
       "route": "GET /version",
       "rule": "declared_errors",
       "reason": "Read-only report with no failure path: it cannot 404, 400 or 409, so declaring a 4xx would document an error the endpoint never raises. It reads two env vars and one /proc file, and reports None when the file is absent."
+    },
+    {
+      "route": "POST /plugins/updates/apply",
+      "rule": "declared_errors",
+      "reason": "Same 503-only shape as its siblings, plus a deliberate partial-success contract: a bulk update of N plugins reports per-plugin outcomes in `failed` at 200, because collapsing them into one status code would throw away which plugin failed and why."
+    },
+    {
+      "route": "POST /plugins/updates/check",
+      "rule": "declared_errors",
+      "reason": "The only failure path is the 503 raised by _require_plugin_system() when the plugin package did not import — a dependency outage, not a client error. It is declared in responses=; there is no 4xx to declare because no request to this route can be wrong."
+    },
+    {
+      "route": "POST /plugins/{plugin_id}/options/{options_id}",
+      "rule": "no_200_on_failure",
+      "reason": "Three returns inside except blocks, all deliberate. Two serve the last good options with stale=true when the provider times out or throws, so a settings form mid-edit keeps its picker instead of blanking. The third turns OptionsUnavailable (\"no API key yet\") into a 200 with an error hint, because that is the expected state while the user is still filling in the very field the credential goes in — a 4xx there would surface a failed-request toast for a form that is simply incomplete."
     },
     {
       "route": "POST /schedules/validate",

--- a/tests/golden/responses/plugins.json
+++ b/tests/golden/responses/plugins.json
@@ -20,7 +20,9 @@
         "plugin_system_enabled": "bool",
         "plugins": [
           {
+            "author": "str",
             "base_plugin_id": "null",
+            "category": "null",
             "config": {
               "api_key": "str",
               "enabled": "bool",
@@ -29,20 +31,38 @@
             "configured": "bool",
             "description": "str",
             "enabled": "bool",
+            "fiestaboard_version": "str",
+            "icon": "null",
             "id": "str",
             "instance_label": "null",
             "name": "str",
+            "plugin_type": "str",
+            "settings_schema": {},
+            "source": "null",
+            "supports_triggers": "bool",
+            "update_available": "bool",
+            "update_blocked_reason": "str",
             "version": "str"
           },
           {
+            "author": "str",
             "base_plugin_id": "null",
+            "category": "null",
             "config": {},
             "configured": "bool",
             "description": "str",
             "enabled": "bool",
+            "fiestaboard_version": "str",
+            "icon": "null",
             "id": "str",
             "instance_label": "null",
             "name": "str",
+            "plugin_type": "str",
+            "settings_schema": {},
+            "source": "null",
+            "supports_triggers": "bool",
+            "update_available": "bool",
+            "update_blocked_reason": "str",
             "version": "str"
           }
         ],
@@ -82,6 +102,13 @@
             "str"
           ]
         },
+        "fetch_breakers": {
+          "slow_plugin": {
+            "consecutive_timeouts": "int",
+            "cooldown_remaining_seconds": "float",
+            "quarantined": "bool"
+          }
+        },
         "plugin_system_enabled": "bool"
       }
     },
@@ -93,10 +120,19 @@
       "shape": {
         "entries": [
           {
+            "author": "str",
+            "branch": "str",
+            "category": "str",
+            "description": "str",
+            "fiestaboard_version": "str",
+            "icon": "str",
             "id": "str",
             "installed": "bool",
             "name": "str",
-            "repository": "str"
+            "plugin_type": "str",
+            "previews": [],
+            "repository": "str",
+            "teaser": "str"
           }
         ],
         "plugin_system_enabled": "bool"
@@ -143,6 +179,8 @@
         "instances": [
           {
             "enabled": "bool",
+            "has_config": "bool",
+            "key": "null",
             "label": "str"
           }
         ],
@@ -199,12 +237,16 @@
       "status": 200,
       "shape": {
         "color_rules_schema": {},
+        "max_lengths": {},
+        "name": "null",
+        "settings_schema": {},
         "variables": {
           "value": {
             "description": "str",
             "example": "str"
           }
-        }
+        },
+        "version": "null"
       }
     },
     {
@@ -227,8 +269,7 @@
           "location": "str",
           "refresh_seconds": "int"
         },
-        "plugin_id": "str",
-        "status": "str"
+        "plugin_id": "str"
       }
     },
     {
@@ -240,7 +281,8 @@
         "detail": {
           "errors": [
             "str"
-          ]
+          ],
+          "message": "str"
         }
       }
     },
@@ -260,8 +302,7 @@
       "status": 200,
       "shape": {
         "enabled": "bool",
-        "plugin_id": "str",
-        "status": "str"
+        "plugin_id": "str"
       }
     },
     {
@@ -289,8 +330,7 @@
       "status": 200,
       "shape": {
         "enabled": "bool",
-        "plugin_id": "str",
-        "status": "str"
+        "plugin_id": "str"
       }
     },
     {
@@ -410,14 +450,14 @@
       "label": "demo_create",
       "method": "POST",
       "path_template": "/plugins/{plugin_id}/demo-page",
-      "status": 200,
+      "status": 201,
       "shape": {
         "page": {
           "id": "str",
           "name": "str",
           "type": "str"
         },
-        "status": "str"
+        "recreated": "bool"
       }
     },
     {
@@ -438,6 +478,8 @@
         "instances": [
           {
             "enabled": "bool",
+            "has_config": "bool",
+            "key": "null",
             "label": "str"
           }
         ],
@@ -449,13 +491,11 @@
       "label": "instance_create",
       "method": "POST",
       "path_template": "/plugins/{plugin_id}/instances",
-      "status": 200,
+      "status": 201,
       "shape": {
         "instance_key": "str",
         "instance_label": "str",
-        "message": "str",
-        "plugin_id": "str",
-        "status": "str"
+        "plugin_id": "str"
       }
     },
     {
@@ -475,9 +515,7 @@
       "shape": {
         "instance_key": "str",
         "instance_label": "str",
-        "message": "str",
-        "plugin_id": "str",
-        "status": "str"
+        "plugin_id": "str"
       }
     },
     {
@@ -486,6 +524,7 @@
       "path_template": "/plugins/{plugin_id}/receive",
       "status": 200,
       "shape": {
+        "plugin_id": "str",
         "status": "str"
       }
     },
@@ -502,11 +541,10 @@
       "label": "registry_install_ok",
       "method": "POST",
       "path_template": "/plugins/registry/{plugin_id}/install",
-      "status": 200,
+      "status": 201,
       "shape": {
         "message": "str",
-        "plugin_id": "str",
-        "status": "str"
+        "plugin_id": "str"
       }
     },
     {
@@ -522,11 +560,10 @@
       "label": "install_git_ok",
       "method": "POST",
       "path_template": "/plugins/install",
-      "status": 200,
+      "status": 201,
       "shape": {
         "message": "str",
-        "plugin_id": "str",
-        "status": "str"
+        "plugin_id": "str"
       }
     },
     {
@@ -545,8 +582,7 @@
       "status": 200,
       "shape": {
         "message": "str",
-        "plugin_id": "str",
-        "status": "str"
+        "plugin_id": "str"
       }
     },
     {

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -1800,26 +1800,31 @@ class TestPluginErrors:
     def test_plugin_errors_system_available(self, client):
         """Plugin errors when system is available."""
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry") as mock_reg,
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry") as mock_reg,
         ):
             registry = Mock()
-            registry.get_load_errors.return_value = {"bad_plugin": "ImportError"}
+            # A list, and a real breaker map: PluginErrorsResponse types both
+            # now, so the bare Mock this used to hand back is rejected.
+            registry.get_load_errors.return_value = {"bad_plugin": ["ImportError"]}
+            registry.get_fetch_breaker_status.return_value = {}
             mock_reg.return_value = registry
             response = client.get("/plugins/errors")
             assert response.status_code == 200
             data = response.json()
             assert data["plugin_system_enabled"] is True
-            assert "bad_plugin" in data["errors"]
+            assert data["errors"] == {"bad_plugin": ["ImportError"]}
+            assert data["fetch_breakers"] == {}
 
     def test_plugin_errors_system_unavailable(self, client):
         """Plugin errors when system is unavailable."""
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False):
+        with patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", False):
             response = client.get("/plugins/errors")
             assert response.status_code == 200
             data = response.json()
             assert data["plugin_system_enabled"] is False
             assert data["errors"] == {}
+            assert data["fetch_breakers"] == {}
 
 
 class TestPluginRegistry:
@@ -1828,8 +1833,8 @@ class TestPluginRegistry:
     def test_registry_list(self, client):
         """List registry plugins."""
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry") as mock_reg,
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry") as mock_reg,
         ):
             registry = Mock()
             registry.get_registry_entries.return_value = [{"id": "weather", "name": "Weather", "installed": True}]
@@ -1840,7 +1845,7 @@ class TestPluginRegistry:
 
     def test_registry_unavailable(self, client):
         """Plugin system unavailable → 503."""
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False):
+        with patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", False):
             response = client.get("/plugins/registry")
             assert response.status_code == 503
 
@@ -1851,8 +1856,8 @@ class TestPluginUpdates:
     def test_get_updates(self, client):
         """Get cached update status."""
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry") as mock_reg,
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry") as mock_reg,
         ):
             registry = Mock()
             registry.get_update_status.return_value = {"my_plugin": True}
@@ -1865,8 +1870,8 @@ class TestPluginUpdates:
     def test_get_updates_includes_blocked_reasons(self, client):
         """Held-back updates are reported with the reason they were held back."""
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry") as mock_reg,
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry") as mock_reg,
         ):
             registry = Mock()
             registry.get_update_status.return_value = {"my_plugin": False}
@@ -1878,7 +1883,7 @@ class TestPluginUpdates:
 
     def test_get_updates_unavailable(self, client):
         """Plugin system unavailable → 503."""
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False):
+        with patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", False):
             response = client.get("/plugins/updates")
             assert response.status_code == 503
 
@@ -1889,8 +1894,8 @@ class TestTriggerPluginUpdateCheck:
     def test_trigger_check(self, client):
         """Trigger update check."""
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry") as mock_reg,
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry") as mock_reg,
         ):
             registry = Mock()
             registry.check_for_updates.return_value = {"plugin_a": True, "plugin_b": False}
@@ -1904,7 +1909,7 @@ class TestTriggerPluginUpdateCheck:
 
     def test_trigger_check_unavailable(self, client):
         """Plugin system unavailable → 503."""
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False):
+        with patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", False):
             response = client.post("/plugins/updates/check")
             assert response.status_code == 503
 

--- a/tests/test_api_coverage_extended.py
+++ b/tests/test_api_coverage_extended.py
@@ -467,8 +467,8 @@ class TestPluginData:
         mock_registry.is_enabled.return_value = True
         mock_registry.fetch_plugin_data.return_value = mock_result
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
         ):
             resp = client.get("/plugins/test_plugin/data")
         assert resp.status_code == 200
@@ -483,8 +483,8 @@ class TestPluginData:
         mock_registry.is_enabled.return_value = True
         mock_registry.fetch_plugin_data.return_value = mock_result
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
         ):
             resp = client.get("/plugins/test_plugin/data")
         assert resp.status_code == 503
@@ -493,8 +493,8 @@ class TestPluginData:
         mock_registry = Mock()
         mock_registry.get_plugin.return_value = None
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
         ):
             resp = client.get("/plugins/nonexistent/data")
         assert resp.status_code == 404
@@ -504,14 +504,14 @@ class TestPluginData:
         mock_registry.get_plugin.return_value = Mock()
         mock_registry.is_enabled.return_value = False
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
         ):
             resp = client.get("/plugins/test_plugin/data")
         assert resp.status_code == 400
 
     def test_get_plugin_data_system_unavailable(self, client):
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False):
+        with patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", False):
             resp = client.get("/plugins/test_plugin/data")
         assert resp.status_code == 503
 
@@ -526,8 +526,8 @@ class TestPluginManagement:
         mock_registry = Mock()
         mock_registry.check_for_updates.return_value = {"plugin_a": True, "plugin_b": False}
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
         ):
             resp = client.post("/plugins/updates/check")
         assert resp.status_code == 200
@@ -535,7 +535,7 @@ class TestPluginManagement:
         assert "plugin_a" in resp.json()["updates_available"]
 
     def test_trigger_update_check_unavailable(self, client):
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False):
+        with patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", False):
             resp = client.post("/plugins/updates/check")
         assert resp.status_code == 503
 
@@ -549,8 +549,8 @@ class TestPluginManagement:
         mock_registry._update_status = {"test_plugin": True}
 
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
             patch("pathlib.Path.is_dir", return_value=True),
             patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")),
             patch("src.plugins.sources.clone_or_update_repo", return_value=(True, None)),
@@ -562,8 +562,8 @@ class TestPluginManagement:
         mock_registry = Mock()
         mock_registry.get_plugin_source.return_value = None
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
         ):
             resp = client.post("/plugins/nonexistent/update")
         assert resp.status_code == 404
@@ -573,8 +573,8 @@ class TestPluginManagement:
         mock_registry = Mock()
         mock_registry.get_plugin_source.return_value = mock_source
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
         ):
             resp = client.post("/plugins/weather/update")
         assert resp.status_code == 400
@@ -595,8 +595,8 @@ class TestPluginManagement:
             return (True, "")
 
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
             patch("pathlib.Path.is_dir", return_value=True),
             patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")),
             patch("src.plugins.sources.clone_or_update_repo", side_effect=capture_clone),
@@ -616,8 +616,8 @@ class TestPluginManagement:
         mock_registry._update_status = {"plugin_a": True}
 
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
             patch("pathlib.Path.is_dir", return_value=True),
             patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")),
             patch("src.plugins.sources.clone_or_update_repo", return_value=(True, "")),
@@ -633,8 +633,8 @@ class TestPluginManagement:
         mock_registry = Mock()
         mock_registry.get_update_status.return_value = {}
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
         ):
             resp = client.post("/plugins/updates/apply")
         assert resp.status_code == 200
@@ -661,8 +661,8 @@ class TestPluginManagement:
             return (True, "")
 
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
             patch("pathlib.Path.is_dir", return_value=True),
             patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")),
             patch("src.plugins.sources.clone_or_update_repo", side_effect=fake_clone),
@@ -674,7 +674,7 @@ class TestPluginManagement:
         assert "bad_plugin" in data["failed"]
 
     def test_apply_all_updates_unavailable(self, client):
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False):
+        with patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", False):
             resp = client.post("/plugins/updates/apply")
         assert resp.status_code == 503
 
@@ -682,28 +682,28 @@ class TestPluginManagement:
         mock_registry = Mock()
         mock_registry.install_from_git.return_value = []
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
             patch("src.plugins.sources.repo_name_from_url", return_value="fiestaboard-plugin-test"),
             patch("src.plugins.sources.plugin_id_from_repo_name", return_value="test"),
         ):
             resp = client.post(
                 "/plugins/install", json={"repository": "https://github.com/example/fiestaboard-plugin-test"}
             )
-        assert resp.status_code == 200
+        assert resp.status_code == 201
 
     def test_install_plugin_errors(self, client):
         mock_registry = Mock()
         mock_registry.install_from_git.return_value = ["Clone failed"]
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
         ):
             resp = client.post("/plugins/install", json={"repository": "https://github.com/example/repo"})
         assert resp.status_code == 400
 
     def test_install_plugin_unavailable(self, client):
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False):
+        with patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", False):
             resp = client.post("/plugins/install", json={"repository": "https://github.com/example/repo"})
         assert resp.status_code == 503
 
@@ -711,8 +711,8 @@ class TestPluginManagement:
         mock_registry = Mock()
         mock_registry.install_from_git.return_value = []
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
             patch("src.plugins.sources.repo_name_from_url", return_value="repo"),
             patch("src.plugins.sources.plugin_id_from_repo_name", return_value="repo"),
         ):
@@ -723,10 +723,10 @@ class TestPluginManagement:
                     "branch": "release/2.0",
                 },
             )
-        assert resp.status_code == 200
+        assert resp.status_code == 201
 
     def test_install_plugin_invalid_branch_rejected(self, client):
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True):
+        with patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True):
             resp = client.post(
                 "/plugins/install",
                 json={
@@ -740,8 +740,8 @@ class TestPluginManagement:
         mock_registry = Mock()
         mock_registry.install_from_git.return_value = ["fatal: repository not found"]
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
         ):
             resp = client.post("/plugins/install", json={"repository": "https://github.com/example/repo"})
         assert resp.status_code == 400
@@ -758,9 +758,9 @@ class TestPluginManagement:
         mock_registry.uninstall_external_plugin.return_value = []
         mock_cm = Mock()
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
         ):
             resp = client.delete("/plugins/muni/uninstall")
         assert resp.status_code == 200
@@ -779,9 +779,9 @@ class TestPluginManagement:
         mock_registry.uninstall_external_plugin.return_value = []
         mock_cm = Mock()
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
         ):
             resp = client.delete("/plugins/weather/uninstall")
         assert resp.status_code == 200
@@ -798,9 +798,9 @@ class TestPluginManagement:
         mock_registry.uninstall_external_plugin.return_value = ["Plugin not found: muni"]
         mock_cm = Mock()
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
         ):
             resp = client.delete("/plugins/muni/uninstall")
         assert resp.status_code == 400
@@ -824,8 +824,8 @@ class TestGenericDataTestFetch:
         mock_cm = Mock()
         mock_cm.get_general.return_value = {"timezone": "UTC"}
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
             patch("src.api_server._get_generic_data_allowed_hosts", return_value=["example.com"]),
             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO),
             patch("requests.request", return_value=mock_resp),
@@ -840,8 +840,8 @@ class TestGenericDataTestFetch:
         mock_cm = Mock()
         mock_cm.get_general.return_value = {}
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
         ):
             resp = client.post("/generic-data/test-fetch", json={"url": ""})
         assert resp.status_code == 400
@@ -850,8 +850,8 @@ class TestGenericDataTestFetch:
         mock_cm = Mock()
         mock_cm.get_general.return_value = {}
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
         ):
             resp = client.post("/generic-data/test-fetch", json={"url": "ftp://bad"})
         assert resp.status_code == 400
@@ -862,8 +862,8 @@ class TestGenericDataTestFetch:
         mock_cm = Mock()
         mock_cm.get_general.return_value = {}
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
             patch("src.api_server._get_generic_data_allowed_hosts", return_value=["example.com"]),
             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO),
             patch("requests.request", side_effect=req.exceptions.Timeout("timeout")),
@@ -877,8 +877,8 @@ class TestGenericDataTestFetch:
         mock_cm = Mock()
         mock_cm.get_general.return_value = {}
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
             patch("src.api_server._get_generic_data_allowed_hosts", return_value=["example.com"]),
             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO),
             patch("requests.request", side_effect=req.exceptions.ConnectionError("conn")),
@@ -893,8 +893,8 @@ class TestGenericDataTestFetch:
         mock_cm = Mock()
         mock_cm.get_general.return_value = {}
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO),
             patch("requests.request", return_value=mock_resp),
         ):
@@ -909,8 +909,8 @@ class TestGenericDataTestFetch:
         mock_cm = Mock()
         mock_cm.get_general.return_value = {}
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
             patch("src.api_server._get_generic_data_allowed_hosts", return_value=["example.com"]),
             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO),
             patch("requests.request", return_value=mock_resp),

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -287,7 +287,10 @@ def mock_template_engine():
 @pytest.fixture
 def mock_plugin_registry():
     """Mock the plugin registry."""
-    with patch("src.api_server.get_plugin_registry") as mock_get, patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True):
+    with (
+        patch("src.plugins.routes.get_plugin_registry") as mock_get,
+        patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+    ):
         reg = Mock()
         reg.list_plugins.return_value = [
             {"id": "weather", "name": "Weather", "enabled": True},
@@ -746,7 +749,7 @@ class TestPluginEndpoints:
         assert data["plugin_system_enabled"] is True
 
     def test_list_plugins_system_unavailable(self, client):
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False):
+        with patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", False):
             response = client.get("/plugins")
         assert response.status_code == 503
 
@@ -772,11 +775,11 @@ class TestPluginEndpoints:
         assert response.status_code == 404
 
     def test_update_plugin_config(self, client, mock_plugin_registry, mock_config_manager):
-        with patch("src.api_server.reset_display_service"), patch("src.api_server.reset_template_engine"):
+        with patch("src.plugins.routes.reset_display_service"), patch("src.plugins.routes.reset_template_engine"):
             response = client.put("/plugins/weather/config", json={"config": {"api_key": "test_key_abc123"}})
         assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "success"
+        assert data["plugin_id"] == "weather"
 
     def test_update_plugin_config_not_found(self, client, mock_plugin_registry, mock_config_manager):
         mock_plugin_registry.get_plugin.return_value = None
@@ -789,12 +792,12 @@ class TestPluginEndpoints:
         assert response.status_code == 400
 
     def test_update_plugin_config_system_unavailable(self, client):
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False):
+        with patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", False):
             response = client.put("/plugins/weather/config", json={"config": {}})
         assert response.status_code == 503
 
     def test_enable_plugin(self, client, mock_plugin_registry, mock_config_manager):
-        with patch("src.api_server.reset_display_service"), patch("src.api_server.reset_template_engine"):
+        with patch("src.plugins.routes.reset_display_service"), patch("src.plugins.routes.reset_template_engine"):
             response = client.post("/plugins/weather/enable")
         assert response.status_code == 200
         assert response.json()["enabled"] is True
@@ -810,7 +813,7 @@ class TestPluginEndpoints:
         assert response.status_code == 400
 
     def test_disable_plugin(self, client, mock_plugin_registry, mock_config_manager):
-        with patch("src.api_server.reset_display_service"), patch("src.api_server.reset_template_engine"):
+        with patch("src.plugins.routes.reset_display_service"), patch("src.plugins.routes.reset_template_engine"):
             response = client.post("/plugins/weather/disable")
         assert response.status_code == 200
         assert response.json()["enabled"] is False
@@ -854,7 +857,7 @@ class TestPluginEndpoints:
         assert data["plugin_system_enabled"] is True
 
     def test_get_all_plugin_variables_system_unavailable(self, client, mock_template_engine):
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False):
+        with patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", False):
             response = client.get("/plugins/variables/all")
         assert response.status_code == 200
         data = response.json()
@@ -863,7 +866,7 @@ class TestPluginEndpoints:
     def test_receive_plugin_payload(self, client, mock_plugin_registry):
         response = client.post("/plugins/weather/receive", json={"message": "hello"})
         assert response.status_code == 200
-        assert response.json() == {"status": "ok"}
+        assert response.json() == {"status": "ok", "plugin_id": "weather"}
         mock_plugin_registry.get_plugin.return_value.receive_payload.assert_called_once()
 
     def test_receive_plugin_payload_not_found(self, client, mock_plugin_registry):
@@ -895,7 +898,7 @@ class TestPluginEndpoints:
         assert response.status_code == 403
 
     def test_receive_plugin_payload_system_unavailable(self, client):
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False):
+        with patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", False):
             response = client.post("/plugins/weather/receive", json={"message": "hello"})
         assert response.status_code == 503
 

--- a/tests/test_blocking_io_event_loop.py
+++ b/tests/test_blocking_io_event_loop.py
@@ -223,7 +223,7 @@ async def test_a_slow_active_page_send_does_not_block_the_event_loop():
             patch("src.api_server.get_service", return_value=service),
             patch("src.api_server.get_collection_service", return_value=Mock()),
             patch("src.api_server.check_ref_board_compatibility", return_value=Mock(ok=True, warnings=[])),
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", False),
             patch("src.api_server._board_is_paused", return_value=False),
         ):
             return await ac.put("/settings/active-page", json={"page_id": "p1"})
@@ -354,3 +354,39 @@ def test_concurrent_direct_send_characters_and_render_serialize():
 
     assert len(posts) == 4
     assert overlaps == [], overlaps
+
+
+@pytest.mark.asyncio
+async def test_a_slow_plugin_data_fetch_does_not_block_the_event_loop():
+    """``GET /plugins/{id}/data`` called ``fetch_plugin_data`` inline.
+
+    It was the last handler in the tree still doing so — the options route two
+    hundred lines away carried a comment naming it as the example not to copy
+    ("Never call the plugin inline... GET /plugins/{id}/data still does this;
+    do not copy it."). A plugin fetch is an outbound HTTP call to somebody
+    else's API, so an unresponsive upstream froze the whole process for the
+    plugin's entire timeout: no board driven, no UI, no ``GET /health``.
+
+    Fail-first output, with the handler still calling the registry inline::
+
+        E  AssertionError: /health waited 5.03s behind the plugin data fetch
+           — the event loop was blocked
+        E  assert 5.032923211008892 < 0.5
+    """
+
+    async def _plugin_data(ac, release):
+        registry = Mock()
+        registry.get_plugin.return_value = Mock()
+        registry.is_enabled.return_value = True
+        registry.fetch_plugin_data = _blocking(
+            release,
+            Mock(available=True, data={"v": 1}, formatted_lines=["SLOW"], error=None),
+        )
+        with (
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=registry),
+        ):
+            return await ac.get("/plugins/slow/data")
+
+    health, waited, still_running = await _health_while_in_flight(_plugin_data)
+    _assert_loop_stayed_free(health, waited, still_running, "plugin data fetch")

--- a/tests/test_demo_pages.py
+++ b/tests/test_demo_pages.py
@@ -570,11 +570,11 @@ class TestCreateDemoPageEndpoint:
         page_service.create_demo_page.return_value = (created_page, False)
 
         return (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=registry),
-            patch("src.api_server.get_settings_service", return_value=settings_service),
-            patch("src.api_server.get_page_service", return_value=page_service),
-            patch("src.api_server.get_config_manager", return_value=Mock(get_plugin_config=Mock(return_value={}))),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=registry),
+            patch("src.plugins.routes.get_settings_service", return_value=settings_service),
+            patch("src.plugins.routes.get_page_service", return_value=page_service),
+            patch("src.plugins.routes.get_config_manager", return_value=Mock(get_plugin_config=Mock(return_value={}))),
             page_service,
         )
 
@@ -588,7 +588,7 @@ class TestCreateDemoPageEndpoint:
         with p_avail, p_reg, p_ss, p_ps, p_cm:
             response = client.post("/plugins/test_plugin/demo-page")
 
-        assert response.status_code == 200, response.text
+        assert response.status_code == 201, response.text
         page_service.create_demo_page.assert_called_once()
         passed_schema = page_service.create_demo_page.call_args[0][1]
         assert passed_schema.device_type == "note", (
@@ -605,7 +605,7 @@ class TestCreateDemoPageEndpoint:
         with p_avail, p_reg, p_ss, p_ps, p_cm:
             response = client.post("/plugins/test_plugin/demo-page")
 
-        assert response.status_code == 200, response.text
+        assert response.status_code == 201, response.text
         passed_schema = page_service.create_demo_page.call_args[0][1]
         assert passed_schema.device_type == "flagship"
 
@@ -619,7 +619,7 @@ class TestCreateDemoPageEndpoint:
         with p_avail, p_reg, p_ss, p_ps, p_cm:
             response = client.post("/plugins/test_plugin/demo-page?device_type=flagship")
 
-        assert response.status_code == 200, response.text
+        assert response.status_code == 201, response.text
         passed_schema = page_service.create_demo_page.call_args[0][1]
         assert passed_schema.device_type == "flagship"
 
@@ -636,6 +636,6 @@ class TestCreateDemoPageEndpoint:
         with p_avail, p_reg, p_ss, p_ps, p_cm:
             response = client.post("/plugins/test_plugin/demo-page")
 
-        assert response.status_code == 200, response.text
+        assert response.status_code == 201, response.text
         passed_schema = page_service.create_demo_page.call_args[0][1]
         assert passed_schema.device_type == "flagship"

--- a/tests/test_page_board_compatibility.py
+++ b/tests/test_page_board_compatibility.py
@@ -57,7 +57,7 @@ def env(monkeypatch, tmp_path):
     monkeypatch.setattr("src.schedules.routes.get_page_service", lambda: page_service)
     monkeypatch.setattr("src.schedules.routes.get_collection_service", lambda: collection_service)
     monkeypatch.setattr("src.api_server.get_service", lambda: None)
-    monkeypatch.setattr("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False)
+    monkeypatch.setattr("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", False)
 
     flagship_page = page_service.create_page(PageCreate(name="Flag Page", type="template", template=["a"]))
     note_page = page_service.create_page(

--- a/tests/test_page_retarget.py
+++ b/tests/test_page_retarget.py
@@ -68,7 +68,11 @@ def env(monkeypatch, tmp_path):
     monkeypatch.setattr("src.api_server.get_schedule_service", lambda: schedule_service)
     monkeypatch.setattr("src.api_server.get_service", lambda: None)
     monkeypatch.setattr("src.board_guards.get_settings_service", lambda: settings)
+    # Both bindings: `api_server` imports the flag but keeps its own local
+    # name for the handlers still in that module, and the plugins router
+    # reads the source.
     monkeypatch.setattr("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False)
+    monkeypatch.setattr("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", False)
 
     flagship_page = page_service.create_page(PageCreate(name="Flag Page", type="template", template=["a"]))
 

--- a/tests/test_plugin_config_mask_roundtrip.py
+++ b/tests/test_plugin_config_mask_roundtrip.py
@@ -67,14 +67,14 @@ def mask_env(tmp_path):
     registry.set_plugin_config.side_effect = lambda _pid, config: applied.append(copy.deepcopy(config)) or []
 
     with (
-        patch("src.api_server.get_plugin_registry", return_value=registry),
+        patch("src.plugins.routes.get_plugin_registry", return_value=registry),
         # The MCP configure_plugin tool goes through PluginService, which
         # resolves the registry from its canonical home (#1757) — patch both
         # lookup points, as tests/test_mcp_server.py's plugin_services does.
         patch("src.plugins.get_plugin_registry", return_value=registry),
-        patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-        patch("src.api_server.reset_display_service"),
-        patch("src.api_server.reset_template_engine"),
+        patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+        patch("src.plugins.routes.reset_display_service"),
+        patch("src.plugins.routes.reset_template_engine"),
     ):
         yield applied, cm
 

--- a/tests/test_plugin_detail_plugin_type.py
+++ b/tests/test_plugin_detail_plugin_type.py
@@ -70,8 +70,8 @@ def client_for(request):
     """Build a TestClient whose registry reports *plugin_type*."""
 
     def _build(plugin_type: str) -> TestClient:
-        registry_patch = patch("src.api_server.get_plugin_registry", return_value=_FakeRegistry(plugin_type))
-        config_patch = patch("src.api_server.get_config_manager", return_value=_FakeConfigManager())
+        registry_patch = patch("src.plugins.routes.get_plugin_registry", return_value=_FakeRegistry(plugin_type))
+        config_patch = patch("src.plugins.routes.get_config_manager", return_value=_FakeConfigManager())
         registry_patch.start()
         config_patch.start()
         request.addfinalizer(registry_patch.stop)

--- a/tests/test_plugin_install_event_loop.py
+++ b/tests/test_plugin_install_event_loop.py
@@ -86,8 +86,8 @@ async def test_a_slow_registry_install_does_not_block_the_event_loop():
         registry = Mock()
         registry.install_from_registry = _blocking(release, [])
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=registry),
         ):
             return await ac.post("/plugins/registry/dad_jokes/install")
 
@@ -103,8 +103,8 @@ async def test_a_slow_git_install_does_not_block_the_event_loop():
         registry = Mock()
         registry.install_from_git = _blocking(release, [])
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=registry),
             patch("src.plugins.sources.repo_name_from_url", return_value="fiestaboard-plugin--x"),
             patch("src.plugins.sources.plugin_id_from_repo_name", return_value="x"),
         ):
@@ -124,8 +124,8 @@ async def test_a_slow_plugin_update_does_not_block_the_event_loop():
         registry.reload_plugin.return_value = Mock()
         registry._update_status = {}
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=registry),
             patch("pathlib.Path.is_dir", return_value=True),
             patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")),
             patch("src.plugins.sources.clone_or_update_repo", _blocking(release, (True, ""))),
@@ -147,8 +147,8 @@ async def test_a_slow_bulk_update_does_not_block_the_event_loop():
         registry.reload_plugin.return_value = Mock()
         registry._update_status = {"plugin_a": True}
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=registry),
             patch("pathlib.Path.is_dir", return_value=True),
             patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")),
             patch("src.plugins.sources.clone_or_update_repo", _blocking(release, (True, ""))),

--- a/tests/test_plugin_instances.py
+++ b/tests/test_plugin_instances.py
@@ -774,31 +774,36 @@ class TestPluginInstanceEndpoints:
 
     def test_list_instances_success(self, client, mock_registry):
         mock_registry.get_plugin.return_value = Mock()
+        # The shape PluginRegistry.list_instances actually returns. The stub
+        # used to say {"id", "instance_label", "enabled"} — keys the registry
+        # has never emitted — so the assertion below was pinning the stub, not
+        # the API. PluginInstancesResponse now rejects that shape outright.
         mock_registry.list_instances.return_value = [
-            {"id": "weather:sf", "instance_label": "sf", "enabled": False},
+            {"label": "sf", "key": "weather:sf", "enabled": False, "has_config": True},
         ]
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
         ):
             resp = client.get("/plugins/weather/instances")
         assert resp.status_code == 200
         data = resp.json()
         assert data["plugin_id"] == "weather"
         assert len(data["instances"]) == 1
-        assert data["instances"][0]["instance_label"] == "sf"
+        assert data["instances"][0]["label"] == "sf"
+        assert data["instances"][0]["key"] == "weather:sf"
 
     def test_list_instances_plugin_not_found(self, client, mock_registry):
         mock_registry.get_plugin.return_value = None
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
         ):
             resp = client.get("/plugins/nonexistent/instances")
         assert resp.status_code == 404
 
     def test_list_instances_system_unavailable(self, client):
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False):
+        with patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", False):
             resp = client.get("/plugins/weather/instances")
         assert resp.status_code == 503
 
@@ -808,16 +813,15 @@ class TestPluginInstanceEndpoints:
         mock_registry.get_plugin.return_value = Mock()
         mock_registry.create_instance.return_value = []  # no errors
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
-            patch("src.api_server.reset_display_service"),
-            patch("src.api_server.reset_template_engine"),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.reset_display_service"),
+            patch("src.plugins.routes.reset_template_engine"),
         ):
             resp = client.post("/plugins/weather/instances", json={"label": "sf"})
-        assert resp.status_code == 200
+        assert resp.status_code == 201
         data = resp.json()
-        assert data["status"] == "success"
         assert data["instance_label"] == "sf"
         assert data["instance_key"] == "weather:sf"
         # Persists config
@@ -828,11 +832,11 @@ class TestPluginInstanceEndpoints:
         mock_registry.get_plugin.return_value = Mock()
         mock_registry.create_instance.return_value = []
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
-            patch("src.api_server.reset_display_service") as mock_rds,
-            patch("src.api_server.reset_template_engine") as mock_rte,
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.reset_display_service") as mock_rds,
+            patch("src.plugins.routes.reset_template_engine") as mock_rte,
         ):
             client.post("/plugins/weather/instances", json={"label": "nyc"})
         mock_rds.assert_called_once()
@@ -846,14 +850,14 @@ class TestPluginInstanceEndpoints:
         mock_registry.get_plugin.return_value = Mock()
         mock_registry.create_instance.return_value = []
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
-            patch("src.api_server.reset_display_service"),
-            patch("src.api_server.reset_template_engine"),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.reset_display_service"),
+            patch("src.plugins.routes.reset_template_engine"),
         ):
             resp = client.post("/plugins/countdown/instances", json={"label": "Xmas"})
-        assert resp.status_code == 200
+        assert resp.status_code == 201
         assert resp.json()["instance_key"] == "countdown:xmas"
         mock_cm.set_plugin_config.assert_called_once_with("countdown:xmas", {"enabled": False})
         mock_cm.clear_plugin_removed.assert_called_once_with("countdown:xmas")
@@ -874,14 +878,14 @@ class TestPluginInstanceEndpoints:
         mock_registry.apply_stored_config.return_value = []
         mock_cm.get_plugin_config.return_value = stored
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
-            patch("src.api_server.reset_display_service"),
-            patch("src.api_server.reset_template_engine"),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.reset_display_service"),
+            patch("src.plugins.routes.reset_template_engine"),
         ):
             resp = client.post("/plugins/countdown/instances", json={"label": "xmas"})
-        assert resp.status_code == 200
+        assert resp.status_code == 201
         # The user's settings are neither overwritten on disk...
         mock_cm.set_plugin_config.assert_not_called()
         # ...nor left behind: the live instance picks them up, still enabled.
@@ -892,8 +896,8 @@ class TestPluginInstanceEndpoints:
         mock_registry.get_plugin.return_value = Mock()
         mock_registry.create_instance.return_value = ["Label already exists"]
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
         ):
             resp = client.post("/plugins/weather/instances", json={"label": "sf"})
         assert resp.status_code == 400
@@ -902,14 +906,14 @@ class TestPluginInstanceEndpoints:
     def test_create_instance_plugin_not_found(self, client, mock_registry):
         mock_registry.get_plugin.return_value = None
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
         ):
             resp = client.post("/plugins/nonexistent/instances", json={"label": "sf"})
         assert resp.status_code == 404
 
     def test_create_instance_system_unavailable(self, client):
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False):
+        with patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", False):
             resp = client.post("/plugins/weather/instances", json={"label": "sf"})
         assert resp.status_code == 503
 
@@ -919,16 +923,15 @@ class TestPluginInstanceEndpoints:
         mock_registry.delete_instance.return_value = []  # no errors
         mock_cm = Mock()
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
-            patch("src.api_server.reset_display_service"),
-            patch("src.api_server.reset_template_engine"),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.reset_display_service"),
+            patch("src.plugins.routes.reset_template_engine"),
         ):
             resp = client.delete("/plugins/weather/instances/sf")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["status"] == "success"
         assert data["instance_key"] == "weather:sf"
         # Uses public delete_plugin_config() (not private internals)
         mock_cm.delete_plugin_config.assert_called_once_with("weather:sf")
@@ -939,11 +942,11 @@ class TestPluginInstanceEndpoints:
         mock_registry.delete_instance.return_value = []
         mock_cm = Mock()
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
-            patch("src.api_server.reset_display_service"),
-            patch("src.api_server.reset_template_engine"),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.reset_display_service"),
+            patch("src.plugins.routes.reset_template_engine"),
         ):
             resp = client.delete("/plugins/weather/instances/sf")
         assert resp.status_code == 200
@@ -955,25 +958,25 @@ class TestPluginInstanceEndpoints:
         mock_registry.get_plugin.return_value = Mock()
         mock_registry.create_instance.return_value = []
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
-            patch("src.api_server.reset_display_service"),
-            patch("src.api_server.reset_template_engine"),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.reset_display_service"),
+            patch("src.plugins.routes.reset_template_engine"),
         ):
             resp = client.post("/plugins/weather/instances", json={"label": "sf"})
-        assert resp.status_code == 200
+        assert resp.status_code == 201
         mock_cm.clear_plugin_removed.assert_called_once_with("weather:sf")
 
     def test_delete_instance_resets_services(self, client, mock_registry):
         """Deleting an instance should reset display and template services."""
         mock_registry.delete_instance.return_value = []
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
-            patch("src.api_server.get_config_manager", return_value=Mock()),
-            patch("src.api_server.reset_display_service") as mock_rds,
-            patch("src.api_server.reset_template_engine") as mock_rte,
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.get_config_manager", return_value=Mock()),
+            patch("src.plugins.routes.reset_display_service") as mock_rds,
+            patch("src.plugins.routes.reset_template_engine") as mock_rte,
         ):
             client.delete("/plugins/weather/instances/sf")
         mock_rds.assert_called_once()
@@ -982,13 +985,13 @@ class TestPluginInstanceEndpoints:
     def test_delete_instance_not_found(self, client, mock_registry):
         mock_registry.delete_instance.return_value = ["Instance not found"]
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry", return_value=mock_registry),
         ):
             resp = client.delete("/plugins/weather/instances/nonexistent")
         assert resp.status_code == 400
 
     def test_delete_instance_system_unavailable(self, client):
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False):
+        with patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", False):
             resp = client.delete("/plugins/weather/instances/sf")
         assert resp.status_code == 503

--- a/tests/test_plugin_lifecycle_round_trip.py
+++ b/tests/test_plugin_lifecycle_round_trip.py
@@ -420,7 +420,7 @@ def test_writing_the_masked_api_key_back_over_mcp_preserves_the_stored_secret(cl
 def test_creating_an_instance_registers_it_under_the_compound_key(client):
     """The instance is addressable as ``<base><SEPARATOR><label>``."""
     created = client.post(f"/plugins/{HEALTHY}/instances", json={"label": "sf"})
-    assert created.status_code == 200, created.text
+    assert created.status_code == 201, created.text
 
     listed = client.get(f"/plugins/{HEALTHY}/instances")
     assert listed.status_code == 200, listed.text
@@ -430,7 +430,7 @@ def test_creating_an_instance_registers_it_under_the_compound_key(client):
 def test_an_instance_config_is_independent_of_the_base_plugin_config(client, plugin_env):
     """Configuring one must not overwrite the other."""
     instance = f"{HEALTHY}{INSTANCE_SEPARATOR}sf"
-    assert client.post(f"/plugins/{HEALTHY}/instances", json={"label": "sf"}).status_code == 200
+    assert client.post(f"/plugins/{HEALTHY}/instances", json={"label": "sf"}).status_code == 201
 
     _put_config(client, HEALTHY, {"label": "base"})
     _put_config(client, instance, {"label": "san francisco"})
@@ -442,7 +442,7 @@ def test_an_instance_config_is_independent_of_the_base_plugin_config(client, plu
 def test_an_instance_secret_is_masked_independently_of_the_base(client):
     """Masking follows the compound key, not the base id."""
     instance = f"{HEALTHY}{INSTANCE_SEPARATOR}sf"
-    assert client.post(f"/plugins/{HEALTHY}/instances", json={"label": "sf"}).status_code == 200
+    assert client.post(f"/plugins/{HEALTHY}/instances", json={"label": "sf"}).status_code == 201
     _put_config(client, instance, {"api_key": SECRET})
 
     response = client.get(f"/plugins/{instance}")
@@ -454,7 +454,7 @@ def test_an_instance_secret_is_masked_independently_of_the_base(client):
 def test_an_instance_renders_under_its_own_template_namespace(client):
     """``{{base:label.var}}`` resolves to the instance's own data."""
     instance = f"{HEALTHY}{INSTANCE_SEPARATOR}sf"
-    assert client.post(f"/plugins/{HEALTHY}/instances", json={"label": "sf"}).status_code == 200
+    assert client.post(f"/plugins/{HEALTHY}/instances", json={"label": "sf"}).status_code == 201
     _put_config(client, instance, {"api_key": SECRET})
     _enable(client, instance)
 
@@ -464,7 +464,7 @@ def test_an_instance_renders_under_its_own_template_namespace(client):
 def test_deleting_an_instance_purges_its_stored_config(client, plugin_env):
     """A deleted instance must not leave configuration behind to be adopted."""
     instance = f"{HEALTHY}{INSTANCE_SEPARATOR}sf"
-    assert client.post(f"/plugins/{HEALTHY}/instances", json={"label": "sf"}).status_code == 200
+    assert client.post(f"/plugins/{HEALTHY}/instances", json={"label": "sf"}).status_code == 201
     _put_config(client, instance, {"api_key": SECRET})
 
     deleted = client.delete(f"/plugins/{HEALTHY}/instances/sf")
@@ -475,7 +475,7 @@ def test_deleting_an_instance_purges_its_stored_config(client, plugin_env):
 
 def test_deleting_an_instance_leaves_the_base_plugin_config_alone(client, plugin_env):
     """Prefix-based purging must not swallow the base plugin's own entry."""
-    assert client.post(f"/plugins/{HEALTHY}/instances", json={"label": "sf"}).status_code == 200
+    assert client.post(f"/plugins/{HEALTHY}/instances", json={"label": "sf"}).status_code == 201
     _put_config(client, HEALTHY, {"label": "base"})
 
     assert client.delete(f"/plugins/{HEALTHY}/instances/sf").status_code == 200
@@ -489,7 +489,7 @@ def test_deleting_an_instance_leaves_the_base_plugin_config_alone(client, plugin
 def test_installing_from_the_registry_makes_the_plugin_configurable(client, plugin_env):
     """The freshly installed plugin accepts and stores a config."""
     installed = client.post(f"/plugins/registry/{EXTERNAL}/install")
-    assert installed.status_code == 200, installed.text
+    assert installed.status_code == 201, installed.text
 
     _put_config(client, EXTERNAL, {"label": "fresh", "api_key": SECRET})
 
@@ -497,7 +497,7 @@ def test_installing_from_the_registry_makes_the_plugin_configurable(client, plug
 
 
 def test_uninstalling_removes_the_plugin_from_the_listing(client):
-    assert client.post(f"/plugins/registry/{EXTERNAL}/install").status_code == 200
+    assert client.post(f"/plugins/registry/{EXTERNAL}/install").status_code == 201
 
     uninstalled = client.delete(f"/plugins/{EXTERNAL}/uninstall")
     assert uninstalled.status_code == 200, uninstalled.text
@@ -507,7 +507,7 @@ def test_uninstalling_removes_the_plugin_from_the_listing(client):
 
 def test_uninstalling_purges_the_plugin_config(client, plugin_env):
     """#948/#1102: a stale config resurrects the plugin on the next upgrade."""
-    assert client.post(f"/plugins/registry/{EXTERNAL}/install").status_code == 200
+    assert client.post(f"/plugins/registry/{EXTERNAL}/install").status_code == 201
     _put_config(client, EXTERNAL, {"label": "fresh", "api_key": SECRET})
 
     assert client.delete(f"/plugins/{EXTERNAL}/uninstall").status_code == 200
@@ -518,8 +518,8 @@ def test_uninstalling_purges_the_plugin_config(client, plugin_env):
 def test_uninstalling_purges_the_configs_of_its_instances_too(client, plugin_env):
     """Instance keys are separate config entries and must go with the base."""
     instance = f"{EXTERNAL}{INSTANCE_SEPARATOR}sf"
-    assert client.post(f"/plugins/registry/{EXTERNAL}/install").status_code == 200
-    assert client.post(f"/plugins/{EXTERNAL}/instances", json={"label": "sf"}).status_code == 200
+    assert client.post(f"/plugins/registry/{EXTERNAL}/install").status_code == 201
+    assert client.post(f"/plugins/{EXTERNAL}/instances", json={"label": "sf"}).status_code == 201
     _put_config(client, instance, {"api_key": SECRET})
 
     assert client.delete(f"/plugins/{EXTERNAL}/uninstall").status_code == 200
@@ -528,7 +528,7 @@ def test_uninstalling_purges_the_configs_of_its_instances_too(client, plugin_env
 
 
 def test_uninstalling_removes_the_plugin_directory_from_disk(client, plugin_env):
-    assert client.post(f"/plugins/registry/{EXTERNAL}/install").status_code == 200
+    assert client.post(f"/plugins/registry/{EXTERNAL}/install").status_code == 201
     assert (plugin_env["external_dir"] / EXTERNAL).is_dir()
 
     assert client.delete(f"/plugins/{EXTERNAL}/uninstall").status_code == 200
@@ -552,7 +552,7 @@ def test_uninstalling_a_builtin_plugin_is_refused(client, plugin_env):
 def test_the_fixture_keeps_plugin_writes_out_of_the_repo_data_dir(client, plugin_env):
     """Guard for #1762: no stub plugin may land in the developer's data/."""
     repo_data = Path(__file__).resolve().parent.parent / "data"
-    assert client.post(f"/plugins/registry/{EXTERNAL}/install").status_code == 200
+    assert client.post(f"/plugins/registry/{EXTERNAL}/install").status_code == 201
     _put_config(client, HEALTHY, {"label": "base", "api_key": SECRET})
 
     assert (plugin_env["external_dir"] / EXTERNAL).is_dir(), "the fixture never redirected the external dir"

--- a/tests/test_plugin_options_route.py
+++ b/tests/test_plugin_options_route.py
@@ -78,14 +78,14 @@ class _FakeRegistry:
 @pytest.fixture
 def registry(monkeypatch):
     """Install a fake plugin registry and reset the route's module state."""
-    from src import api_server
+    from src.plugins import options_runtime, routes
 
     fake = _FakeRegistry()
-    monkeypatch.setattr(api_server, "PLUGIN_SYSTEM_AVAILABLE", True)
-    monkeypatch.setattr(api_server, "get_plugin_registry", lambda: fake)
+    monkeypatch.setattr(routes, "PLUGIN_SYSTEM_AVAILABLE", True)
+    monkeypatch.setattr(routes, "get_plugin_registry", lambda: fake)
     # Both caches are process-global; give every test its own.
-    monkeypatch.setattr(api_server, "_PLUGIN_OPTIONS_CACHE", {})
-    monkeypatch.setattr(api_server, "_plugin_options_last_refresh", {})
+    monkeypatch.setattr(options_runtime, "_PLUGIN_OPTIONS_CACHE", {})
+    monkeypatch.setattr(options_runtime, "_plugin_options_last_refresh", {})
     return fake
 
 
@@ -115,9 +115,9 @@ def test_unknown_plugin_is_a_404(registry, client):
 
 def test_plugin_system_unavailable_is_a_503(registry, client, monkeypatch):
     """No plugin system at all is an infrastructure problem, not a bad request."""
-    from src import api_server
+    from src.plugins import routes
 
-    monkeypatch.setattr(api_server, "PLUGIN_SYSTEM_AVAILABLE", False)
+    monkeypatch.setattr(routes, "PLUGIN_SYSTEM_AVAILABLE", False)
 
     response = _post(client)
 
@@ -262,9 +262,9 @@ def _blocking_provider(release: threading.Event, seconds: float = 1.0):
 
 def test_a_plugin_that_hangs_gets_cut_off_with_a_504(registry, client, monkeypatch):
     """A settings dialog cannot wait on an unbounded upstream call."""
-    from src import api_server
+    from src.plugins import routes
 
-    monkeypatch.setattr(api_server, "PLUGIN_OPTIONS_TIMEOUT_SECONDS", 0.2)
+    monkeypatch.setattr(routes, "PLUGIN_OPTIONS_TIMEOUT_SECONDS", 0.2)
     release = threading.Event()
     registry.result = _blocking_provider(release)
 
@@ -286,9 +286,9 @@ async def test_a_slow_plugin_does_not_block_the_event_loop(registry, monkeypatch
     bug continuous rather than occasional. Assert directly on the symptom: a
     cheap endpoint must answer *while* a slow options lookup is in flight.
     """
-    from src import api_server
+    from src.plugins import routes
 
-    monkeypatch.setattr(api_server, "PLUGIN_OPTIONS_TIMEOUT_SECONDS", 2.0)
+    monkeypatch.setattr(routes, "PLUGIN_OPTIONS_TIMEOUT_SECONDS", 2.0)
     release = threading.Event()
     registry.result = _blocking_provider(release, seconds=2.0)
 
@@ -405,10 +405,10 @@ def test_a_failing_refresh_falls_back_to_the_last_good_answer(registry, client):
 def test_a_timeout_after_a_good_answer_also_serves_stale(registry, client, monkeypatch):
     """Same reasoning as a failing refresh: a hung upstream is not a reason to
     throw away a list we already have."""
-    from src import api_server
+    from src.plugins import routes
 
     good = _post(client)
-    monkeypatch.setattr(api_server, "PLUGIN_OPTIONS_TIMEOUT_SECONDS", 0.2)
+    monkeypatch.setattr(routes, "PLUGIN_OPTIONS_TIMEOUT_SECONDS", 0.2)
     release = threading.Event()
     registry.result = _blocking_provider(release)
 
@@ -592,7 +592,7 @@ def test_an_unmasked_secret_in_draft_config_is_passed_through(registry, client):
 def test_draft_config_values_are_never_logged(registry, client, caplog):
     """Debug logging around a settings dialog is exactly where credentials
     leak. Key names are useful; values are not worth the risk."""
-    with caplog.at_level(logging.DEBUG, logger="src.api_server"):
+    with caplog.at_level(logging.DEBUG, logger="src.plugins.routes"):
         _post(client, draft_config={"api_key": "s3cr3t-do-not-log", "exchange": "NASDAQ"})
 
     assert "s3cr3t-do-not-log" not in caplog.text
@@ -624,10 +624,10 @@ async def test_concurrent_lookups_cannot_exhaust_the_thread_pool(registry, monke
     """``asyncio.to_thread`` shares one bounded default executor with the rest
     of the process. Without a cap, a plugin that is merely slow would let a
     settings dialog starve every other background call."""
-    from src import api_server
+    from src.plugins import options_runtime, routes
 
-    monkeypatch.setattr(api_server, "_PLUGIN_OPTIONS_SEMAPHORE", asyncio.Semaphore(2))
-    monkeypatch.setattr(api_server, "PLUGIN_OPTIONS_TIMEOUT_SECONDS", 10.0)
+    monkeypatch.setattr(options_runtime, "_PLUGIN_OPTIONS_SEMAPHORE", asyncio.Semaphore(2))
+    monkeypatch.setattr(routes, "PLUGIN_OPTIONS_TIMEOUT_SECONDS", 10.0)
 
     counter_lock = threading.Lock()
     state = {"in_flight": 0, "peak": 0}
@@ -662,10 +662,10 @@ async def test_a_timed_out_lookup_holds_its_slot_until_the_thread_really_ends(re
     fresh threads forever, which is precisely the exhaustion the cap exists to
     prevent.
     """
-    from src import api_server
+    from src.plugins import options_runtime, routes
 
-    monkeypatch.setattr(api_server, "_PLUGIN_OPTIONS_SEMAPHORE", asyncio.Semaphore(1))
-    monkeypatch.setattr(api_server, "PLUGIN_OPTIONS_TIMEOUT_SECONDS", 0.2)
+    monkeypatch.setattr(options_runtime, "_PLUGIN_OPTIONS_SEMAPHORE", asyncio.Semaphore(1))
+    monkeypatch.setattr(routes, "PLUGIN_OPTIONS_TIMEOUT_SECONDS", 0.2)
     release = threading.Event()
     registry.result = _blocking_provider(release, seconds=3.0)
 
@@ -712,13 +712,13 @@ def test_a_plugin_with_no_manifest_declares_no_providers(registry, client):
 def test_the_caches_are_bounded(registry, client, monkeypatch):
     """A settings search box makes one cache entry per keystroke, and this
     process runs for months."""
-    from src import api_server
+    from src.plugins import options_runtime
 
-    monkeypatch.setattr(api_server, "PLUGIN_OPTIONS_CACHE_MAX_ENTRIES", 3)
+    monkeypatch.setattr(options_runtime, "PLUGIN_OPTIONS_CACHE_MAX_ENTRIES", 3)
 
     for i in range(8):
         _post(client, query=f"q{i}")
         _post(client, query=f"q{i}", refresh=True)
 
-    assert len(api_server._PLUGIN_OPTIONS_CACHE) <= 3
-    assert len(api_server._plugin_options_last_refresh) <= 4
+    assert len(options_runtime._PLUGIN_OPTIONS_CACHE) <= 3
+    assert len(options_runtime._plugin_options_last_refresh) <= 4

--- a/tests/test_plugin_service.py
+++ b/tests/test_plugin_service.py
@@ -15,8 +15,12 @@ from __future__ import annotations
 from unittest.mock import Mock, patch
 
 import pytest
-from fastapi import HTTPException
 
+from src.plugins.errors import (
+    PluginConfigInvalid,
+    PluginNotFound,
+    PluginOperationRejected,
+)
 from src.plugins.service import PluginService, sanitize_optional_plugin_id
 
 
@@ -91,11 +95,10 @@ def test_update_plugin_config_validation_failure_neither_persists_nor_resets():
     rec = _Recorder()
     svc = _service(rec, config_errors=["api_key: too short"])
 
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(PluginConfigInvalid) as exc_info:
         svc.update_plugin_config("alpha", {"api_key": "x"})
 
-    assert exc_info.value.status_code == 400
-    assert exc_info.value.detail == {"errors": ["api_key: too short"]}
+    assert exc_info.value.errors == ["api_key: too short"]
     assert rec.steps == ["validate"], "a rejected config must not be saved or applied"
 
 
@@ -141,7 +144,7 @@ def test_create_instance_persists_then_resets():
     svc.config_manager.clear_plugin_removed.assert_called_once_with("alpha:work")
 
 
-def test_unknown_plugin_is_a_404_for_config_enable_and_disable():
+def test_unknown_plugin_raises_not_found_for_config_enable_and_disable():
     rec = _Recorder()
     svc = _service(rec)
     svc.registry.get_plugin.return_value = None
@@ -151,9 +154,8 @@ def test_unknown_plugin_is_a_404_for_config_enable_and_disable():
         lambda: svc.enable_plugin("missing"),
         lambda: svc.disable_plugin("missing"),
     ):
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(PluginNotFound):
             call()
-        assert exc_info.value.status_code == 404
 
 
 def test_mask_config_delegates_to_the_config_managers_masker():
@@ -202,9 +204,8 @@ def test_bare_service_resolves_collaborators_from_canonical_homes():
 
 @pytest.mark.parametrize("bad", ["", "UPPER", "has-dash", "has space", "dot.dot"])
 def test_sanitize_optional_plugin_id_rejects_invalid_ids(bad: str):
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(PluginOperationRejected):
         sanitize_optional_plugin_id(bad)
-    assert exc_info.value.status_code == 400
 
 
 def test_sanitize_optional_plugin_id_accepts_none_and_valid_ids():
@@ -213,15 +214,14 @@ def test_sanitize_optional_plugin_id_accepts_none_and_valid_ids():
 
 
 @pytest.mark.asyncio
-async def test_install_from_registry_errors_become_a_400():
+async def test_install_from_registry_errors_become_a_rejection():
     svc = _service(_Recorder())
     svc.registry.install_from_registry = Mock(return_value=["Plugin 'nope' not found in the registry"])
 
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(PluginOperationRejected) as exc_info:
         await svc.install_from_registry("nope")
 
-    assert exc_info.value.status_code == 400
-    assert "not found in the registry" in exc_info.value.detail
+    assert "not found in the registry" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
@@ -239,10 +239,9 @@ async def test_install_from_git_rejects_a_bad_branch_before_touching_git():
     svc = _service(_Recorder())
     svc.registry.install_from_git = Mock(return_value=[])
 
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(PluginOperationRejected):
         await svc.install_from_git("https://github.com/example/fiestaboard-plugin--x.git", branch="bad branch")
 
-    assert exc_info.value.status_code == 400
     svc.registry.install_from_git.assert_not_called()
 
 
@@ -263,18 +262,17 @@ def test_uninstall_purges_base_and_instance_configs():
 
 
 @pytest.mark.asyncio
-async def test_apply_update_missing_source_is_a_404_and_builtin_a_400():
+async def test_apply_update_missing_source_is_not_found_and_builtin_a_rejection():
+    """The service names the *kind* of failure; routes.py picks the status code."""
     svc = _service(_Recorder())
 
     svc.registry.get_plugin_source = Mock(return_value=None)
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(PluginNotFound):
         await svc.apply_update("missing")
-    assert exc_info.value.status_code == 404
 
     svc.registry.get_plugin_source = Mock(return_value=Mock(source_type="builtin", local_path=None))
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(PluginOperationRejected):
         await svc.apply_update("alpha")
-    assert exc_info.value.status_code == 400
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugins_contract.py
+++ b/tests/test_plugins_contract.py
@@ -1,0 +1,969 @@
+"""Value-level contract goldens for the /plugins API (Phase 2 §2, slice 4).
+
+These are deliberately *values*, not shapes. The shape corpus in
+``tests/golden/responses/plugins.json`` records key sets and type names, so it
+cannot see a secret replaced by three asterisks, an env value written into
+``config.json``, a plugin id echoed back wrong, or an error string that stopped
+naming the missing plugin.
+
+That is not hypothetical here. The masking round-trip is the highest-stakes
+contract in this codebase: an independent audit found a regression in it that
+the shape golden provably could not catch (#1743), and a later PR nearly
+reintroduced it during a merge (#1864 review). The three facts pinned by
+:class:`TestMaskedSecretRoundTrip` and :class:`TestEnvOverrideRoundTrip` —
+by value, against a **real** ``ConfigManager`` writing a **real** file — are
+what stop that from happening a third time:
+
+1. a masked field posted back as ``"***"`` persists the STORED secret, never
+   the literal ``"***"``;
+2. with an env override active, the persisted value stays the stored one while
+   the LIVE plugin config carries the env value;
+3. ``env_overridden_keys`` names exactly the keys the environment controls,
+   and their values never appear in ``config``.
+
+Covers all 25 routes the ``plugins`` router serves, success and failure paths.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.config_manager import ConfigManager
+
+REAL_SECRET = "super-secret-key-abc123"
+MASK = "***"
+
+
+# ── Stubs ───────────────────────────────────────────────────────────────────
+
+
+class _ContractRegistry:
+    """Deterministic registry covering the whole /plugins route family.
+
+    Mirrors the stub in ``tests/test_response_shape_goldens.py`` so the two
+    corpora describe the same world; the difference is what is asserted about
+    it, not what it is.
+    """
+
+    def __init__(self) -> None:
+        self.enabled: dict[str, bool] = {"alpha": True, "ext_plugin": False}
+        self.config_errors: list[str] = []
+        self.enable_ok = True
+        self.applied: list[dict[str, Any]] = []
+        alpha_manifest = SimpleNamespace(
+            name="Alpha",
+            version="1.0.0",
+            description="Contract fixture plugin 'alpha'.",
+            author="Contract Fixtures",
+            icon="sparkles",
+            category="utility",
+            plugin_type="data",
+            settings_schema={
+                "type": "object",
+                "required": ["api_key"],
+                "properties": {
+                    "api_key": {"type": "string", "title": "API Key"},
+                    "location": {"type": "string", "title": "Location"},
+                    "symbols": {
+                        "type": "array",
+                        "ui:widget": "remote-options",
+                        "ui:options": {"options_id": "symbols", "cache_seconds": 0},
+                    },
+                },
+            },
+            max_lengths={"value": 10},
+            env_vars=[],
+            documentation=None,
+            demo={"flagship": {"name": "Alpha Demo", "template": ["ALPHA"]}},
+            raw={
+                "variables": {"value": {"description": "A value", "example": "X"}},
+                "color_rules_schema": {},
+                "options": [{"id": "symbols", "cache_seconds": 0}],
+            },
+        )
+        no_demo_manifest = SimpleNamespace(
+            name="No Demo",
+            version="0.2.0",
+            description="Fixture without a demo template.",
+            author="Contract Fixtures",
+            icon=None,
+            category="utility",
+            plugin_type="data",
+            settings_schema={},
+            max_lengths={},
+            env_vars=[],
+            documentation=None,
+            demo=None,
+            raw={"variables": {}},
+        )
+        self.manifests = {"alpha": alpha_manifest, "norecv": no_demo_manifest}
+        self.plugins = {"alpha": Mock(), "norecv": Mock(), "ext_plugin": Mock()}
+        self.fetch_result = SimpleNamespace(
+            available=True,
+            data={"value": 42},
+            formatted_lines=["ALPHA 42"],
+            error=None,
+        )
+        self.update_status = {"ext_plugin": True, "quiet_plugin": False}
+        self.sources = {
+            "ext_plugin": SimpleNamespace(source_type="git", local_path=None),
+            "alpha": SimpleNamespace(source_type="builtin", local_path=None),
+        }
+
+    # -- read surface -------------------------------------------------------
+    def list_plugins(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "id": "alpha",
+                "name": "Alpha",
+                "version": "1.0.0",
+                "description": "Contract fixture plugin 'alpha'.",
+                "enabled": True,
+                "base_plugin_id": None,
+                "instance_label": None,
+            },
+            {
+                "id": "ext_plugin",
+                "name": "Ext Plugin",
+                "version": "0.1.0",
+                "description": "Contract fixture external plugin.",
+                "enabled": False,
+                "base_plugin_id": None,
+                "instance_label": None,
+            },
+        ]
+
+    def get_all_variables(self) -> dict[str, Any]:
+        return {"alpha": {"value": {"description": "A value", "example": "X"}}}
+
+    def get_all_max_lengths(self) -> dict[str, Any]:
+        return {"alpha": {"value": 10}}
+
+    def get_load_errors(self) -> dict[str, Any]:
+        return {"broken_plugin": ["ImportError: contract fixture"]}
+
+    def get_fetch_breaker_status(self) -> dict[str, dict[str, Any]]:
+        return {
+            "slow_plugin": {
+                "consecutive_timeouts": 3,
+                "quarantined": True,
+                "cooldown_remaining_seconds": 42.5,
+            }
+        }
+
+    def get_registry_entries(self) -> list[dict[str, Any]]:
+        return [{"id": "beta", "name": "Beta", "installed": False, "repository": "fiestaboard-plugin--beta"}]
+
+    def get_update_status(self) -> dict[str, bool]:
+        return dict(self.update_status)
+
+    def get_update_blocked_reasons(self) -> dict[str, str]:
+        return {"blocked_plugin": "the incoming manifest needs a newer FiestaBoard core"}
+
+    def get_manifest(self, plugin_id: str) -> Any:
+        return self.manifests.get(plugin_id)
+
+    def get_plugin(self, plugin_id: str) -> Any:
+        return self.plugins.get(plugin_id)
+
+    def get_plugin_config(self, plugin_id: str) -> dict[str, Any] | None:
+        return {"api_key": REAL_SECRET} if plugin_id == "alpha" else None
+
+    def is_enabled(self, plugin_id: str) -> bool:
+        return self.enabled.get(plugin_id, False)
+
+    def fetch_plugin_data(self, plugin_id: str) -> Any:
+        return self.fetch_result
+
+    def get_plugin_options(self, plugin_id: str, options_id: str, request: Any, draft_config: Any = None) -> Any:
+        from src.plugins.base import Option, OptionsResult
+
+        return OptionsResult(options=[Option(value="AAPL", label="Apple")])
+
+    # -- instances ----------------------------------------------------------
+    def parse_instance_key(self, plugin_id: str) -> tuple[str, str | None]:
+        base, _, label = plugin_id.partition(":")
+        return base, (label or None)
+
+    def make_instance_key(self, base_id: str, label: str) -> str:
+        return f"{base_id}:{label}"
+
+    def list_instances(self, base_id: str) -> list[dict[str, Any]]:
+        return [{"label": "work", "enabled": False}] if base_id == "alpha" else []
+
+    def create_instance(self, base_id: str, label: str) -> list[str]:
+        return [] if label != "bad label" else ["Invalid instance label"]
+
+    def delete_instance(self, base_id: str, label: str) -> list[str]:
+        return []
+
+    def apply_stored_config(self, compound_key: str, stored: dict[str, Any]) -> list[str]:
+        return []
+
+    # -- mutation surface ---------------------------------------------------
+    def set_plugin_config(self, plugin_id: str, config: dict[str, Any]) -> list[str]:
+        # Snapshot: the endpoint hands the *same dict object* down the chain
+        # and un-masks it in place, so a call-args assertion would inspect the
+        # already-repaired dict and pass no matter what.
+        self.applied.append(copy.deepcopy(config))
+        return list(self.config_errors)
+
+    def enable_plugin(self, plugin_id: str) -> bool:
+        return self.enable_ok
+
+    def disable_plugin(self, plugin_id: str) -> bool:
+        return True
+
+    # -- install / update surface -------------------------------------------
+    def install_from_registry(self, plugin_id: str) -> list[str]:
+        return [] if plugin_id == "beta" else [f"Plugin '{plugin_id}' not found in the registry"]
+
+    def install_from_git(self, repository: str, plugin_id: str | None = None, branch: str = "") -> list[str]:
+        return []
+
+    def uninstall_external_plugin(self, plugin_id: str) -> list[str]:
+        return [] if plugin_id == "ext_plugin" else [f"Plugin '{plugin_id}' is a built-in plugin"]
+
+    def check_for_updates(self) -> dict[str, bool]:
+        return {"ext_plugin": True, "quiet_plugin": False}
+
+    def get_plugin_source(self, plugin_id: str) -> Any:
+        return self.sources.get(plugin_id)
+
+    def clear_update_status(self, plugin_id: str) -> None:
+        self.update_status.pop(plugin_id, None)
+
+
+class _ContractConfigManager:
+    """ConfigManager stub with the same masking contract as the real one."""
+
+    SENSITIVE = {"api_key"}
+
+    def __init__(self) -> None:
+        self.configs: dict[str, dict[str, Any]] = {
+            "alpha": {"enabled": True, "api_key": REAL_SECRET, "location": "New York, NY"},
+        }
+        self.removed: set[str] = set()
+
+    def get_plugin_config(self, plugin_id: str, include_env_overrides: bool = True) -> dict[str, Any] | None:
+        config = self.configs.get(plugin_id)
+        return dict(config) if config else None
+
+    def get_plugin_env_overrides(self, plugin_id: str) -> dict[str, Any]:
+        return {}
+
+    def set_plugin_config(self, plugin_id: str, config: dict[str, Any]) -> None:
+        self.configs[plugin_id] = dict(config)
+
+    def enable_plugin(self, plugin_id: str) -> None:
+        self.configs.setdefault(plugin_id, {})["enabled"] = True
+
+    def disable_plugin(self, plugin_id: str) -> None:
+        self.configs.setdefault(plugin_id, {})["enabled"] = False
+
+    def delete_plugin_config(self, plugin_id: str) -> None:
+        self.configs.pop(plugin_id, None)
+
+    def mark_plugin_removed(self, plugin_id: str) -> None:
+        self.removed.add(plugin_id)
+
+    def clear_plugin_removed(self, plugin_id: str) -> None:
+        self.removed.discard(plugin_id)
+
+    def _mask_sensitive(self, obj: Any, path: str = "") -> Any:
+        if isinstance(obj, dict):
+            return {
+                key: (MASK if key in self.SENSITIVE and isinstance(value, str) else self._mask_sensitive(value))
+                for key, value in obj.items()
+            }
+        return obj
+
+
+@pytest.fixture
+def registry() -> _ContractRegistry:
+    return _ContractRegistry()
+
+
+@pytest.fixture
+def config_manager() -> _ContractConfigManager:
+    return _ContractConfigManager()
+
+
+@pytest.fixture
+def page_service():
+    demo_page = SimpleNamespace(
+        id="demo-page-1",
+        model_dump=lambda: {"id": "demo-page-1", "name": "Alpha Demo", "type": "template"},
+    )
+    return SimpleNamespace(
+        get_demo_page=lambda plugin_id, device_type=None: None,
+        create_demo_page=lambda plugin_id, schema: (demo_page, False),
+    )
+
+
+@pytest.fixture
+def client(_isolated_data_dir, registry, config_manager, page_service):
+    """TestClient with the whole plugin collaborator set stubbed."""
+    from src.api_server import app
+
+    with (
+        patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+        patch("src.api_server.get_plugin_registry", new=lambda: registry),
+        patch("src.api_server.get_config_manager", new=lambda: config_manager),
+        patch("src.api_server.reset_display_service", new=Mock()),
+        patch("src.api_server.reset_template_engine", new=Mock()),
+        patch("src.api_server.get_page_service", new=lambda: page_service),
+        patch("src.api_server._PLUGIN_OPTIONS_CACHE", new={}),
+        patch("src.api_server._plugin_options_last_refresh", new={}),
+    ):
+        yield TestClient(app, raise_server_exceptions=False)
+
+
+# ── GET /plugins ────────────────────────────────────────────────────────────
+
+
+class TestListPlugins:
+    def test_lists_every_plugin_with_its_id_name_and_enabled_flag(self, client):
+        body = client.get("/plugins").json()
+
+        assert [p["id"] for p in body["plugins"]] == ["alpha", "ext_plugin"]
+        assert [p["name"] for p in body["plugins"]] == ["Alpha", "Ext Plugin"]
+        assert [p["enabled"] for p in body["plugins"]] == [True, False]
+
+    def test_totals_count_plugins_and_enabled_plugins_separately(self, client):
+        body = client.get("/plugins").json()
+
+        assert body["total"] == 2
+        assert body["enabled_count"] == 1
+
+    def test_a_configured_plugin_carries_its_config_masked(self, client):
+        body = client.get("/plugins").json()
+
+        alpha = next(p for p in body["plugins"] if p["id"] == "alpha")
+        assert alpha["configured"] is True
+        assert alpha["config"]["api_key"] == MASK
+        assert alpha["config"]["location"] == "New York, NY"
+        assert REAL_SECRET not in json.dumps(body)
+
+    def test_an_unconfigured_plugin_reports_configured_false_and_an_empty_config(self, client):
+        body = client.get("/plugins").json()
+
+        ext = next(p for p in body["plugins"] if p["id"] == "ext_plugin")
+        assert ext["configured"] is False
+        assert ext["config"] == {}
+
+    def test_503_when_the_plugin_system_failed_to_import(self, client):
+        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False):
+            response = client.get("/plugins")
+
+        assert response.status_code == 503
+        assert response.json()["detail"] == "Plugin system is not available."
+
+
+# ── GET /plugins/variables/all ──────────────────────────────────────────────
+
+
+class TestAllVariables:
+    def test_returns_the_registry_variables_and_max_lengths(self, client):
+        body = client.get("/plugins/variables/all").json()
+
+        assert body["variables"] == {"alpha": {"value": {"description": "A value", "example": "X"}}}
+        assert body["max_lengths"] == {"alpha": {"value": 10}}
+        assert body["plugin_system_enabled"] is True
+
+
+# ── GET /plugins/errors ─────────────────────────────────────────────────────
+
+
+class TestPluginErrors:
+    def test_reports_load_errors_keyed_by_plugin_id(self, client):
+        body = client.get("/plugins/errors").json()
+
+        assert body["errors"] == {"broken_plugin": ["ImportError: contract fixture"]}
+
+
+# ── GET /plugins/registry ───────────────────────────────────────────────────
+
+
+class TestRegistryListing:
+    def test_returns_the_curated_entries_with_their_install_state(self, client):
+        body = client.get("/plugins/registry").json()
+
+        assert body["entries"] == [
+            {"id": "beta", "name": "Beta", "installed": False, "repository": "fiestaboard-plugin--beta"}
+        ]
+
+
+# ── GET /plugins/updates ────────────────────────────────────────────────────
+
+
+class TestUpdateStatus:
+    def test_reports_which_plugins_have_updates_and_which_are_blocked(self, client):
+        body = client.get("/plugins/updates").json()
+
+        assert body["updates"] == {"ext_plugin": True, "quiet_plugin": False}
+        assert body["blocked"] == {"blocked_plugin": "the incoming manifest needs a newer FiestaBoard core"}
+
+
+# ── GET /plugins/{plugin_id} ────────────────────────────────────────────────
+
+
+class TestPluginDetail:
+    def test_carries_the_manifest_identity_fields_by_value(self, client):
+        body = client.get("/plugins/alpha").json()
+
+        assert body["id"] == "alpha"
+        assert body["name"] == "Alpha"
+        assert body["version"] == "1.0.0"
+        assert body["author"] == "Contract Fixtures"
+        assert body["category"] == "utility"
+        assert body["plugin_type"] == "data"
+        assert body["enabled"] is True
+
+    def test_config_is_masked_and_the_stored_secret_never_appears(self, client):
+        body = client.get("/plugins/alpha").json()
+
+        assert body["config"]["api_key"] == MASK
+        assert body["config"]["location"] == "New York, NY"
+        assert REAL_SECRET not in json.dumps(body)
+
+    def test_reports_the_demo_template_and_instance_topology(self, client):
+        body = client.get("/plugins/alpha").json()
+
+        assert body["has_demo"] is True
+        assert body["demo_page_id"] is None
+        assert body["base_plugin_id"] == "alpha"
+        assert body["instance_label"] is None
+        assert body["instances"] == [{"label": "work", "enabled": False}]
+
+    def test_404_names_the_missing_plugin(self, client):
+        response = client.get("/plugins/missing")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Plugin not found: missing"
+
+
+# ── GET /plugins/{plugin_id}/manifest ───────────────────────────────────────
+
+
+class TestPluginManifest:
+    def test_returns_the_raw_manifest(self, client):
+        body = client.get("/plugins/alpha/manifest").json()
+
+        assert body["variables"] == {"value": {"description": "A value", "example": "X"}}
+
+    def test_404_names_the_missing_plugin(self, client):
+        response = client.get("/plugins/missing/manifest")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Plugin not found: missing"
+
+
+# ── PUT /plugins/{plugin_id}/config ─────────────────────────────────────────
+
+
+class TestUpdateConfig:
+    def test_echoes_the_stored_config_back_masked(self, client):
+        response = client.put(
+            "/plugins/alpha/config",
+            json={"config": {"api_key": "brand-new-key", "location": "London, UK"}},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["config"]["api_key"] == MASK
+        assert response.json()["config"]["location"] == "London, UK"
+
+    def test_a_real_new_key_reaches_the_live_plugin_and_the_store(self, client, registry, config_manager):
+        client.put("/plugins/alpha/config", json={"config": {"api_key": "brand-new-key"}})
+
+        assert registry.applied[-1]["api_key"] == "brand-new-key"
+        assert config_manager.configs["alpha"]["api_key"] == "brand-new-key"
+
+    def test_404_names_the_missing_plugin(self, client):
+        response = client.put("/plugins/missing/config", json={"config": {}})
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Plugin not found: missing"
+
+    def test_schema_validation_failures_are_reported_per_field(self, client, registry):
+        registry.config_errors = ["api_key: does not match the schema"]
+
+        response = client.put("/plugins/alpha/config", json={"config": {"api_key": 5}})
+
+        assert response.status_code == 400
+        assert response.json()["detail"]["errors"] == ["api_key: does not match the schema"]
+
+
+# ── The masking round-trip (the highest-stakes contract here) ───────────────
+
+
+@pytest.fixture
+def real_config(tmp_path, monkeypatch):
+    """A real ConfigManager on a real file, holding a real stored secret.
+
+    The disk assertions below are about what actually gets persisted, not
+    about a mock's call log. CI's platform job exports ``WEATHER_API_KEY``
+    (and friends), so every override this fixture does not set itself is
+    deleted first — otherwise "the stored value survived" would be indis-
+    tinguishable from "the ambient env value was written".
+    """
+    from src.config_manager import ENV_PLUGIN_OVERRIDES
+
+    for env_var in ENV_PLUGIN_OVERRIDES:
+        monkeypatch.delenv(env_var, raising=False)
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"board": {}, "features": {}, "general": {}, "plugins": {}}))
+    cm = ConfigManager(config_path=str(config_path))
+    cm.set_plugin_config("weather", {"enabled": True, "api_key": REAL_SECRET, "location": "New York, NY"})
+    return cm
+
+
+@pytest.fixture
+def mask_client(_isolated_data_dir, real_config, registry, page_service):
+    from src.api_server import app
+
+    with (
+        patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+        patch("src.api_server.get_plugin_registry", new=lambda: registry),
+        patch("src.plugins.get_plugin_registry", new=lambda: registry),
+        patch("src.api_server.get_config_manager", new=lambda: real_config),
+        patch("src.api_server.reset_display_service", new=Mock()),
+        patch("src.api_server.reset_template_engine", new=Mock()),
+        patch("src.api_server.get_page_service", new=lambda: page_service),
+    ):
+        registry.plugins["weather"] = Mock()
+        registry.manifests["weather"] = registry.manifests["alpha"]
+        registry.enabled["weather"] = True
+        yield TestClient(app, raise_server_exceptions=False)
+
+
+def _stored(cm: ConfigManager, plugin_id: str) -> dict[str, Any]:
+    """What is actually on disk, with no env overlay."""
+    return cm.get_plugin_config(plugin_id, include_env_overrides=False) or {}
+
+
+class TestMaskedSecretRoundTrip:
+    """A ``"***"`` posted back must resolve to the STORED secret. Always."""
+
+    def test_the_sentinel_is_never_persisted_as_the_literal_mask(self, mask_client, real_config):
+        response = mask_client.put(
+            "/plugins/weather/config",
+            json={"config": {"enabled": True, "api_key": MASK, "location": "Chicago, IL"}},
+        )
+
+        assert response.status_code == 200
+        assert _stored(real_config, "weather")["api_key"] == REAL_SECRET
+        assert _stored(real_config, "weather")["api_key"] != MASK
+
+    def test_the_sentinel_never_reaches_the_live_plugin(self, mask_client, registry):
+        mask_client.put(
+            "/plugins/weather/config",
+            json={"config": {"enabled": True, "api_key": MASK, "location": "Chicago, IL"}},
+        )
+
+        assert registry.applied[-1]["api_key"] == REAL_SECRET
+
+    def test_the_rest_of_the_payload_still_saves(self, mask_client, real_config):
+        mask_client.put(
+            "/plugins/weather/config",
+            json={"config": {"enabled": True, "api_key": MASK, "location": "Chicago, IL"}},
+        )
+
+        assert _stored(real_config, "weather")["location"] == "Chicago, IL"
+
+    def test_a_genuinely_new_secret_still_replaces_the_stored_one(self, mask_client, real_config):
+        mask_client.put(
+            "/plugins/weather/config",
+            json={"config": {"enabled": True, "api_key": "rotated-key", "location": "Chicago, IL"}},
+        )
+
+        assert _stored(real_config, "weather")["api_key"] == "rotated-key"
+
+
+class TestEnvOverrideRoundTrip:
+    """An env override steers the LIVE plugin and never touches the file."""
+
+    # The override is set in each test body, not in a fixture: ``real_config``
+    # deletes every ENV_PLUGIN_OVERRIDES variable so an ambient CI value cannot
+    # masquerade as a stored one, and a class-level autouse fixture would run
+    # *before* it and be deleted again.
+    ENV_VALUE = "key-from-the-environment"
+
+    def test_the_detail_endpoint_serves_the_stored_config_not_the_env_value(self, mask_client, monkeypatch):
+        monkeypatch.setenv("WEATHER_API_KEY", self.ENV_VALUE)
+
+        body = mask_client.get("/plugins/weather").json()
+
+        # Masked, so neither value is visible — but the point is that the
+        # env value is not what would come back in the next save.
+        assert body["config"]["api_key"] == MASK
+        assert self.ENV_VALUE not in json.dumps(body)
+
+    def test_env_overridden_keys_names_exactly_the_env_controlled_keys(self, mask_client, monkeypatch):
+        monkeypatch.setenv("WEATHER_API_KEY", self.ENV_VALUE)
+
+        body = mask_client.get("/plugins/weather").json()
+
+        assert body["env_overridden_keys"] == ["api_key"]
+
+    def test_saving_the_masked_form_persists_the_stored_secret_not_the_env_value(
+        self, mask_client, real_config, monkeypatch
+    ):
+        monkeypatch.setenv("WEATHER_API_KEY", self.ENV_VALUE)
+
+        mask_client.put(
+            "/plugins/weather/config",
+            json={"config": {"enabled": True, "api_key": MASK, "location": "Chicago, IL"}},
+        )
+
+        assert _stored(real_config, "weather")["api_key"] == REAL_SECRET
+        assert _stored(real_config, "weather")["api_key"] != self.ENV_VALUE
+
+    def test_the_live_plugin_config_keeps_the_env_value_after_the_save(self, mask_client, registry, monkeypatch):
+        monkeypatch.setenv("WEATHER_API_KEY", self.ENV_VALUE)
+
+        mask_client.put(
+            "/plugins/weather/config",
+            json={"config": {"enabled": True, "api_key": MASK, "location": "Chicago, IL"}},
+        )
+
+        # Last thing handed to the registry is the env-overlaid read: a save
+        # must not kill a working env-supplied credential until restart.
+        assert registry.applied[-1]["api_key"] == self.ENV_VALUE
+
+    def test_no_env_override_means_no_env_overridden_keys(self, mask_client):
+        body = mask_client.get("/plugins/weather").json()
+
+        assert body["env_overridden_keys"] == []
+
+
+# ── POST /plugins/{plugin_id}/enable and /disable ───────────────────────────
+
+
+class TestEnableDisable:
+    def test_enable_reports_the_plugin_enabled(self, client):
+        response = client.post("/plugins/alpha/enable")
+
+        assert response.status_code == 200
+        assert response.json()["plugin_id"] == "alpha"
+        assert response.json()["enabled"] is True
+
+    def test_enable_persists_the_flag(self, client, config_manager):
+        client.post("/plugins/alpha/enable")
+
+        assert config_manager.configs["alpha"]["enabled"] is True
+
+    def test_enable_404s_for_a_missing_plugin(self, client):
+        response = client.post("/plugins/missing/enable")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Plugin not found: missing"
+
+    def test_a_registry_refusal_is_a_400_naming_the_plugin(self, client, registry):
+        registry.enable_ok = False
+
+        response = client.post("/plugins/alpha/enable")
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Failed to enable plugin: alpha"
+
+    def test_disable_reports_the_plugin_disabled(self, client, config_manager):
+        response = client.post("/plugins/alpha/disable")
+
+        assert response.status_code == 200
+        assert response.json()["enabled"] is False
+        assert config_manager.configs["alpha"]["enabled"] is False
+
+
+# ── GET /plugins/{plugin_id}/data ───────────────────────────────────────────
+
+
+class TestPluginData:
+    def test_returns_the_fetched_data_and_formatted_lines(self, client):
+        body = client.get("/plugins/alpha/data").json()
+
+        assert body["plugin_id"] == "alpha"
+        assert body["available"] is True
+        assert body["data"] == {"value": 42}
+        assert body["formatted_lines"] == ["ALPHA 42"]
+        assert body["error"] is None
+
+    def test_404_for_a_plugin_that_is_not_installed(self, client):
+        response = client.get("/plugins/missing/data")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Plugin not found: missing"
+
+    def test_400_for_an_installed_but_disabled_plugin(self, client, registry):
+        registry.enabled["alpha"] = False
+
+        response = client.get("/plugins/alpha/data")
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Plugin not enabled: alpha"
+
+    def test_503_carries_the_plugin_reason_when_data_is_unavailable(self, client, registry):
+        registry.fetch_result = SimpleNamespace(
+            available=False, data=None, formatted_lines=None, error="not configured"
+        )
+
+        response = client.get("/plugins/alpha/data")
+
+        assert response.status_code == 503
+        assert response.json()["detail"] == "not configured"
+
+
+# ── GET /plugins/{plugin_id}/variables ──────────────────────────────────────
+
+
+class TestPluginVariables:
+    def test_returns_the_variables_max_lengths_and_colour_rules_schema(self, client):
+        body = client.get("/plugins/alpha/variables").json()
+
+        assert body["plugin_id"] == "alpha"
+        assert body["variables"] == {"value": {"description": "A value", "example": "X"}}
+        assert body["max_lengths"] == {"value": 10}
+        assert body["color_rules_schema"] == {}
+
+
+# ── POST /plugins/{plugin_id}/options/{options_id} ──────────────────────────
+
+
+class TestPluginOptions:
+    def test_returns_the_providers_options_by_value(self, client):
+        body = client.post("/plugins/alpha/options/symbols", json={"query": "AAP"}).json()
+
+        assert body["plugin_id"] == "alpha"
+        assert body["options_id"] == "symbols"
+        assert body["options"] == [
+            {
+                "value": "AAPL",
+                "label": "Apple",
+                "description": None,
+                "group": None,
+                "preview": None,
+                "disabled": False,
+                "meta": None,
+            }
+        ]
+        assert body["error"] is None
+
+    def test_an_undeclared_provider_is_a_400_naming_it(self, client):
+        response = client.post("/plugins/alpha/options/not_declared", json={})
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Plugin 'alpha' does not declare options provider 'not_declared'"
+
+
+# ── /plugins/{plugin_id}/demo-page ──────────────────────────────────────────
+
+
+class TestDemoPage:
+    def test_get_reports_no_page_yet_but_a_template_for_this_device(self, client):
+        body = client.get("/plugins/alpha/demo-page").json()
+
+        assert body["exists"] is False
+        assert body["page_id"] is None
+        assert body["has_demo_template"] is True
+
+    def test_get_reports_no_template_for_a_plugin_without_a_demo(self, client):
+        body = client.get("/plugins/norecv/demo-page").json()
+
+        assert body == {"exists": False, "page_id": None, "has_demo_template": False}
+
+    def test_create_returns_the_created_page(self, client):
+        response = client.post("/plugins/alpha/demo-page?device_type=flagship")
+
+        assert response.status_code == 200
+        assert response.json()["page"]["id"] == "demo-page-1"
+        assert response.json()["page"]["name"] == "Alpha Demo"
+
+    def test_create_400s_for_a_plugin_that_ships_no_demo(self, client):
+        response = client.post("/plugins/norecv/demo-page")
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Plugin 'norecv' does not include a demo page template."
+
+
+# ── /plugins/{plugin_id}/instances ──────────────────────────────────────────
+
+
+class TestInstances:
+    def test_list_returns_the_instances_of_the_base_plugin(self, client):
+        body = client.get("/plugins/alpha/instances").json()
+
+        assert body["plugin_id"] == "alpha"
+        assert body["instances"] == [{"label": "work", "enabled": False}]
+        assert body["total"] == 1
+
+    def test_create_reports_the_normalized_label_and_compound_key(self, client):
+        response = client.post("/plugins/alpha/instances", json={"label": "office"})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["plugin_id"] == "alpha"
+        assert body["instance_label"] == "office"
+        assert body["instance_key"] == "alpha:office"
+
+    def test_create_seeds_a_disabled_config_for_the_new_instance(self, client, config_manager):
+        client.post("/plugins/alpha/instances", json={"label": "office"})
+
+        assert config_manager.configs["alpha:office"] == {"enabled": False}
+
+    def test_a_rejected_label_is_a_400_carrying_the_registry_reason(self, client):
+        response = client.post("/plugins/alpha/instances", json={"label": "bad label"})
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid instance label"
+
+    def test_delete_reports_the_key_it_removed(self, client):
+        response = client.delete("/plugins/alpha/instances/work")
+
+        assert response.status_code == 200
+        assert response.json()["instance_key"] == "alpha:work"
+
+    def test_delete_purges_the_config_and_tombstones_the_key(self, client, config_manager):
+        config_manager.configs["alpha:work"] = {"enabled": True}
+
+        client.delete("/plugins/alpha/instances/work")
+
+        assert "alpha:work" not in config_manager.configs
+        assert "alpha:work" in config_manager.removed
+
+
+# ── POST /plugins/{plugin_id}/receive ───────────────────────────────────────
+
+
+class TestReceivePayload:
+    def test_a_supported_plugin_accepts_the_payload(self, client, registry):
+        registry.plugins["alpha"].receive_payload = Mock(return_value=None)
+
+        response = client.post("/plugins/alpha/receive", json={"hello": "world"})
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+        assert registry.plugins["alpha"].receive_payload.call_args[0][0] == {"hello": "world"}
+
+    def test_405_when_the_plugin_does_not_implement_receive(self, client, registry):
+        registry.plugins["alpha"].receive_payload = Mock(side_effect=NotImplementedError())
+
+        response = client.post("/plugins/alpha/receive", json={})
+
+        assert response.status_code == 405
+        assert response.json()["detail"] == "Plugin 'alpha' does not support receive"
+
+    def test_403_when_the_plugin_rejects_the_signature(self, client, registry):
+        registry.plugins["alpha"].receive_payload = Mock(side_effect=PermissionError("bad signature"))
+
+        response = client.post("/plugins/alpha/receive", json={})
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "bad signature"
+
+    def test_400_for_a_body_that_is_not_json(self, client):
+        response = client.post("/plugins/alpha/receive", content=b"not json")
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Request body must be valid JSON"
+
+    def test_400_for_a_disabled_plugin(self, client, registry):
+        registry.enabled["alpha"] = False
+
+        response = client.post("/plugins/alpha/receive", json={})
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Plugin not enabled: alpha"
+
+
+# ── Install / uninstall / update ────────────────────────────────────────────
+
+
+class TestInstall:
+    def test_registry_install_reports_the_installed_plugin_id(self, client):
+        response = client.post("/plugins/registry/beta/install")
+
+        assert response.status_code == 200
+        assert response.json()["plugin_id"] == "beta"
+
+    def test_a_registry_install_failure_is_a_400_carrying_the_reason(self, client):
+        response = client.post("/plugins/registry/nope/install")
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Plugin 'nope' not found in the registry"
+
+    def test_a_git_install_derives_the_plugin_id_from_the_repo_name(self, client):
+        response = client.post(
+            "/plugins/install",
+            json={"repository": "https://github.com/example/fiestaboard-plugin--gamma"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["plugin_id"] == "gamma"
+
+    def test_a_malformed_branch_is_rejected_before_any_clone(self, client):
+        response = client.post(
+            "/plugins/install",
+            json={"repository": "https://github.com/example/repo", "branch": "--upload-pack=evil"},
+        )
+
+        assert response.status_code == 400
+
+    def test_a_malformed_plugin_id_is_rejected(self, client):
+        response = client.post(
+            "/plugins/install",
+            json={"repository": "https://github.com/example/repo", "plugin_id": "Bad-Id"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "plugin_id may contain only lowercase letters, digits, and underscores"
+
+
+class TestUninstall:
+    def test_uninstalling_an_external_plugin_reports_its_id(self, client):
+        response = client.delete("/plugins/ext_plugin/uninstall")
+
+        assert response.status_code == 200
+        assert response.json()["plugin_id"] == "ext_plugin"
+
+    def test_a_builtin_refusal_is_a_400_carrying_the_reason(self, client):
+        response = client.delete("/plugins/alpha/uninstall")
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Plugin 'alpha' is a built-in plugin"
+
+
+class TestUpdates:
+    def test_the_update_check_reports_how_many_were_checked_and_which_have_updates(self, client):
+        body = client.post("/plugins/updates/check").json()
+
+        assert body["checked"] == 2
+        assert body["updates_available"] == ["ext_plugin"]
+
+    def test_updating_a_plugin_with_no_source_404s(self, client):
+        response = client.post("/plugins/nosource/update")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Plugin 'nosource' not found."
+
+    def test_updating_a_builtin_is_a_400_saying_so(self, client):
+        response = client.post("/plugins/alpha/update")
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Plugin 'alpha' is a built-in plugin and cannot be updated this way."
+
+    def test_apply_all_with_nothing_pending_says_so(self, client, registry):
+        registry.update_status = {"ext_plugin": False}
+
+        body = client.post("/plugins/updates/apply").json()
+
+        assert body["updated"] == []
+        assert body["failed"] == {}
+        assert body["message"] == "No updates available."

--- a/tests/test_plugins_contract.py
+++ b/tests/test_plugins_contract.py
@@ -22,6 +22,34 @@ what stop that from happening a third time:
    and their values never appear in ``config``.
 
 Covers all 25 routes the ``plugins`` router serves, success and failure paths.
+
+Re-pinned by the conventions pass in the following commit. What deliberately
+changed, and nothing else:
+
+* Creates answer **201**: ``POST /plugins/{id}/instances``,
+  ``POST /plugins/{id}/demo-page``, ``POST /plugins/install`` and
+  ``POST /plugins/registry/{id}/install`` — conventions doc, "Status codes".
+* ``"status": "success"`` is gone from the config-update, enable, disable,
+  instance create/delete, install, uninstall and update bodies. The status
+  code already carried it.
+* ``POST /plugins/{id}/demo-page`` reports ``recreated: bool`` instead of
+  ``status: "created" | "recreated"``.
+* ``POST /plugins/{id}/receive`` **keeps** its ``{"status": "ok"}`` — it is a
+  webhook target for third-party systems this repo cannot update in lockstep —
+  and gains ``plugin_id`` so the ack names what it acked.
+* The 400 on schema validation now carries ``detail.message`` alongside
+  ``detail.errors``; a dict detail with no message is the exact anti-pattern
+  the conventions doc bans.
+* ``GET /plugins/errors`` gains ``fetch_breakers``, exposing
+  ``registry.get_fetch_breaker_status()`` for the first time.
+* Registry entries and instance infos always carry their full declared key
+  set (defaults where the source is silent) instead of whatever keys the
+  producer happened to include — recipe addendum 4, the "sometimes-absent
+  key" anti-pattern.
+
+Every other value assertion — ids, masked secrets, env-override behavior,
+error strings, the 400/403/404/405/503 status codes — is unchanged from the
+pre-conversion recording. None was weakened.
 """
 
 from __future__ import annotations
@@ -314,14 +342,14 @@ def client(_isolated_data_dir, registry, config_manager, page_service):
     from src.api_server import app
 
     with (
-        patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-        patch("src.api_server.get_plugin_registry", new=lambda: registry),
-        patch("src.api_server.get_config_manager", new=lambda: config_manager),
-        patch("src.api_server.reset_display_service", new=Mock()),
-        patch("src.api_server.reset_template_engine", new=Mock()),
-        patch("src.api_server.get_page_service", new=lambda: page_service),
-        patch("src.api_server._PLUGIN_OPTIONS_CACHE", new={}),
-        patch("src.api_server._plugin_options_last_refresh", new={}),
+        patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+        patch("src.plugins.routes.get_plugin_registry", new=lambda: registry),
+        patch("src.plugins.routes.get_config_manager", new=lambda: config_manager),
+        patch("src.plugins.routes.reset_display_service", new=Mock()),
+        patch("src.plugins.routes.reset_template_engine", new=Mock()),
+        patch("src.plugins.routes.get_page_service", new=lambda: page_service),
+        patch("src.plugins.options_runtime._PLUGIN_OPTIONS_CACHE", new={}),
+        patch("src.plugins.options_runtime._plugin_options_last_refresh", new={}),
     ):
         yield TestClient(app, raise_server_exceptions=False)
 
@@ -360,7 +388,7 @@ class TestListPlugins:
         assert ext["config"] == {}
 
     def test_503_when_the_plugin_system_failed_to_import(self, client):
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False):
+        with patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", False):
             response = client.get("/plugins")
 
         assert response.status_code == 503
@@ -388,6 +416,23 @@ class TestPluginErrors:
 
         assert body["errors"] == {"broken_plugin": ["ImportError: contract fixture"]}
 
+    def test_reports_the_fetch_circuit_breakers_holding_plugins_back(self, client):
+        """Run-time failures, not just load-time ones (new in this slice).
+
+        ``registry.get_fetch_breaker_status()`` shipped with the pool-
+        starvation fix (#1884) and nothing exposed it, so a plugin could sit
+        quarantined for minutes while the UI showed only stale variables.
+        """
+        body = client.get("/plugins/errors").json()
+
+        assert body["fetch_breakers"] == {
+            "slow_plugin": {
+                "consecutive_timeouts": 3,
+                "quarantined": True,
+                "cooldown_remaining_seconds": 42.5,
+            }
+        }
+
 
 # ── GET /plugins/registry ───────────────────────────────────────────────────
 
@@ -396,9 +441,16 @@ class TestRegistryListing:
     def test_returns_the_curated_entries_with_their_install_state(self, client):
         body = client.get("/plugins/registry").json()
 
-        assert body["entries"] == [
-            {"id": "beta", "name": "Beta", "installed": False, "repository": "fiestaboard-plugin--beta"}
-        ]
+        entry = body["entries"][0]
+        assert entry["id"] == "beta"
+        assert entry["name"] == "Beta"
+        assert entry["installed"] is False
+        assert entry["repository"] == "fiestaboard-plugin--beta"
+        # Always-present, never sometimes-absent: RegistryEntry declares the
+        # whole key set with defaults, so the marketplace card does not have
+        # to guess whether a missing `teaser` means "none" or "old payload".
+        assert entry["teaser"] == ""
+        assert entry["previews"] == []
 
 
 # ── GET /plugins/updates ────────────────────────────────────────────────────
@@ -441,7 +493,7 @@ class TestPluginDetail:
         assert body["demo_page_id"] is None
         assert body["base_plugin_id"] == "alpha"
         assert body["instance_label"] is None
-        assert body["instances"] == [{"label": "work", "enabled": False}]
+        assert body["instances"] == [{"label": "work", "key": None, "enabled": False, "has_config": False}]
 
     def test_404_names_the_missing_plugin(self, client):
         response = client.get("/plugins/missing")
@@ -499,6 +551,9 @@ class TestUpdateConfig:
 
         assert response.status_code == 400
         assert response.json()["detail"]["errors"] == ["api_key: does not match the schema"]
+        # A dict detail must carry a message key — an errors-only body is the
+        # anti-pattern API_CONVENTIONS.md bans.
+        assert response.json()["detail"]["message"] == "Configuration for 'alpha' failed validation."
 
 
 # ── The masking round-trip (the highest-stakes contract here) ───────────────
@@ -531,13 +586,13 @@ def mask_client(_isolated_data_dir, real_config, registry, page_service):
     from src.api_server import app
 
     with (
-        patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-        patch("src.api_server.get_plugin_registry", new=lambda: registry),
+        patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+        patch("src.plugins.routes.get_plugin_registry", new=lambda: registry),
         patch("src.plugins.get_plugin_registry", new=lambda: registry),
-        patch("src.api_server.get_config_manager", new=lambda: real_config),
-        patch("src.api_server.reset_display_service", new=Mock()),
-        patch("src.api_server.reset_template_engine", new=Mock()),
-        patch("src.api_server.get_page_service", new=lambda: page_service),
+        patch("src.plugins.routes.get_config_manager", new=lambda: real_config),
+        patch("src.plugins.routes.reset_display_service", new=Mock()),
+        patch("src.plugins.routes.reset_template_engine", new=Mock()),
+        patch("src.plugins.routes.get_page_service", new=lambda: page_service),
     ):
         registry.plugins["weather"] = Mock()
         registry.manifests["weather"] = registry.manifests["alpha"]
@@ -606,6 +661,25 @@ class TestEnvOverrideRoundTrip:
         # env value is not what would come back in the next save.
         assert body["config"]["api_key"] == MASK
         assert self.ENV_VALUE not in json.dumps(body)
+
+    def test_a_non_secret_env_override_is_not_baked_into_the_form(self, mask_client, monkeypatch):
+        """The masked keys hide this one, so it needs its own unmasked witness.
+
+        ``api_key`` is masked on the way out either way, so serving the
+        env-overlaid config instead of the stored one is invisible on that
+        field — a mutation that swaps ``include_env_overrides=False`` for the
+        default passes every other assertion in this class. ``location`` is
+        env-overridable and *not* sensitive, so it is where the difference
+        shows: if the overlay were served, the form would show the env value,
+        the user would save it back, and an env-supplied setting would be
+        frozen into config.json permanently (#1864 review).
+        """
+        monkeypatch.setenv("WEATHER_LOCATION", "Reykjavik, IS")
+
+        body = mask_client.get("/plugins/weather").json()
+
+        assert body["config"]["location"] == "New York, NY"
+        assert body["env_overridden_keys"] == ["location"]
 
     def test_env_overridden_keys_names_exactly_the_env_controlled_keys(self, mask_client, monkeypatch):
         monkeypatch.setenv("WEATHER_API_KEY", self.ENV_VALUE)
@@ -782,9 +856,10 @@ class TestDemoPage:
     def test_create_returns_the_created_page(self, client):
         response = client.post("/plugins/alpha/demo-page?device_type=flagship")
 
-        assert response.status_code == 200
+        assert response.status_code == 201
         assert response.json()["page"]["id"] == "demo-page-1"
         assert response.json()["page"]["name"] == "Alpha Demo"
+        assert response.json()["recreated"] is False
 
     def test_create_400s_for_a_plugin_that_ships_no_demo(self, client):
         response = client.post("/plugins/norecv/demo-page")
@@ -801,13 +876,13 @@ class TestInstances:
         body = client.get("/plugins/alpha/instances").json()
 
         assert body["plugin_id"] == "alpha"
-        assert body["instances"] == [{"label": "work", "enabled": False}]
+        assert body["instances"] == [{"label": "work", "key": None, "enabled": False, "has_config": False}]
         assert body["total"] == 1
 
     def test_create_reports_the_normalized_label_and_compound_key(self, client):
         response = client.post("/plugins/alpha/instances", json={"label": "office"})
 
-        assert response.status_code == 200
+        assert response.status_code == 201
         body = response.json()
         assert body["plugin_id"] == "alpha"
         assert body["instance_label"] == "office"
@@ -849,7 +924,7 @@ class TestReceivePayload:
         response = client.post("/plugins/alpha/receive", json={"hello": "world"})
 
         assert response.status_code == 200
-        assert response.json() == {"status": "ok"}
+        assert response.json() == {"status": "ok", "plugin_id": "alpha"}
         assert registry.plugins["alpha"].receive_payload.call_args[0][0] == {"hello": "world"}
 
     def test_405_when_the_plugin_does_not_implement_receive(self, client, registry):
@@ -890,7 +965,7 @@ class TestInstall:
     def test_registry_install_reports_the_installed_plugin_id(self, client):
         response = client.post("/plugins/registry/beta/install")
 
-        assert response.status_code == 200
+        assert response.status_code == 201
         assert response.json()["plugin_id"] == "beta"
 
     def test_a_registry_install_failure_is_a_400_carrying_the_reason(self, client):
@@ -905,7 +980,7 @@ class TestInstall:
             json={"repository": "https://github.com/example/fiestaboard-plugin--gamma"},
         )
 
-        assert response.status_code == 200
+        assert response.status_code == 201
         assert response.json()["plugin_id"] == "gamma"
 
     def test_a_malformed_branch_is_rejected_before_any_clone(self, client):

--- a/tests/test_plugins_decoupled.py
+++ b/tests/test_plugins_decoupled.py
@@ -1,0 +1,351 @@
+"""The plugins router must not depend on ``src.api_server`` (Phase 2 §2.3).
+
+The #1757 extraction moved the twenty-five plugin handlers out of the 10k-line
+``src/api_server.py`` but left **twenty-nine** call-time
+``from src.api_server import ...`` names behind — the heaviest of any router,
+thirteen of them just for the remote-options runtime — purely so the suite's
+``patch("src.api_server.<name>")`` targets kept resolving. That is not an
+extraction: importing the router was clean, but *serving a request* pulled the
+whole module — its route table, its background tasks, its MCP mount — back in,
+and the 2026-09 audit counted those seams going up 4.2x across Phase 1.
+
+This test pins the fix the honest way. In a fresh interpreter it imports the
+router, drives **all twenty-five** handlers end to end against patched
+canonical seams (``src.plugins.routes.<name>``), asserts the stubs really were
+driven — so a handler that silently no-op'd could not pass — and then asserts
+``src.api_server`` never entered ``sys.modules``.
+
+Importing the module alone would be a much weaker claim: the seams were call
+time, so a module-level import check passes with every one of them still in
+place.
+
+Where the collaborators went is tabulated in ``src/plugins/routes.py``'s
+module docstring, for the reader chasing a patch target.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SCRIPT = r"""
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import src.plugins.routes as routes
+from src.plugins.base import Option, OptionsResult
+from src.plugins.models import (
+    ExternalPluginInstallRequest,
+    PluginConfigRequest,
+    PluginInstanceCreateRequest,
+    PluginOptionsRequest,
+)
+
+assert "src.api_server" not in sys.modules, "importing the plugins router must not import api_server"
+
+
+def call(coro):
+    return asyncio.run(coro)
+
+
+MANIFEST = SimpleNamespace(
+    name="Alpha",
+    version="1.0.0",
+    description="Decoupled fixture",
+    author="Fixtures",
+    icon="sparkles",
+    category="utility",
+    plugin_type="data",
+    settings_schema={
+        "type": "object",
+        "properties": {
+            "symbols": {
+                "type": "array",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "symbols", "cache_seconds": 0},
+            }
+        },
+    },
+    max_lengths={"value": 10},
+    env_vars=[],
+    documentation=None,
+    demo={"flagship": {"name": "Alpha Demo"}},
+    raw={"variables": {"value": {"description": "A value"}}, "color_rules_schema": {}},
+)
+
+registry = MagicMock()
+registry.list_plugins.return_value = [
+    {"id": "alpha", "name": "Alpha", "version": "1.0.0", "description": "", "enabled": True}
+]
+registry.get_all_variables.return_value = {"alpha": {"value": {}}}
+registry.get_all_max_lengths.return_value = {"alpha": {"value": 10}}
+registry.get_load_errors.return_value = {"broken": ["ImportError"]}
+registry.get_fetch_breaker_status.return_value = {
+    "slow": {"consecutive_timeouts": 2, "quarantined": False, "cooldown_remaining_seconds": 0.0}
+}
+registry.get_registry_entries.return_value = [{"id": "beta", "name": "Beta", "installed": False}]
+registry.get_update_status.return_value = {"ext": True}
+registry.get_update_blocked_reasons.return_value = {}
+registry.get_manifest.return_value = MANIFEST
+registry.get_plugin.return_value = MagicMock()
+registry.is_enabled.return_value = True
+registry.parse_instance_key.side_effect = lambda pid: (pid.split(":")[0], (pid.split(":")[1:] or [None])[0])
+registry.make_instance_key.side_effect = lambda base, label: f"{base}:{label}"
+registry.list_instances.return_value = [{"label": "work", "key": "alpha:work", "enabled": False}]
+registry.create_instance.return_value = []
+registry.apply_stored_config.return_value = []
+registry.delete_instance.return_value = []
+registry.set_plugin_config.return_value = []
+registry.enable_plugin.return_value = True
+registry.disable_plugin.return_value = True
+registry.install_from_registry.return_value = []
+registry.install_from_git.return_value = []
+registry.uninstall_external_plugin.return_value = []
+registry.check_for_updates.return_value = {"ext": True, "quiet": False}
+registry.get_plugin_config.return_value = {"api_key": "stored"}
+registry.get_plugin_options.return_value = OptionsResult(options=[Option(value="AAPL", label="Apple")])
+registry.fetch_plugin_data.return_value = SimpleNamespace(
+    available=True, data={"v": 1}, formatted_lines=["ALPHA"], error=None
+)
+registry.get_plugin_source.return_value = SimpleNamespace(source_type="git", local_path="/nope")
+
+config_manager = MagicMock()
+config_manager.get_plugin_config.return_value = {"api_key": "stored", "location": "NYC"}
+config_manager.get_plugin_env_overrides.return_value = {"api_key": "from-env"}
+config_manager._mask_sensitive.side_effect = lambda cfg, path="": {
+    k: ("***" if k == "api_key" else v) for k, v in cfg.items()
+}
+
+demo_page = SimpleNamespace(id="demo-1", model_dump=lambda: {"id": "demo-1", "name": "Alpha Demo"})
+page_service = MagicMock()
+page_service.get_demo_page.return_value = None
+page_service.create_demo_page.return_value = (demo_page, False)
+
+settings_service = MagicMock()
+settings_service.get_board_settings.return_value = SimpleNamespace(boards=[{"device_type": "flagship"}])
+
+template_engine = MagicMock()
+template_engine.get_available_variables.return_value = {}
+template_engine.get_variable_max_lengths.return_value = {}
+
+reset_display = MagicMock()
+reset_template = MagicMock()
+
+receive_request = MagicMock()
+
+
+async def _body():
+    return b'{"hello": "world"}'
+
+
+receive_request.body = _body
+receive_request.headers = {}
+
+with (
+    patch("src.plugins.routes.get_plugin_registry", return_value=registry),
+    patch("src.plugins.routes.get_config_manager", return_value=config_manager),
+    patch("src.plugins.routes.get_page_service", return_value=page_service),
+    patch("src.plugins.routes.get_settings_service", return_value=settings_service),
+    patch("src.plugins.routes.get_template_engine", return_value=template_engine),
+    patch("src.plugins.routes.reset_display_service", reset_display),
+    patch("src.plugins.routes.reset_template_engine", reset_template),
+):
+    # 1. GET /plugins
+    listed = call(routes.list_plugins())
+    assert listed.total == 1 and listed.plugins[0].id == "alpha", listed
+    assert listed.plugins[0].config["api_key"] == "***", listed
+
+    # 2. GET /plugins/variables/all
+    variables = call(routes.get_all_plugin_variables())
+    assert variables.plugin_system_enabled is True, variables
+
+    # 3. GET /plugins/errors
+    plugin_errors = call(routes.get_plugin_errors())
+    assert plugin_errors.errors == {"broken": ["ImportError"]}, plugin_errors
+    assert plugin_errors.fetch_breakers["slow"].consecutive_timeouts == 2, plugin_errors
+
+    # 4. GET /plugins/registry
+    entries = call(routes.list_registry_plugins())
+    assert entries.entries[0].id == "beta", entries
+
+    # 5. GET /plugins/updates
+    updates = call(routes.get_plugin_updates())
+    assert updates.updates == {"ext": True}, updates
+
+    # 6. GET /plugins/{id}
+    detail = call(routes.get_plugin("alpha"))
+    assert detail.id == "alpha" and detail.config["api_key"] == "***", detail
+    assert detail.env_overridden_keys == ["api_key"], detail
+
+    # 7. GET /plugins/{id}/manifest
+    manifest = call(routes.get_plugin_manifest("alpha"))
+    assert manifest.variables == {"value": {"description": "A value"}}, manifest
+
+    # 8. PUT /plugins/{id}/config
+    saved = call(routes.update_plugin_config("alpha", PluginConfigRequest(config={"api_key": "***"})))
+    assert saved.plugin_id == "alpha" and saved.config["api_key"] == "***", saved
+
+    # 9/10. enable + disable
+    assert call(routes.enable_plugin("alpha")).enabled is True
+    assert call(routes.disable_plugin("alpha")).enabled is False
+
+    # 11. GET /plugins/{id}/data
+    data = call(routes.get_plugin_data("alpha"))
+    assert data.formatted_lines == ["ALPHA"], data
+
+    # 12. GET /plugins/{id}/variables
+    plugin_vars = call(routes.get_plugin_variables("alpha"))
+    assert plugin_vars.plugin_id == "alpha", plugin_vars
+
+    # 13. POST /plugins/{id}/options/{options_id}
+    options = call(routes.get_plugin_options_endpoint("alpha", "symbols", PluginOptionsRequest()))
+    assert [o.value for o in options.options] == ["AAPL"], options
+
+    # 14/15. demo pages
+    demo = call(routes.get_plugin_demo_page("alpha"))
+    assert demo.has_demo_template is True, demo
+    created_demo = call(routes.create_plugin_demo_page("alpha"))
+    assert created_demo.page["id"] == "demo-1" and created_demo.recreated is False, created_demo
+
+    # 16/17/18. instances
+    instances = call(routes.list_plugin_instances("alpha"))
+    assert instances.total == 1, instances
+    created = call(routes.create_plugin_instance("alpha", PluginInstanceCreateRequest(label="office")))
+    assert created.instance_key == "alpha:office", created
+    deleted = call(routes.delete_plugin_instance("alpha", "office"))
+    assert deleted.instance_key == "alpha:office", deleted
+
+    # 19. POST /plugins/{id}/receive
+    received = call(routes.receive_plugin_payload("alpha", receive_request))
+    assert received.status == "ok" and received.plugin_id == "alpha", received
+
+    # 20/21. installs
+    from_registry = call(routes.install_registry_plugin("beta"))
+    assert from_registry.plugin_id == "beta", from_registry
+    from_git = call(
+        routes.install_external_plugin(
+            ExternalPluginInstallRequest(repository="https://example.com/fiestaboard-plugin--gamma")
+        )
+    )
+    assert from_git.plugin_id == "gamma", from_git
+
+    # 22. DELETE /plugins/{id}/uninstall
+    uninstalled = call(routes.uninstall_external_plugin("ext"))
+    assert uninstalled.plugin_id == "ext", uninstalled
+
+    # 23. POST /plugins/updates/check
+    checked = call(routes.trigger_plugin_update_check())
+    assert checked.checked == 2 and checked.updates_available == ["ext"], checked
+
+    # 24. POST /plugins/{id}/update
+    with patch("src.plugins.service.PluginService._validated_update_path"), patch(
+        "src.plugins.sources.clone_or_update_repo", return_value=(True, "")
+    ):
+        registry.reload_plugin.return_value = object()
+        updated = call(routes.update_plugin("ext"))
+    assert updated.plugin_id == "ext", updated
+
+    # 25. POST /plugins/updates/apply
+    registry.get_update_status.return_value = {"ext": False}
+    applied = call(routes.apply_all_plugin_updates())
+    assert applied.updated == [] and applied.message == "No updates available.", applied
+
+# Not vacuous: every handler really drove its collaborator. A handler that
+# silently returned a canned value would fail here even though its assertion
+# above passed.
+registry.list_plugins.assert_called()  # GET /plugins, and again by uninstall
+registry.get_load_errors.assert_called_once()
+registry.get_fetch_breaker_status.assert_called_once()
+registry.get_registry_entries.assert_called_once()
+registry.set_plugin_config.assert_called()
+registry.enable_plugin.assert_called()
+registry.disable_plugin.assert_called_once_with("alpha")
+registry.fetch_plugin_data.assert_called_once_with("alpha")
+registry.get_plugin_options.assert_called_once()
+registry.create_instance.assert_called_once_with("alpha", "office")
+registry.delete_instance.assert_called_once_with("alpha", "office")
+registry.install_from_registry.assert_called_once_with("beta")
+registry.install_from_git.assert_called_once()
+registry.uninstall_external_plugin.assert_called_once_with("ext")
+registry.check_for_updates.assert_called_once()
+config_manager.set_plugin_config.assert_called()
+config_manager.get_plugin_env_overrides.assert_called()
+page_service.create_demo_page.assert_called_once()
+settings_service.get_board_settings.assert_called_once()
+assert reset_display.call_count >= 4, reset_display.call_count
+assert reset_template.call_count >= 4, reset_template.call_count
+
+assert "src.api_server" not in sys.modules, (
+    "a plugins handler imported src.api_server — the call-time seam regrew"
+)
+print("DECOUPLED")
+"""
+
+
+def test_plugins_router_serves_every_route_without_importing_api_server():
+    result = subprocess.run(
+        [sys.executable, "-c", SCRIPT],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    assert "DECOUPLED" in result.stdout
+
+
+def test_plugins_router_source_declares_no_api_server_import():
+    """A static backstop over every branch, not just the exercised ones.
+
+    The subprocess test above can only catch a seam on a code path it drives.
+    This walks the AST of every module in the package, so an
+    ``import api_server`` hidden inside a rarely-taken ``except`` branch fails
+    the build too.
+    """
+    import ast
+
+    offenders: list[str] = []
+    for path in sorted((REPO_ROOT / "src" / "plugins").glob("*.py")):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                offenders += [f"{path.name}: {a.name}" for a in node.names if "api_server" in a.name]
+            elif isinstance(node, ast.ImportFrom) and "api_server" in (node.module or ""):
+                offenders.append(f"{path.name}: {node.module}")
+
+    assert offenders == [], f"src/plugins/ imports api_server: {offenders}"
+
+
+def test_the_plugin_service_raises_no_transport_exception():
+    """Layering: the service names failures, the router picks status codes.
+
+    ``PluginService`` was the one service in the tree raising
+    ``fastapi.HTTPException`` — 25 sites — which is the violation the 2026-09
+    audit called out. A static check because a runtime one would only cover
+    the raise sites a test happens to reach.
+    """
+    import ast
+
+    source = (REPO_ROOT / "src" / "plugins" / "service.py").read_text()
+    tree = ast.parse(source)
+
+    fastapi_imports = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and (node.module or "").startswith("fastapi")
+    ]
+    assert fastapi_imports == [], "src/plugins/service.py must not import fastapi"
+
+    raised = {
+        node.exc.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Raise) and isinstance(node.exc, ast.Call) and isinstance(node.exc.func, ast.Name)
+    }
+    assert "HTTPException" not in raised, f"service raises HTTPException; it raises {sorted(raised)}"
+    assert raised, "the service raises nothing — this test would be vacuous"

--- a/tests/test_response_shape_goldens.py
+++ b/tests/test_response_shape_goldens.py
@@ -564,7 +564,7 @@ def test_collections_response_shapes():
 #
 # The plugin routes reach network (git clones, upstream APIs) and the live
 # registry, so this scenario patches the same seams the rest of the API suite
-# patches — ``src.api_server.get_plugin_registry`` / ``get_config_manager`` /
+# patches — ``src.plugins.routes.get_plugin_registry`` / ``get_config_manager`` /
 # ``reset_display_service`` / ``reset_template_engine`` /
 # ``PLUGIN_SYSTEM_AVAILABLE`` — with deterministic stubs. The recorded shapes
 # are of the stub-driven responses; identical stubs re-drive identical shapes
@@ -673,6 +673,15 @@ class _GoldenRegistry:
 
     def get_load_errors(self) -> dict[str, Any]:
         return {"broken_plugin": ["ImportError: golden fixture"]}
+
+    def get_fetch_breaker_status(self) -> dict[str, dict[str, Any]]:
+        return {
+            "slow_plugin": {
+                "consecutive_timeouts": 3,
+                "quarantined": True,
+                "cooldown_remaining_seconds": 42.5,
+            }
+        }
 
     def get_registry_entries(self) -> list[dict[str, Any]]:
         return [{"id": "beta", "name": "Beta", "installed": False, "repository": "fiestaboard-plugin--beta"}]
@@ -807,17 +816,17 @@ def test_plugins_response_shapes():
     )
 
     with (
-        patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-        patch("src.api_server.get_plugin_registry", new=lambda: registry),
-        patch("src.api_server.get_config_manager", new=lambda: config_manager),
-        patch("src.api_server.reset_display_service", new=Mock()),
-        patch("src.api_server.reset_template_engine", new=Mock()),
-        patch("src.api_server.get_page_service", new=lambda: page_service),
+        patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+        patch("src.plugins.routes.get_plugin_registry", new=lambda: registry),
+        patch("src.plugins.routes.get_config_manager", new=lambda: config_manager),
+        patch("src.plugins.routes.reset_display_service", new=Mock()),
+        patch("src.plugins.routes.reset_template_engine", new=Mock()),
+        patch("src.plugins.routes.get_page_service", new=lambda: page_service),
         # Process-global options caches: isolate the scenario from other tests.
-        patch("src.api_server._PLUGIN_OPTIONS_CACHE", new={}),
-        patch("src.api_server._plugin_options_last_refresh", new={}),
+        patch("src.plugins.options_runtime._PLUGIN_OPTIONS_CACHE", new={}),
+        patch("src.plugins.options_runtime._plugin_options_last_refresh", new={}),
     ):
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False):
+        with patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", False):
             rec.hit("plugin_system_unavailable", "GET", "/plugins")
 
         rec.hit("list_plugins", "GET", "/plugins")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -31,7 +31,10 @@ def client():
 @pytest.fixture
 def mock_plugin_registry_secure():
     """Mock plugin registry that returns None for unknown/traversal plugin IDs."""
-    with patch("src.api_server.get_plugin_registry") as mock_get, patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True):
+    with (
+        patch("src.plugins.routes.get_plugin_registry") as mock_get,
+        patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+    ):
         reg = Mock()
         reg.get_manifest.return_value = None
         reg.get_plugin.return_value = None
@@ -47,9 +50,9 @@ def mock_plugin_registry_secure():
 def mock_plugin_with_sensitive_config():
     """Mock plugin registry with a plugin that has sensitive config fields."""
     with (
-        patch("src.api_server.get_plugin_registry") as mock_get,
-        patch("src.api_server.get_config_manager") as mock_cm_get,
-        patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+        patch("src.plugins.routes.get_plugin_registry") as mock_get,
+        patch("src.plugins.routes.get_config_manager") as mock_cm_get,
+        patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
     ):
         reg = Mock()
         manifest = Mock()
@@ -186,7 +189,7 @@ class TestInputValidation:
 
     def test_put_plugin_config_malformed_json_returns_422(self, client):
         """PUT /plugins/{id}/config with malformed JSON returns 422."""
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True):
+        with patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True):
             response = client.put(
                 "/plugins/some_plugin/config",
                 content=b"not valid json {{{",
@@ -196,7 +199,7 @@ class TestInputValidation:
 
     def test_put_plugin_config_missing_config_field_returns_422(self, client):
         """PUT /plugins/{id}/config without 'config' key returns 422."""
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True):
+        with patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True):
             response = client.put(
                 "/plugins/some_plugin/config",
                 json={"wrong_key": {"setting": "value"}},
@@ -297,11 +300,11 @@ class TestPluginEnableDisableAPI:
     def test_enable_plugin_success_returns_correct_shape(self, client):
         """POST /plugins/{id}/enable for known plugin returns success shape."""
         with (
-            patch("src.api_server.get_plugin_registry") as mock_reg_get,
-            patch("src.api_server.get_config_manager") as mock_cm_get,
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.reset_display_service"),
-            patch("src.api_server.reset_template_engine"),
+            patch("src.plugins.routes.get_plugin_registry") as mock_reg_get,
+            patch("src.plugins.routes.get_config_manager") as mock_cm_get,
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.reset_display_service"),
+            patch("src.plugins.routes.reset_template_engine"),
         ):
             reg = Mock()
             reg.get_plugin.return_value = Mock()
@@ -312,18 +315,17 @@ class TestPluginEnableDisableAPI:
             response = client.post("/plugins/date_time/enable")
             assert response.status_code == 200
             data = response.json()
-            assert data["status"] == "success"
             assert data["plugin_id"] == "date_time"
             assert data["enabled"] is True
 
     def test_disable_plugin_success_returns_correct_shape(self, client):
         """POST /plugins/{id}/disable for known plugin returns success shape."""
         with (
-            patch("src.api_server.get_plugin_registry") as mock_reg_get,
-            patch("src.api_server.get_config_manager") as mock_cm_get,
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.reset_display_service"),
-            patch("src.api_server.reset_template_engine"),
+            patch("src.plugins.routes.get_plugin_registry") as mock_reg_get,
+            patch("src.plugins.routes.get_config_manager") as mock_cm_get,
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.reset_display_service"),
+            patch("src.plugins.routes.reset_template_engine"),
         ):
             reg = Mock()
             reg.get_plugin.return_value = Mock()
@@ -334,15 +336,14 @@ class TestPluginEnableDisableAPI:
             response = client.post("/plugins/date_time/disable")
             assert response.status_code == 200
             data = response.json()
-            assert data["status"] == "success"
             assert data["plugin_id"] == "date_time"
             assert data["enabled"] is False
 
     def test_enable_plugin_registry_failure_returns_400(self, client):
         """POST /plugins/{id}/enable when registry returns False gives 400."""
         with (
-            patch("src.api_server.get_plugin_registry") as mock_reg_get,
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry") as mock_reg_get,
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
         ):
             reg = Mock()
             reg.get_plugin.return_value = Mock()
@@ -422,8 +423,8 @@ class TestRefreshSecondsBypass:
     def test_put_config_with_below_minimum_refresh_returns_400(self, client):
         """PUT /plugins/{id}/config with refresh_seconds below minimum returns 400."""
         with (
-            patch("src.api_server.get_plugin_registry") as mock_reg_get,
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_plugin_registry") as mock_reg_get,
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
         ):
             reg = Mock()
             reg.get_plugin.return_value = Mock()
@@ -441,11 +442,11 @@ class TestRefreshSecondsBypass:
     def test_put_config_with_valid_refresh_succeeds(self, client):
         """PUT /plugins/{id}/config with valid refresh_seconds returns 200."""
         with (
-            patch("src.api_server.get_plugin_registry") as mock_reg_get,
-            patch("src.api_server.get_config_manager") as mock_cm_get,
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.reset_display_service"),
-            patch("src.api_server.reset_template_engine"),
+            patch("src.plugins.routes.get_plugin_registry") as mock_reg_get,
+            patch("src.plugins.routes.get_config_manager") as mock_cm_get,
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.reset_display_service"),
+            patch("src.plugins.routes.reset_template_engine"),
         ):
             reg = Mock()
             reg.get_plugin.return_value = Mock()
@@ -485,8 +486,8 @@ class TestSSRFProtection:
 
     def _post(self, client, url: str, mock_cm):
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
         ):
             return client.post("/generic-data/test-fetch", json={"url": url})
 
@@ -559,8 +560,8 @@ class TestSSRFProtection:
     def test_rejects_domain_resolving_to_private_ip(self, client, mock_cm):
         private_addr_info = _make_addr_info("10.0.0.5", 80)
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
             patch("socket.getaddrinfo", return_value=private_addr_info),
         ):
             resp = client.post("/generic-data/test-fetch", json={"url": "https://internal.corp/api"})
@@ -572,8 +573,8 @@ class TestSSRFProtection:
         import socket
 
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
             patch("socket.getaddrinfo", side_effect=socket.gaierror("no such host")),
         ):
             resp = client.post("/generic-data/test-fetch", json={"url": "https://no-such-host.invalid/api"})
@@ -587,8 +588,8 @@ class TestSSRFProtection:
         mock_resp.content = b'{"ok": true}'
         mock_resp.json.return_value = {"ok": True}
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
             patch("src.api_server._get_generic_data_allowed_hosts", return_value=["93.184.216.34"]),
             patch("requests.request", return_value=mock_resp),
         ):
@@ -601,8 +602,8 @@ class TestSSRFProtection:
         mock_resp.content = b'{"ok": true}'
         mock_resp.json.return_value = {"ok": True}
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
             patch("src.api_server._get_generic_data_allowed_hosts", return_value=["example.com"]),
             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO),
             patch("requests.request", return_value=mock_resp),
@@ -617,8 +618,8 @@ class TestSSRFProtection:
         mock_resp.content = b'{"ok": true}'
         mock_resp.json.return_value = {"ok": True}
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
             patch("src.api_server._get_generic_data_allowed_hosts", return_value=[]),
             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO),
             patch("requests.request", return_value=mock_resp),
@@ -629,8 +630,8 @@ class TestSSRFProtection:
     def test_rejects_host_not_in_allowlist(self, client, mock_cm):
         """When GENERIC_DATA_ALLOWED_HOSTS is set, hosts outside the list are rejected."""
         with (
-            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
-            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.plugins.routes.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.plugins.routes.get_config_manager", return_value=mock_cm),
             patch("src.api_server._get_generic_data_allowed_hosts", return_value=["myapi.com"]),
             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO),
         ):

--- a/web/app/routes/integrations._index.tsx
+++ b/web/app/routes/integrations._index.tsx
@@ -1111,7 +1111,7 @@ function InstalledPluginRow({
     setIsCreatingDemo(true);
     try {
       const result = await api.createPluginDemoPage(plugin.id);
-      const verb = result.status === "recreated" ? "recreated" : "created";
+      const verb = result.recreated ? "recreated" : "created";
       toast.success(`Demo page ${verb} for ${plugin.name}`);
       queryClient.invalidateQueries({ queryKey: ["plugin", plugin.id] });
       queryClient.invalidateQueries({ queryKey: ["pages"] });

--- a/web/src/__tests__/api-extended.test.ts
+++ b/web/src/__tests__/api-extended.test.ts
@@ -842,7 +842,7 @@ describe("API Extended Tests", () => {
       server.use(
         http.put(`${API_BASE}/plugins/:pluginId/config`, async ({ request }) => {
           capturedBody = await request.json();
-          return HttpResponse.json({ status: "success", plugin_id: "test", config: {} });
+          return HttpResponse.json({ plugin_id: "test", config: {} });
         }),
       );
       await api.updatePluginConfig("test", { key: "value" });
@@ -852,7 +852,7 @@ describe("API Extended Tests", () => {
     it("enablePlugin sends POST", async () => {
       server.use(
         http.post(`${API_BASE}/plugins/:pluginId/enable`, () =>
-          HttpResponse.json({ status: "success", plugin_id: "test", enabled: true }),
+          HttpResponse.json({ plugin_id: "test", enabled: true }),
         ),
       );
       const result = await api.enablePlugin("test");
@@ -862,7 +862,7 @@ describe("API Extended Tests", () => {
     it("disablePlugin sends POST", async () => {
       server.use(
         http.post(`${API_BASE}/plugins/:pluginId/disable`, () =>
-          HttpResponse.json({ status: "success", plugin_id: "test", enabled: false }),
+          HttpResponse.json({ plugin_id: "test", enabled: false }),
         ),
       );
       const result = await api.disablePlugin("test");
@@ -901,10 +901,29 @@ describe("API Extended Tests", () => {
 
     it("getPluginErrors returns errors", async () => {
       server.use(
-        http.get(`${API_BASE}/plugins/errors`, () => HttpResponse.json({ errors: {}, plugin_system_enabled: true })),
+        http.get(`${API_BASE}/plugins/errors`, () =>
+          HttpResponse.json({ errors: {}, fetch_breakers: {}, plugin_system_enabled: true }),
+        ),
       );
       const result = await api.getPluginErrors();
       expect(result.plugin_system_enabled).toBe(true);
+    });
+
+    it("getPluginErrors reports plugins the fetch circuit breaker is holding back", async () => {
+      server.use(
+        http.get(`${API_BASE}/plugins/errors`, () =>
+          HttpResponse.json({
+            errors: {},
+            fetch_breakers: {
+              stocks: { consecutive_timeouts: 3, quarantined: true, cooldown_remaining_seconds: 42.5 },
+            },
+            plugin_system_enabled: true,
+          }),
+        ),
+      );
+      const result = await api.getPluginErrors();
+      expect(result.fetch_breakers.stocks.quarantined).toBe(true);
+      expect(result.fetch_breakers.stocks.consecutive_timeouts).toBe(3);
     });
   });
 

--- a/web/src/__tests__/mocks/handlers.ts
+++ b/web/src/__tests__/mocks/handlers.ts
@@ -258,12 +258,14 @@ export const mockSilenceSchedulePlugin: PluginDetailResponse = {
   author: "FiestaBoard",
   icon: "moon",
   category: "utility",
+  plugin_type: "data",
   enabled: true,
   config: {
     enabled: false,
     start_time: "04:00+00:00",
     end_time: "15:00+00:00",
   },
+  env_overridden_keys: [],
   settings_schema: {
     type: "object",
     properties: {
@@ -278,6 +280,9 @@ export const mockSilenceSchedulePlugin: PluginDetailResponse = {
   documentation: "",
   has_demo: false,
   demo_page_id: null,
+  instance_label: null,
+  base_plugin_id: "silence_schedule",
+  instances: [],
 };
 
 // Store for tracking request bodies in tests
@@ -761,13 +766,20 @@ export const handlers = [
       author: "Unknown",
       icon: "puzzle",
       category: "utility",
+      plugin_type: "data",
       enabled: false,
       config: {},
+      env_overridden_keys: [],
       settings_schema: {},
       variables: {},
       max_lengths: {},
       env_vars: [],
       documentation: "",
+      has_demo: false,
+      demo_page_id: null,
+      instance_label: null,
+      base_plugin_id: String(pluginId),
+      instances: [],
     });
   }),
 
@@ -817,7 +829,6 @@ export const handlers = [
     const { pluginId } = params;
     const body = (await request.json()) as { config: Record<string, unknown> };
     return HttpResponse.json({
-      status: "success",
       plugin_id: pluginId,
       config: body.config,
     });
@@ -827,7 +838,6 @@ export const handlers = [
     const { pluginId } = params;
     const body = (await request.json()) as { config: Record<string, unknown> };
     return HttpResponse.json({
-      status: "success",
       plugin_id: pluginId,
       config: body.config,
     });
@@ -839,6 +849,7 @@ export const handlers = [
     return HttpResponse.json({
       plugin_id: pluginId,
       instances: [],
+      total: 0,
     });
   }),
 
@@ -846,24 +857,23 @@ export const handlers = [
     const { pluginId } = params;
     const body = (await request.json()) as { label: string };
     const instanceKey = `${pluginId}:${body.label}`;
-    return HttpResponse.json({
-      status: "success",
-      plugin_id: pluginId,
-      instance_label: body.label,
-      instance_key: instanceKey,
-      message: `Instance "${body.label}" created for plugin "${pluginId}".`,
-    });
+    return HttpResponse.json(
+      {
+        plugin_id: pluginId,
+        instance_label: body.label,
+        instance_key: instanceKey,
+      },
+      { status: 201 },
+    );
   }),
 
   http.delete(`${API_BASE}/plugins/:pluginId/instances/:instanceLabel`, ({ params }) => {
     const { pluginId, instanceLabel } = params;
     const instanceKey = `${pluginId}:${instanceLabel}`;
     return HttpResponse.json({
-      status: "success",
       plugin_id: pluginId,
       instance_label: instanceLabel,
       instance_key: instanceKey,
-      message: `Instance "${instanceLabel}" of plugin "${pluginId}" deleted.`,
     });
   }),
 

--- a/web/src/__tests__/plugin-instances.test.ts
+++ b/web/src/__tests__/plugin-instances.test.ts
@@ -63,7 +63,6 @@ describe("Plugin Instance API", () => {
   describe("createPluginInstance", () => {
     it("creates an instance and returns correct shape", async () => {
       const result = await api.createPluginInstance("weather", "sf");
-      expect(result.status).toBe("success");
       expect(result.plugin_id).toBe("weather");
       expect(result.instance_label).toBe("sf");
       expect(result.instance_key).toBe("weather:sf");
@@ -75,13 +74,14 @@ describe("Plugin Instance API", () => {
         http.post(`${API_BASE}/plugins/:pluginId/instances`, async ({ request, params }) => {
           capturedBody = await request.json();
           const body = capturedBody as { label: string };
-          return HttpResponse.json({
-            status: "success",
-            plugin_id: params.pluginId,
-            instance_label: body.label,
-            instance_key: `${params.pluginId}:${body.label}`,
-            message: "created",
-          });
+          return HttpResponse.json(
+            {
+              plugin_id: params.pluginId,
+              instance_label: body.label,
+              instance_key: `${params.pluginId}:${body.label}`,
+            },
+            { status: 201 },
+          );
         }),
       );
       await api.createPluginInstance("weather", "prod");
@@ -118,7 +118,6 @@ describe("Plugin Instance API", () => {
   describe("deletePluginInstance", () => {
     it("deletes an instance and returns correct shape", async () => {
       const result = await api.deletePluginInstance("weather", "sf");
-      expect(result.status).toBe("success");
       expect(result.plugin_id).toBe("weather");
       expect(result.instance_label).toBe("sf");
       expect(result.instance_key).toBe("weather:sf");

--- a/web/src/lib/api/plugin-registry.ts
+++ b/web/src/lib/api/plugin-registry.ts
@@ -21,7 +21,7 @@ export interface RegistryEntry {
    * frame-by-frame board animation). Absent on registry payloads that predate
    * the field — treat missing as "data".
    */
-  plugin_type?: "data" | "transition";
+  plugin_type: "data" | "transition";
   /**
    * One-line board strip for the marketplace card, at most 15 tiles. Empty for
    * plugins that predate the previews contract.
@@ -33,22 +33,28 @@ export interface RegistryEntry {
 
 export interface RegistryListResponse {
   entries: RegistryEntry[];
+  plugin_system_enabled: boolean;
 }
 
 export interface PluginInstallResponse {
-  status: string;
   plugin_id: string;
   message: string;
 }
 
 export interface PluginUninstallResponse {
-  status: string;
   plugin_id: string;
   message: string;
 }
 
 export interface PluginUpdatesResponse {
   updates: Record<string, boolean>;
+  /**
+   * Why an upstream commit was not offered for a plugin — currently only
+   * "the incoming manifest needs a newer FiestaBoard core". Those plugins
+   * appear in `updates` as `false`; this is what lets the UI say why instead
+   * of looking stuck.
+   */
+  blocked: Record<string, string>;
 }
 
 export interface PluginUpdateCheckResponse {

--- a/web/src/lib/api/plugins.ts
+++ b/web/src/lib/api/plugins.ts
@@ -23,14 +23,22 @@ export interface PluginInfo {
    * installed one regardless of `enabled` — the UI must not offer a toggle
    * for them. Absent on responses that predate the field; treat as `"data"`.
    */
-  plugin_type?: "data" | "transition";
-  fiestaboard_version?: string;
+  plugin_type: "data" | "transition";
+  fiestaboard_version: string;
+  /** The stored configuration, with every sensitive value masked as `"***"`. */
   config: Record<string, unknown>;
-  source?: { source_type: "builtin" | "registry" | "external" | "git"; repository_url?: string; local_path?: string };
-  update_available?: boolean;
-  instance_label?: string | null;
-  base_plugin_id?: string;
-  settings_schema?: Record<string, unknown>;
+  source: {
+    source_type: "builtin" | "registry" | "external" | "git";
+    repository_url?: string;
+    local_path?: string;
+  } | null;
+  update_available: boolean;
+  /** Why an upstream commit was not offered; empty when nothing is blocked. */
+  update_blocked_reason: string;
+  supports_triggers: boolean;
+  instance_label: string | null;
+  base_plugin_id: string | null;
+  settings_schema: Record<string, unknown>;
 }
 
 export interface PluginsListResponse {
@@ -135,10 +143,23 @@ export interface PluginDetailResponse {
   version: string;
   description: string;
   author: string;
-  icon: string;
-  category: string;
+  icon: string | null;
+  category: string | null;
+  plugin_type: "data" | "transition";
   enabled: boolean;
+  /**
+   * The **stored** configuration with sensitive values replaced by `"***"`,
+   * deliberately without the environment overlay. Post it back as-is: the
+   * server resolves each `"***"` against the secret it already holds. Serving
+   * the overlay here would freeze env values into `config.json` on the next
+   * save.
+   */
   config: Record<string, unknown>;
+  /**
+   * Config keys whose live value currently comes from an environment
+   * variable. Their values are deliberately absent from `config`.
+   */
+  env_overridden_keys: string[];
   settings_schema: Record<string, unknown>;
   variables: Record<string, unknown>;
   max_lengths: Record<string, number>;
@@ -147,17 +168,17 @@ export interface PluginDetailResponse {
     required: boolean;
     description: string;
   }>;
-  documentation: string;
+  documentation: string | null;
   has_demo: boolean;
   demo_page_id: string | null;
-  instance_label?: string | null;
-  base_plugin_id?: string;
-  instances?: PluginInstanceInfo[];
+  instance_label: string | null;
+  base_plugin_id: string | null;
+  instances: PluginInstanceInfo[];
 }
 
 export interface PluginInstanceInfo {
   label: string;
-  key: string;
+  key: string | null;
   enabled: boolean;
   has_config: boolean;
 }
@@ -168,20 +189,15 @@ export interface PluginInstancesResponse {
   total: number;
 }
 
-export interface PluginInstanceCreateResponse {
-  status: string;
+/**
+ * `POST` and `DELETE` on `/plugins/{id}/instances` answer the same shape.
+ * `instance_label` is the *normalized* label the registry actually holds,
+ * which is not always the string that was sent.
+ */
+export interface PluginInstanceResponse {
   plugin_id: string;
   instance_label: string;
   instance_key: string;
-  message: string;
-}
-
-export interface PluginInstanceDeleteResponse {
-  status: string;
-  plugin_id: string;
-  instance_label: string;
-  instance_key: string;
-  message: string;
 }
 
 export interface PluginDemoPageResponse {
@@ -191,18 +207,18 @@ export interface PluginDemoPageResponse {
 }
 
 export interface PluginDemoPageCreateResponse {
-  status: "created" | "recreated";
+  /** True when an existing demo page for this device type was replaced. */
+  recreated: boolean;
   page: Page;
 }
 
 export interface PluginConfigUpdateResponse {
-  status: string;
   plugin_id: string;
+  /** The stored configuration, re-masked. Never echoes a real secret back. */
   config: Record<string, unknown>;
 }
 
 export interface PluginEnableResponse {
-  status: string;
   plugin_id: string;
   enabled: boolean;
 }
@@ -210,9 +226,10 @@ export interface PluginEnableResponse {
 export interface PluginDataResponse {
   plugin_id: string;
   available: boolean;
-  data: Record<string, unknown>;
-  formatted?: string;
-  error?: string;
+  data: Record<string, unknown> | null;
+  /** The plugin's rendered board lines. (Was mistyped as `formatted`.) */
+  formatted_lines: string[] | null;
+  error: string | null;
 }
 
 export interface PluginVariablesResponse {
@@ -228,8 +245,18 @@ export interface AllPluginVariablesResponse {
   plugin_system_enabled: boolean;
 }
 
+/** One plugin's standing with the data-fetch circuit breaker. */
+export interface FetchBreakerStatus {
+  consecutive_timeouts: number;
+  quarantined: boolean;
+  cooldown_remaining_seconds: number;
+}
+
 export interface PluginErrorsResponse {
+  /** Load-time failures: the plugin never imported. */
   errors: Record<string, string[]>;
+  /** Run-time failures: it imported, then stopped answering. */
+  fetch_breakers: Record<string, FetchBreakerStatus>;
   plugin_system_enabled: boolean;
 }
 
@@ -287,13 +314,13 @@ export const pluginsApi = {
   listPluginInstances: (pluginId: string) => fetchApi<PluginInstancesResponse>(`/plugins/${pluginId}/instances`),
 
   createPluginInstance: (pluginId: string, label: string) =>
-    fetchApi<PluginInstanceCreateResponse>(`/plugins/${pluginId}/instances`, {
+    fetchApi<PluginInstanceResponse>(`/plugins/${pluginId}/instances`, {
       method: "POST",
       body: JSON.stringify({ label }),
     }),
 
   deletePluginInstance: (pluginId: string, instanceLabel: string) =>
-    fetchApi<PluginInstanceDeleteResponse>(`/plugins/${pluginId}/instances/${instanceLabel}`, {
+    fetchApi<PluginInstanceResponse>(`/plugins/${pluginId}/instances/${instanceLabel}`, {
       method: "DELETE",
     }),
 };

--- a/web/tests/api-extended.spec.ts
+++ b/web/tests/api-extended.spec.ts
@@ -298,8 +298,10 @@ test.describe("API – Plugins (extended)", () => {
     });
     if (res.ok) {
       const data = await res.json();
-      expect(data.status).toBe("success");
+      // No "status" envelope since the plugins conventions pass; the 200
+      // carries that, and the body is the plugin id plus its masked config.
       expect(data.plugin_id).toBe("date_time");
+      expect(data).toHaveProperty("config");
     } else {
       expect(res.status).toBe(503);
     }

--- a/web/tests/plugin-management.spec.ts
+++ b/web/tests/plugin-management.spec.ts
@@ -94,8 +94,10 @@ test.describe("Plugin Management", () => {
     });
     if (res.ok) {
       const data = await res.json();
-      expect(data.status).toBe("success");
+      // No "status" envelope since the plugins conventions pass; the 200
+      // carries that, and the body is the plugin id plus its masked config.
       expect(data.plugin_id).toBe("date_time");
+      expect(data).toHaveProperty("config");
     } else {
       // Plugin system may not be fully available
       expect(res.status).toBe(503);


### PR DESCRIPTION
Phase 2 slice 4 — the largest extracted domain: **25 routes**, 43 golden records, and the `"***"` masking round-trip the 2026-09 audit called the highest-stakes contract in the codebase.

## Sizing, up front (recipe addendum 6)

The plan warned that plugins could be worse than pages on the web side if the settings UI read the masked-config round-trip back into form state. **It does not, and the web effort is about 0.45× pages** — 8 web files and 2 Playwright specs, against pages' 18 files + 17 specs.

Why it is small:

- `grep` for `"***"` across `web/src` and `web/app` returns **no hit in any plugin file**. The sentinel is seeded into form state from `GET /plugins/{id}`, posted back verbatim, and resolved entirely server-side. `handleSaveConfig` **discards** the `PUT` response (it invalidates and refetches), so the echoed config was never read into state.
- 23 of the 30 production call sites throw the response body away. Dropping the `{"status": "success"}` envelopes changed **one** consumer — the demo-page toast.
- `fetchApi` treats any 2xx as success and the Playwright helpers check `res.ok`, so the four 200 → 201 changes cost nothing on the client.

The one constraint the round-trip imposes: `PluginConfigRequest.config` must stay a free-form map. A per-plugin typed body would reject three asterisks where a URL or a number is declared — that is the single place a `typed_body` "fix" here would be a silent regression.

## Fail-first evidence

`"plugins"` added to `converted_domains` before any code change:

```
FAILED test_converted_domains_declare_response_models
  DELETE /plugins/{plugin_id}/instances/{instance_label}: no response_model= declared
  DELETE /plugins/{plugin_id}/uninstall: no response_model= declared
  GET /plugins/errors: no response_model= declared
  GET /plugins/registry: no response_model= declared
  GET /plugins/updates: no response_model= declared
  GET /plugins/variables/all: no response_model= declared
  GET /plugins/{plugin_id}/data: no response_model= declared
  GET /plugins/{plugin_id}/demo-page: no response_model= declared
  GET /plugins/{plugin_id}/instances: no response_model= declared
  GET /plugins/{plugin_id}/manifest: no response_model= declared
  GET /plugins/{plugin_id}/variables: no response_model= declared
  GET /plugins/{plugin_id}: no response_model= declared
  GET /plugins: no response_model= declared
  POST /plugins/install: no response_model= declared
  POST /plugins/registry/{plugin_id}/install: no response_model= declared
  POST /plugins/updates/apply: no response_model= declared
  POST /plugins/updates/check: no response_model= declared
  POST /plugins/{plugin_id}/demo-page: no response_model= declared
  POST /plugins/{plugin_id}/disable: no response_model= declared
  POST /plugins/{plugin_id}/enable: no response_model= declared
  POST /plugins/{plugin_id}/instances: no response_model= declared
  POST /plugins/{plugin_id}/options/{options_id}: no response_model= declared
  POST /plugins/{plugin_id}/receive: no response_model= declared
  POST /plugins/{plugin_id}/update: no response_model= declared
  PUT /plugins/{plugin_id}/config: no response_model= declared

FAILED test_converted_domains_never_return_200_on_failure
  POST /plugins/{plugin_id}/options/{options_id}: src/plugins/routes.py:531: return inside an except block -> `return stale`
  POST /plugins/{plugin_id}/options/{options_id}: src/plugins/routes.py:548: return inside an except block -> `return _envelope(error=str(e))`
  POST /plugins/{plugin_id}/options/{options_id}: src/plugins/routes.py:556: return inside an except block -> `return stale`

FAILED test_converted_domains_declare_error_responses
  ... the same 25 routes, "declares no 4xx in responses=" ...
```

`typed_body` passed already — the domain's one dict-shaped body is the plugin config, and it stays one deliberately.

## The masking contract, pinned by value

`tests/test_plugins_contract.py` (68 assertions across all 25 routes) drives the round-trip against a **real `ConfigManager` writing a real file**, not a mock's call log. It pins, by value:

1. a masked field posted back as `"***"` persists the **stored** secret — never the literal `"***"`, never the env value;
2. with `WEATHER_API_KEY` set, the persisted value stays the stored one while the config handed to the **live plugin** carries the env value;
3. `env_overridden_keys` names exactly the env-controlled keys, and the env value appears nowhere in the response.

Fixture note for reviewers: CI's platform job exports `WEATHER_API_KEY=test_key`, so the fixture deletes every `ENV_PLUGIN_OVERRIDES` variable first — otherwise "the stored value survived" is indistinguishable from "the ambient env value was written". That is also why each test sets its own override in the test body: a class-level autouse fixture runs *before* the config fixture and gets deleted again.

## Mutation proofs

Each mutant applied, output observed, reverted.

| # | Mutation | Result |
|---|---|---|
| 1 | Drop the un-mask in `update_plugin_config` | `test_the_sentinel_never_reaches_the_live_plugin` fails: `'***' == 'super-secret-key-abc123'` |
| 2 | Drop the env-overlay reseed of the live config | `test_the_live_plugin_config_keeps_the_env_value_after_the_save` fails: `'super-secret-key-abc123' == 'key-from-the-environment'` |
| 3 | Serve the env-overlaid config from `GET /plugins/{id}` | **caught nothing** — see below |
| 4 | Regrow a call-time `from src.api_server import ...` | both decoupled tests fail (sys.modules + AST backstop) |
| 5 | Drop `fetch_breakers` from `GET /plugins/errors` | contract, decoupled and shape-golden tests fail |
| 6 | Remove `response_model` **and** the return annotation from one route | ratchet fails naming it (below) |
| 7 | Call `fetch_plugin_data` inline again | `/health waited 5.03s behind the plugin data fetch — the event loop was blocked` / `assert 5.032923211008892 < 0.5` |

**Mutation 1 is worth reading twice.** Only *one* test failed, and it was about the live plugin — not the file. `ConfigManager` un-masks again on the way to disk, so the *persisted* secret survives while the running plugin authenticates with three asterisks. That asymmetry is exactly why a shape golden could not see #1743.

**Mutation 3 found a real hole in my own test suite.** Serving the env overlay from `GET /plugins/{id}` passed everything, because `api_key` is masked either way so the difference is invisible on that field. The regression it hides is real: a *non-sensitive* env-overridden key (`WEATHER_LOCATION`) would be shown in the form, saved back, and frozen into `config.json` permanently. Added `test_a_non_secret_env_override_is_not_baked_into_the_form`; the mutant now fails with `'Reykjavik, IS' == 'New York, NY'`. Without it the env half of this contract was decorative.

## Domain-specific work

### The service stops raising `HTTPException`

`PluginService` raised `fastapi.HTTPException` at 25 sites — the one service in the tree that knew a status code, and the one written during Phase 1 while the rule was being written down. It now raises the domain errors in `src/plugins/errors.py`, which carry **no status codes at all**; `routes.py` owns a single `_STATUS_BY_ERROR` table applied by `@plugin_errors_to_http`. `src/ops/executors.py` catches `PluginError` instead, so the MCP and chat surfaces no longer import a web framework to catch a plugin failure. `tests/test_plugins_decoupled.py` pins it statically: `service.py` may not import fastapi and may not raise `HTTPException`.

### `GET /plugins/{id}/data` is off the event loop

It was the last handler calling a plugin inline — the options runtime 170 lines away literally named it as the example not to copy. A plugin fetch is an outbound HTTP call, so an unresponsive upstream froze the whole process: no board driven, no UI, no `/health`. Now `asyncio.to_thread`, with a watchdog in the `tests/test_blocking_io_event_loop.py` style (mutation 7 above). The stale comment is gone.

### The fetch circuit breaker becomes observable

`registry.get_fetch_breaker_status()` shipped with the pool-starvation fix (#1884) and nothing exposed it — a plugin could sit quarantined for minutes while the UI showed only stale variables. `GET /plugins/errors` now serves it as `fetch_breakers` next to the load-time `errors`, because the UI asks one question ("what is wrong with my plugins?") and those are its two answers. Typed as `FetchBreakerStatus`, covered in the contract test, the decoupled test, the shape golden and a new vitest case.

### Addendum 4 — sometimes-absent keys

Registry entries, plugin summaries and instance infos previously carried whatever keys the producer happened to include. They now always carry their full declared key set with defaults, so the marketplace card no longer has to guess whether a missing `teaser` means "none" or "old payload". One test — `test_list_instances_success` — was asserting `instances[0]["instance_label"]`, a key the real registry **has never emitted**; it was pinning its own stub. Fixed to the real shape.

### Addendum 2 — `StrictBool`

Checked and not applicable: this domain converted no hand-rolled `isinstance(x, bool)` check. The only booleans on the wire are outputs.

### Addendum 7 — a real module, not parameter-passing

The 13-name remote-options runtime (~260 lines: concurrency guard, caches, refresh throttle, payload ceilings) had no home outside `api_server`. It is now `src/plugins/options_runtime.py`, per the addendum's preferred end state. Its one `HTTPException(429)` became `PluginOptionsThrottled`, so the runtime is free of transport concerns too.

## Seam retirement

The router resolved **29 names** through `src.api_server` at call time — the heaviest of any router. All gone. `api_server` also drops the three seam-only imports (`unmask_sensitive_values`, `reset_display_service`, `reset_template_engine`) — plugins was their last consumer — and deliberately does **not** re-export the options runtime: a binding that steers nothing is worse than no binding, and would advertise a dead patch target. `PLUGIN_SYSTEM_AVAILABLE` is defined by the router and imported by `api_server`, whose own three handlers still branch on it and whose tests still patch it there.

Fourteen test modules repointed. The mapping table is in `src/plugins/routes.py`'s docstring for anyone chasing a patch target.

## Manifest, and proof it is load-bearing

`"plugins"` is in `converted_domains` **in this PR**, with 8 documented exceptions:

- **7 × `declared_errors`** for routes whose only failure is the `503` from `_require_plugin_system()`. The rule asks for a *4xx* and they have none — the 503 is declared in `responses=` regardless, so the failure is documented; the exception explains why it is not a client error. (`GET /plugins`, `/plugins/registry`, `/plugins/updates`, `/plugins/variables/all`, `/plugins/errors`, `POST /plugins/updates/check`, `POST /plugins/updates/apply`.) I added a paragraph to `API_CONVENTIONS.md` naming this shape, since later slices will hit it too.
- **1 × `no_200_on_failure`** for the options route's three deliberate 200s (two serve the last good options with `stale=true`; the third turns "no API key yet" into an inline hint rather than a failed-request toast on a half-filled form).

Load-bearing proof — `response_model` and the return annotation removed from one route:

```
FAILED tests/test_api_conventions_ratchet.py::test_converted_domains_declare_response_models
E   AssertionError: Converted domains must declare response_model on every route
    (API_CONVENTIONS.md §response shape). Fix the route, or add a
    {"rule": "response_model", ...} exception to tests/conventions_manifest.json
    with a reason:
E       GET /plugins/{plugin_id}/variables: no response_model= declared
```

Reverted; ratchet green (21 passed).

**One thing later slices should know:** FastAPI infers `response_model` from a handler's **return annotation**, so removing only the explicit `response_model=` does *not* break the ratchet. A convincing load-bearing proof has to remove both.

## Golden diff — `plugins.json` only, other domains untouched

Four `200 → 201`s (instances, demo page, both installs); seven envelope removals; `receive` gaining `plugin_id`; the validation detail gaining `message`; `GET /plugins/errors` gaining `fetch_breakers`; and the always-present key sets on summaries, registry entries and instance infos.

Two shape changes are deliberate divergences from "drop the envelope everywhere":

- **`POST /plugins/{id}/receive` keeps `{"status": "ok"}`.** It is a webhook target for third-party systems (CI pipelines, home automations) that this repo does not control and cannot update in lockstep. "Deprecation, never deletion" applies to it more literally than to any browser-facing route. It gains `plugin_id` so the ack names what it acked.
- **`GET /plugins/{id}` gets a distinct `PluginDetail`, not a bare alias.** Its body is assembled from four collaborators and every secret in it is masked, so the wire shape is not the stored shape and must not claim to be. `CollectionResponse = Collection` is honest for collections; here it would have quietly declared the masked shape to be the stored shape — the conflation that let #1743 through.

`tests/golden/api_routes.json` is **unchanged**: it records path, methods, name and kind, none of which moved.

## Suites

| | Baseline (taken first) | This branch |
|---|---|---|
| pytest `tests/` | 5887 passed, 1 skipped, 1 failed | 5959 passed, 1 skipped, 1 failed |

The one failure in both is `test_check_image_formats.py::TestRepositoryIsClean`, the known worktree-environmental failure named in the plan's global constraints. **Strict subset.**

- `tests/test_plugin*.py` + `tests/test_plugins*.py` + `tests/test_settings_plugins.py` + `tests/test_env_plugin_overrides.py`: **1102 passed**.
- Conventions ratchet: 21 passed with `plugins` converted.
- **Zero data-dir leaks** with an explicit directory mounted over `/app/data` (`VOLUME /app/data` hides writes without it).
- ruff 0.16.5: `check` and `format --check` clean on everything touched. (`src/api_server.py` has one pre-existing `format` deviation at line 2515 that is present on `next-rebuild` too — verified against `HEAD:src/api_server.py` in-repo, not introduced here.)
- Web in node:24: `npm ci --legacy-peer-deps` → `react-router typegen` → `tsc --noEmit` → `vitest run` (146 files, 1622 passed, 7 skipped) → `prettier --check` → `eslint`. All clean.

## Divergences from the recipe, for the remaining slices

1. **A `503`-only route cannot satisfy `declared_errors`.** Seven of 25 routes here. Either the rule grows a "declares any error" arm, or every remaining domain writes the same exception seven times. Flagging rather than changing the ratchet mid-stack; `API_CONVENTIONS.md` now documents the shape.
2. **FastAPI infers `response_model` from return annotations** — the load-bearing proof must remove both, or it silently proves nothing.
3. **Mutation-test the *invisible* half of a masked contract.** Mutation 3 passed everything because the field under test was masked either way. Any domain with masked fields needs an unmasked witness field for the same code path.
4. **Repoint patch targets by running, not by reading.** The mixed-purpose test modules (`test_api_coverage.py`, `test_security.py`, …) patch `src.api_server.get_config_manager` for both plugin and non-plugin handlers. A blind sed breaks the non-plugin ones; a proximity heuristic (repoint only where a plugin-route patch is in the same `with` block) plus a full-suite run got it right in one pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP
