### PR TITLE
fix(engine): stop a torn dedupe read double-sending a frame

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -224,6 +224,12 @@ class DisplayService:
         # two first-send threads could each create a worker for one runtime.
         self._workers_lock = threading.Lock()
 
+        # Per-thread snapshot of one board's in-flight send keys, taken once
+        # at the top of the pass currently running on THIS thread. See
+        # ``_pass_in_flight_keys`` for why the snapshot (rather than a live
+        # read at each guard) is what makes the dedupe race-free.
+        self._pass_in_flight = threading.local()
+
     # ------------------------------------------------------------------ #
     # Primary-runtime resolution + back-compat property shims
     # ------------------------------------------------------------------ #
@@ -456,9 +462,42 @@ class DisplayService:
                 rt.send_worker = worker
             return worker
 
-    @staticmethod
-    def _send_in_flight(rt: BoardRuntime, key: tuple) -> bool:
-        """True when this exact send is already queued or executing.
+    @contextmanager
+    def _pass_in_flight_keys(self, rt: BoardRuntime):
+        """Snapshot one board's in-flight send keys for the whole pass.
+
+        A fire-and-forget pass decides "does this frame still need sending?"
+        from TWO pieces of state the send worker writes at two different
+        moments: the dedupe caches (``last_active_page_content``,
+        ``snoozing_message_sent``, ...) written by post-send bookkeeping, and
+        the worker's in-flight key set, retired only after that bookkeeping
+        has run. Reading them live, one after the other, TEARS — the worker
+        can finish in the gap, leaving the pass with a stale cache AND an
+        empty queue, so it enqueues the identical frame a second time and the
+        board is written twice. That is the duplicate send CI caught in
+        ``test_collection_rotation_time_mode``.
+
+        Taking the key set ONCE, before the pass reads any dedupe state,
+        removes the tear without a lock and without serializing anything: a
+        key missing from the snapshot means the job was already retired at
+        snapshot time, which means its bookkeeping had already been written,
+        which means every dedupe read later in this pass sees the fresh
+        value. A key present in the snapshot means "skip", exactly as a live
+        read would have.
+
+        Nesting restores the enclosing snapshot, so the silence dispatch
+        calling into ``_send_silence_indicator`` keeps its own board's view.
+        """
+        worker = rt.send_worker
+        previous = getattr(self._pass_in_flight, "keys", None)
+        self._pass_in_flight.keys = worker.active_keys() if worker is not None else frozenset()
+        try:
+            yield
+        finally:
+            self._pass_in_flight.keys = previous
+
+    def _send_in_flight(self, rt: BoardRuntime, key: tuple) -> bool:
+        """True when this exact send was already queued or executing this pass.
 
         The engine's dedupe caches are updated by post-send bookkeeping,
         which now runs on the worker thread — so during a long transition the
@@ -467,9 +506,16 @@ class DisplayService:
         dedupe; only the engine's fire-and-forget passes consult it, so a
         user-initiated ``wait=True`` send still preempts and re-sends exactly
         as an inline ``render()`` call did.
+
+        Inside a board pass the answer comes from that pass's snapshot (see
+        ``_pass_in_flight_keys``); a direct caller outside one falls back to
+        a live read.
         """
-        worker = rt.send_worker
-        return worker is not None and key in worker.active_keys()
+        snapshot = getattr(self._pass_in_flight, "keys", None)
+        if snapshot is None:
+            worker = rt.send_worker
+            snapshot = worker.active_keys() if worker is not None else frozenset()
+        return key in snapshot
 
     def wait_until_idle(self, timeout: float = 5.0, board_ids=None) -> bool:
         """Block (real time) until the boards' send queues are drained.
@@ -1321,6 +1367,25 @@ class DisplayService:
             True if content was sent to this board (``wait=False``: enqueued),
             False otherwise.
         """
+        # The in-flight key snapshot MUST be taken before the pass reads any
+        # of this board's dedupe state, or the two halves of the dedupe tear
+        # and a frame the worker just delivered is sent again.
+        with self._pass_in_flight_keys(rt):
+            return self._drive_board_pass(
+                board_id, rt, is_primary=is_primary, board=board, contexts=contexts, wait=wait
+            )
+
+    def _drive_board_pass(
+        self,
+        board_id,
+        rt: BoardRuntime,
+        *,
+        is_primary: bool,
+        board: dict | None = None,
+        contexts: dict[str, dict] | None = None,
+        wait: bool = True,
+    ) -> bool:
+        """The body of :meth:`check_and_send_for_board`, run under its snapshot."""
         try:
             # Each pass starts clean: a benign skip must not leave a stale
             # failure reason behind (issue #1791).

--- a/tests/engine_harness.py
+++ b/tests/engine_harness.py
@@ -53,6 +53,7 @@ coverage for any of the following, because no scenario exercises them:
 
 from __future__ import annotations
 
+import threading
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -142,6 +143,63 @@ class GoldenRecordingClient:
 
     def clear_cache(self):
         self._last_characters = None
+
+
+# --------------------------------------------------------------------------
+# Torn-read runtime (duplicate-send race)
+# --------------------------------------------------------------------------
+
+
+class TornReadRuntime(BoardRuntime):
+    """A runtime that parks the tick thread on every dedupe-state read.
+
+    An engine pass decides "should this frame go to the board?" from TWO
+    pieces of state the send worker writes at two different moments: the
+    dedupe cache (``last_active_page_content`` / ``snoozing_message_sent``,
+    written by post-send bookkeeping) and the worker's in-flight key set
+    (retired once the job leaves the queue). The tick reads them one after
+    the other, so a worker that finishes BETWEEN the two reads leaves the
+    tick holding a stale cache value and looking at an empty queue - and it
+    enqueues the very same frame a second time.
+
+    This runtime makes that interleaving deterministic instead of waiting for
+    a loaded CI runner to produce it: reading a dedupe field captures the
+    current (stale) value, runs ``park`` - which the caller uses to let the
+    worker finish its whole job - and only then returns the captured value.
+    That is exactly what the tick thread being descheduled at that bytecode
+    looks like from the engine's point of view.
+
+    ``park`` only runs on the thread that built the runtime (the tick
+    thread); a send worker reading the same field must never recurse into it.
+    """
+
+    def __init__(self, client, board_id, park: Callable[[], None] | None = None):
+        self._park = None
+        super().__init__(client, board_id)
+        self._park = park
+        self._park_thread = threading.get_ident()
+
+    def _torn_read(self, name: str):
+        value = self.__dict__[name]
+        if self._park is not None and threading.get_ident() == self._park_thread:
+            self._park()
+        return value
+
+    @property
+    def last_active_page_content(self):
+        return self._torn_read("_last_active_page_content")
+
+    @last_active_page_content.setter
+    def last_active_page_content(self, value):
+        self.__dict__["_last_active_page_content"] = value
+
+    @property
+    def snoozing_message_sent(self):
+        return self._torn_read("_snoozing_message_sent")
+
+    @snoozing_message_sent.setter
+    def snoozing_message_sent(self, value):
+        self.__dict__["_snoozing_message_sent"] = value
 
 
 # --------------------------------------------------------------------------
@@ -406,6 +464,7 @@ def run_engine_scenario(
     client_factories: dict[str, Callable] | None = None,
     idle_boards: list[str] | None = None,
     before_settle: Callable[[], None] | None = None,
+    runtime_factory: Callable[[DisplayService, object, str], BoardRuntime] | None = None,
 ) -> ScenarioResult:
     """Run the REAL ``DisplayService.run()`` over ``[start, run_until]``.
 
@@ -427,6 +486,10 @@ def run_engine_scenario(
     building a custom stand-in client for that board (scenario 10's blocking
     client); other boards get the default ``GoldenRecordingClient``.
     ``idle_boards`` / ``before_settle`` are forwarded to :class:`LoopHarness`.
+
+    ``runtime_factory(service, client, board_id)`` replaces the plain
+    ``BoardRuntime`` construction, so a scenario can drive the engine through
+    an instrumented runtime (:class:`TornReadRuntime`).
     """
     clock = FakeClock(start)
     service = DisplayService()
@@ -439,7 +502,10 @@ def run_engine_scenario(
             clients[board_id] = factory(clock, board_id, sink)
         else:
             clients[board_id] = GoldenRecordingClient(clock, board_id, sink, fail_when=(fail_when or {}).get(board_id))
-        service.runtimes[board_id] = BoardRuntime(client=clients[board_id], board_id=board_id)
+        if runtime_factory is not None:
+            service.runtimes[board_id] = runtime_factory(service, clients[board_id], board_id)
+        else:
+            service.runtimes[board_id] = BoardRuntime(client=clients[board_id], board_id=board_id)
     service._primary_board_id = boards[0]["id"]
 
     harness = LoopHarness(service, clock, run_until, idle_boards=idle_boards, before_settle=before_settle)

--- a/tests/test_engine_equivalence.py
+++ b/tests/test_engine_equivalence.py
@@ -43,9 +43,11 @@ from src.settings.service import TemporaryOverride
 from src.triggers.service import reset_trigger_service
 from tests.engine_harness import (
     FakeClock,
+    GoldenRecordingClient,
     SilenceConfigManager,
     StubPluginRegistry,
     StubTriggerPlugin,
+    TornReadRuntime,
     make_board,
     make_page_service,
     make_settings_service,
@@ -204,6 +206,79 @@ def test_collection_rotation_time_mode(monkeypatch):
         collections=CollectionService(storage=storage),
     )
     check_golden("collection_rotation_time_mode", result.sends)
+
+
+def test_collection_rotation_survives_a_worker_finishing_mid_guard(monkeypatch):
+    """Pins: no frame is sent twice when a send lands between the guard reads.
+
+    This is the CI-only failure of ``test_collection_rotation_time_mode``
+    made deterministic. At 09:00:20 the loop drives the board twice - the
+    initial pass plus the collection gate's first check - and the second pass
+    decides whether to send from two pieces of state the send worker writes
+    at two different moments: the dedupe cache (post-send bookkeeping) and
+    the worker's in-flight key set (retired when the job leaves the queue).
+    Read one after the other they tear, and on a loaded runner the worker
+    finishes in the gap: stale cache, empty queue, ALPHA sent twice.
+
+    ``TornReadRuntime`` + the render gate force that interleaving on EVERY
+    pass of the scenario, so the whole rotation runs at the worst case rather
+    than waiting for CI to produce it. The send sequence must still be the
+    committed golden, byte for byte, and no ``(instant, board, frame)``
+    triple may ever repeat.
+    """
+    collection = Collection(
+        id=COLLECTION_ID,
+        name="Rotation",
+        page_ids=["page-a", "page-b"],
+        selection_mode="time",
+        time=TimeModeConfig(interval_seconds=30),
+    )
+    storage = MagicMock()
+    storage.get.side_effect = lambda cid: collection if cid == COLLECTION_ID else None
+    golden = json.loads((GOLDEN_DIR / "collection_rotation_time_mode.json").read_text())["sends"]
+
+    def one_run():
+        """One full rotation with the worst-case interleaving on every pass."""
+        # The gate holds every render until a dedupe read (or the harness's
+        # pre-advance settle) opens it, so a job is always still in flight
+        # when the next pass starts reading its guards.
+        gate = threading.Event()
+        holder: dict = {}
+
+        class GatedClient(GoldenRecordingClient):
+            def render(self, board_array, **kwargs):
+                assert gate.wait(timeout=10)
+                return super().render(board_array, **kwargs)
+
+        def park():
+            gate.set()
+            assert holder["svc"].wait_until_idle(timeout=10)
+            gate.clear()
+
+        def runtime_factory(service, client, board_id):
+            holder["svc"] = service
+            return TornReadRuntime(client, board_id, park=park)
+
+        return run_engine_scenario(
+            monkeypatch,
+            start=T0 + timedelta(seconds=20),
+            run_until=T0 + timedelta(minutes=2),
+            boards=[make_board("board-1")],
+            settings=make_settings_service(
+                boards=[make_board("board-1")], polling_interval=300, active_page_ids={"board-1": COLLECTION_ID}
+            ),
+            pages=make_page_service({"page-a": "ALPHA", "page-b": "BETA"}),
+            collections=CollectionService(storage=storage),
+            client_factories={"board-1": lambda clock, board_id, sink: GatedClient(clock, board_id, sink)},
+            runtime_factory=runtime_factory,
+            before_settle=gate.set,
+        )
+
+    for _ in range(5):
+        sends = one_run().sends
+        triples = [(s["t"], s["board"], tuple(s["rows"])) for s in sends]
+        assert len(triples) == len(set(triples)), f"the same frame reached the board twice: {triples}"
+        assert sends == golden, f"send sequence diverged: {[(s['t'], s['rows'][0].strip()) for s in sends]}"
 
 
 def test_silence_window_indicator(monkeypatch):

--- a/tests/test_per_board_engine.py
+++ b/tests/test_per_board_engine.py
@@ -21,6 +21,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from src.main import BoardRuntime, DisplayService
+from tests.engine_harness import TornReadRuntime
 
 TRANSITIONS = SimpleNamespace(strategy="instant", step_interval_ms=0, step_size=1)
 
@@ -126,8 +127,12 @@ def _schedule_service(active_by_board):
     return svc
 
 
-def _service_with_runtimes(boards):
-    """Build a DisplayService with a mock-client runtime per board."""
+def _service_with_runtimes(boards, runtime_factory=None):
+    """Build a DisplayService with a mock-client runtime per board.
+
+    ``runtime_factory(client, board_id)`` swaps in an instrumented runtime
+    (``TornReadRuntime``) instead of the plain ``BoardRuntime``.
+    """
     svc = DisplayService()
     runtimes = {}
     clients = {}
@@ -140,7 +145,10 @@ def _service_with_runtimes(boards):
         # reads. Pin it False so these behave as real hardware clients.
         client.is_virtual = False
         clients[board["id"]] = client
-        runtimes[board["id"]] = BoardRuntime(client=client, board_id=board["id"])
+        if runtime_factory is not None:
+            runtimes[board["id"]] = runtime_factory(client, board["id"])
+        else:
+            runtimes[board["id"]] = BoardRuntime(client=client, board_id=board["id"])
     svc.runtimes = runtimes
     svc._primary_board_id = boards[0]["id"] if boards else None
     return svc, clients
@@ -532,6 +540,82 @@ class TestEngineTickInFlightDedupe:
         assert svc.wait_until_idle(timeout=5)
         assert results == [True]
         assert clients["b1"].render.call_count == 2
+
+
+class TestDuplicateSendRaceAcrossTheGuardReads:
+    """An engine pass must never send a frame the worker JUST finished sending.
+
+    Each fire-and-forget pass consults two pieces of state that the send
+    worker writes at two different moments: the dedupe cache (written by
+    post-send bookkeeping) and the worker's in-flight key set (retired once
+    the job leaves the queue). Reading them one after the other tears - a
+    worker that completes in the gap leaves the pass holding a stale cache
+    AND looking at an empty queue, so it enqueues the identical frame again
+    and the board is written twice with the same content.
+
+    ``TornReadRuntime`` forces exactly that interleaving: the tick captures
+    the stale dedupe value, the worker then runs its job to completion
+    (send, bookkeeping, key retirement), and only then does the tick reach
+    its in-flight guard.
+    """
+
+    def _drive_twice_with_a_torn_read(self, *, silence=False, trigger_content=None):
+        """Two engine passes; the second one tears across the worker's finish.
+
+        Returns how many frames actually reached the board client.
+        """
+        boards = [_board("b1", "Primary", schedule_enabled=False)]
+        started = threading.Event()
+        release = threading.Event()
+        # The first pass must run undisturbed: it is what puts a job on the
+        # worker for the second pass to race with.
+        armed = threading.Event()
+        holder = {}
+
+        def park():
+            # The tick is "descheduled" right here: let the worker's render
+            # return and wait for the whole job - bookkeeping included - to
+            # finish before the tick reads its next piece of dedupe state.
+            if not armed.is_set():
+                return
+            release.set()
+            assert holder["svc"].wait_until_idle(timeout=5)
+
+        svc, clients = _service_with_runtimes(
+            boards, runtime_factory=lambda client, board_id: TornReadRuntime(client, board_id, park=park)
+        )
+        holder["svc"] = svc
+
+        def blocking_render(*_a, **_k):
+            started.set()
+            assert release.wait(timeout=10)
+            return True, True
+
+        clients["b1"].render.side_effect = blocking_render
+        settings = _settings_service(boards, schedule_off=("b1",), manual={"b1": "page-1"})
+        pages = _page_service({"page-1": {"content": "HELLO"}})
+        kwargs = {"silence": silence, "trigger_content": trigger_content, "wait": False}
+        try:
+            _drive(svc, boards, settings=settings, pages=pages, **kwargs)
+            assert started.wait(timeout=5)
+            armed.set()
+            _drive(svc, boards, settings=settings, pages=pages, **kwargs)
+        finally:
+            release.set()
+        assert svc.wait_until_idle(timeout=5)
+        return clients["b1"].render.call_count
+
+    def test_page_send_is_not_repeated_when_the_worker_finishes_mid_guard(self):
+        sends = self._drive_twice_with_a_torn_read()
+        assert sends == 1, "the same page frame was sent to the board twice"
+
+    def test_silence_indicator_is_not_repeated_when_the_worker_finishes_mid_guard(self):
+        sends = self._drive_twice_with_a_torn_read(silence=True)
+        assert sends == 1, "the same silence indicator was sent to the board twice"
+
+    def test_trigger_send_is_not_repeated_when_the_worker_finishes_mid_guard(self):
+        sends = self._drive_twice_with_a_torn_read(trigger_content="DOOR OPEN")
+        assert sends == 1, "the same trigger frame was sent to the board twice"
 
 
 class TestSeams:


### PR DESCRIPTION
## The bug

`tests/test_engine_equivalence.py::test_collection_rotation_time_mode` has
failed CI twice, on two different branches, under the full suite with
`-n auto`:

```
AssertionError: Send sequence diverged from golden collection_rotation_time_mode.json:
6 sends [('2026-07-15T09:00:20+00:00','board-1'), ('2026-07-15T09:00:20+00:00','board-1'),
         ('2026-07-15T09:00:30+00:00','board-1'), ...]
vs golden 5 sends [...]
```

Two sends at the same simulated instant — the same `ALPHA` frame delivered to
the board twice. It is a real duplicate send, not a flake.

## Mechanism

An engine pass decides "does this frame still need sending?" from **two**
pieces of state that the per-board send worker (#1755) writes at **two
different moments** (line numbers on `next-rebuild`):

| | written by | where |
|---|---|---|
| dedupe cache (`rt.last_active_page_content` / `rt.snoozing_message_sent`) | post-send bookkeeping, inside `SendJob.execute` | `src/main.py:1674`, `:1979`, `:2229` |
| in-flight key set (`worker.active_keys()`) | retired in `BoardSendWorker._drain`'s `finally` | `src/displays/send_worker.py:203` |

The **writes** are correctly ordered — bookkeeping runs first, the key is
retired after. The **reads** were not. Every guard site reads the cache first
and the in-flight key second:

| site | cache read | in-flight read |
|---|---|---|
| page | `src/main.py:1613` | `src/main.py:1623` |
| silence indicator | `src/main.py:1406` (`snoozing_message_sent`) | `src/main.py:1957` |
| trigger | `src/main.py:2203` | `src/main.py:2210` |

If the worker completes **between** those two reads, the pass holds a stale
cache value AND looks at an empty queue: both guards fail open and it enqueues
the identical frame again.

In the failing scenario the run loop drives the board twice within the same
simulated second at `09:00:20` — the initial `engine_pass()` before the loop,
plus the collection gate's first check — which is exactly the pair of passes
that races. It needs CPU contention to move the GIL switch into that window,
which is why it only ever reproduced in CI under `-n auto`.

(The original hypothesis was that the in-flight key is released *before* the
bookkeeping. It is not — `_drain` clears `_current` strictly after
`job.execute()` returns. The write order is fine; the read order was the bug.)

## The fix

Snapshot the board's in-flight key set **once**, at the top of
`check_and_send_for_board`, before the pass reads any dedupe state, and answer
every in-flight guard in that pass from the snapshot.

A key missing from the snapshot means the job was already retired at snapshot
time → its bookkeeping had already been written → every dedupe read later in
the pass sees the fresh value. A key present means "skip", exactly as a live
read would have. The tear is gone without a lock.

Nothing is serialized: the snapshot is one brief `active_keys()` call on the
tick thread, and `src/displays/send_worker.py` is **not touched at all** —
latest-wins replacement, waiter adoption, the runtime-epoch guard and the
`*_with_status` failure-reason propagation are all bit-for-bit as #1755 left
them. `check_and_send_for_board` keeps its signature (MQTT and the API call it
by name); its body moved into `_drive_board_pass`, run under the snapshot.

## Tests

`TornReadRuntime` (`tests/engine_harness.py`) makes the interleaving
deterministic instead of waiting for a loaded runner: reading a dedupe field
captures the current (stale) value, runs a `park` callback — which lets the
worker finish its whole job — and only then returns the captured value. That
is what the tick being descheduled at that bytecode looks like to the engine.

- `TestDuplicateSendRaceAcrossTheGuardReads` — all three guard sites (page,
  silence indicator, trigger), two passes each, asserting one frame reaches
  the client.
- `test_collection_rotation_survives_a_worker_finishing_mid_guard` — replays
  the whole collection rotation with that worst-case interleaving forced on
  **every** pass, 5×, asserting no `(instant, board, frame)` triple ever
  repeats and the send sequence still equals the committed golden.

### Fail-first (fix reverted, final tests)

```
tests/test_per_board_engine.py FFF                                       [ 75%]
tests/test_engine_equivalence.py F                                       [100%]

E   AssertionError: the same page frame was sent to the board twice
E   assert 2 == 1
E   AssertionError: the same silence indicator was sent to the board twice
E   assert 2 == 1
E   AssertionError: the same trigger frame was sent to the board twice
E   assert 2 == 1
E   AssertionError: the same frame reached the board twice: [
E     ('2026-07-15T09:00:20+00:00', 'board-1', ('ALPHA ...')),
E     ('2026-07-15T09:00:20+00:00', 'board-1', ('ALPHA ...')),
E     ('2026-07-15T09:00:30+00:00', 'board-1', ('BETA  ...')),
E     ('2026-07-15T09:01:00+00:00', 'board-1', ('ALPHA ...')),
E     ('2026-07-15T09:01:30+00:00', 'board-1', ('BETA  ...')),
E     ('2026-07-15T09:02:00+00:00', 'board-1', ('ALPHA ...'))]
E   assert 6 == 5

4 failed, 1 warning in 0.20s
```

The scenario test reproduces the CI failure exactly: 6 sends vs the golden's
5, duplicated at `09:00:20`.

## Verification

- `tests/test_engine_equivalence.py` — **10× repeat, 12 passed every time**
- `tests/test_engine_equivalence.py tests/test_per_board_engine.py tests/test_send_worker.py` — 78 passed
- Full suite `-m "not integration" -n auto`, **3×**: `1 failed, 6062 passed, 1 skipped`
  every run, the failure being only the known environmental
  `test_check_image_formats.py::TestRepositoryIsClean` — a strict subset of the
  `origin/next-rebuild` baseline taken first (`1 failed, 6058 passed, 1 skipped`,
  same test)
- `ruff==0.16.5 check` + `format --check`: clean
- `git status tests/golden/` clean — **no golden byte changed**. This removes a
  spurious extra send, never a legitimate one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP
