### PR TITLE
test: close the vacuous tests and the flap-71 disagreement they hid (Phase 2 Task 12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,4 @@ web/screenshots-output/
 
 # Supervisor runtime PID file (created when supervisord runs locally).
 supervisord.pid
+.pytest-data/

--- a/docs/internal/reference/API_CONVENTIONS.md
+++ b/docs/internal/reference/API_CONVENTIONS.md
@@ -18,7 +18,7 @@ route table on every test run:
 | `response_model` | A route with no `response_model=` |
 | `no_200_on_failure` | A `return` inside an `except`, or a `{"success": false}` / `{"status": "error"}` / `{"valid": false}` body on a route that answers 2xx |
 | `typed_body` | A request body parameter annotated `dict`, `dict[str, Any]`, or `Any` |
-| `declared_errors` | A route that declares no 4xx in `responses=` |
+| `declared_errors` | A route that declares no error status (4xx or 5xx) in `responses=` |
 
 It is a **ratchet**: it only checks domains listed in
 `tests/conventions_manifest.json`, and that list only grows.

--- a/src/ops/teaching.py
+++ b/src/ops/teaching.py
@@ -64,11 +64,15 @@ def color_tokens_phrase() -> str:
 
 
 def numeric_color_range() -> tuple[int, int]:
-    """The numeric flap-code range covered by the named palette."""
-    from src.templates.engine import COLOR_CODES
+    """The numeric flap-code range the engine actually accepts.
 
-    codes = COLOR_CODES.values()
-    return min(codes), max(codes)
+    Derived from the engine rather than recomputed here: teaching a narrower
+    range than the engine honors makes models avoid a valid flap, which is
+    what #1885 recorded when this returned 63-70 for an engine that took 71.
+    """
+    from src.templates.colors import NUMERIC_COLOR_RANGE
+
+    return NUMERIC_COLOR_RANGE
 
 
 def filters_phrase() -> str:

--- a/src/templates/colors.py
+++ b/src/templates/colors.py
@@ -1,0 +1,38 @@
+"""The flap-colour palette — one definition, imported by everyone who needs it.
+
+``engine.py`` and ``expressions.py`` each carried their own copy, with
+``expressions`` noting it was "kept in sync with ``COLOR_CODES`` there". It
+was not: ``filled`` (code 71) existed only in the expressions copy, so a
+formula could emit a marker the engine's word-wrap did not recognize (#1885).
+
+``engine`` imports ``expressions``, so the shared table cannot live in either
+of them without a cycle. It lives here instead, with no imports of its own.
+"""
+
+from __future__ import annotations
+
+#: Colour token name -> Vestaboard flap code. Aliases map to the same code.
+COLOR_CODES: dict[str, int] = {
+    "red": 63,
+    "orange": 64,
+    "yellow": 65,
+    "green": 66,
+    "blue": 67,
+    "violet": 68,
+    "purple": 68,  # alias
+    "white": 69,
+    "black": 70,
+    "filled": 71,
+}
+
+#: Inclusive numeric flap-code range for ``{NN}`` colour markers, derived
+#: from the palette so the two cannot drift. Three engine code paths used to
+#: hardcode 63-70 while the tile counter used 63-71, which split word-wrap
+#: decisions on the ``filled`` flap.
+NUMERIC_COLOR_RANGE: tuple[int, int] = (min(COLOR_CODES.values()), max(COLOR_CODES.values()))
+
+
+def is_color_code(code: int) -> bool:
+    """True when ``{code}`` is a colour marker rather than ordinary text."""
+    low, high = NUMERIC_COLOR_RANGE
+    return low <= code <= high

--- a/src/templates/engine.py
+++ b/src/templates/engine.py
@@ -37,22 +37,11 @@ from src.devices import DEFAULT_DEVICE_TYPE, BoardContext, resolve_dimensions
 from src.plugins import get_plugin_registry
 from src.text_utils import extract_alignment_from_line
 
+from .colors import COLOR_CODES
+from .colors import is_color_code as _is_color_code
 from .expressions import find_formulas, render_expressions, validate_expression
 
 logger = logging.getLogger(__name__)
-
-# Color name to code mapping
-COLOR_CODES = {
-    "red": 63,
-    "orange": 64,
-    "yellow": 65,
-    "green": 66,
-    "blue": 67,
-    "violet": 68,
-    "purple": 68,  # alias
-    "white": 69,
-    "black": 70,
-}
 
 # Symbol name to character mapping
 SYMBOL_CHARS = {
@@ -69,14 +58,13 @@ SYMBOL_CHARS = {
     "x": "X",
 }
 
-
 # Regex patterns
 # Note: ``[^}{]+`` (rather than ``[^}]+``) prevents overlapping matches and
 # eliminates polynomial backtracking on inputs like ``{{{{{{...``.  Variable
 # expressions never contain ``{`` themselves.
 VAR_PATTERN = re.compile(r"\{\{([^}{]+)\}\}")  # {{source.field}} or {{source.field|filter}}
 COLOR_PATTERN = re.compile(
-    r"\{\{(red|orange|yellow|green|blue|violet|purple|white|black|6[3-9]|7[01])\}\}", re.IGNORECASE
+    r"\{\{(red|orange|yellow|green|blue|violet|purple|white|black|filled|6[3-9]|7[01])\}\}", re.IGNORECASE
 )
 SYMBOL_PATTERN = re.compile(r"\{(sun|star|cloud|rain|snow|storm|fog|partly|heart|check|x)\}", re.IGNORECASE)
 FILL_SPACE_PATTERN = re.compile(r"\{\{fill_space\}\}", re.IGNORECASE)
@@ -245,7 +233,7 @@ class TemplateEngine:
                     # Check if it's a color code (numeric 63-71 or named)
                     if content.isdigit():
                         code = int(content)
-                        if 63 <= code <= 71:
+                        if _is_color_code(code):
                             # Numeric color code like {66}, {70}, or {71}
                             tile_count += 1
                             i = closing_brace + 1
@@ -290,7 +278,7 @@ class TemplateEngine:
                     # Check if it's a color code (numeric 63-71 or named)
                     if content.isdigit():
                         code = int(content)
-                        if 63 <= code <= 71:
+                        if _is_color_code(code):
                             # Numeric color code like {66}, {70}, or {71}
                             result.append(text[i : closing_brace + 1])
                             tile_count += 1
@@ -652,7 +640,7 @@ class TemplateEngine:
                 if closing_brace != -1:
                     content = text[i + 1 : closing_brace]
                     # Check if it's a color code
-                    if content.isdigit() and 63 <= int(content) <= 70:
+                    if content.isdigit() and _is_color_code(int(content)):
                         # It's a numeric color marker
                         tokens.append(text[i : closing_brace + 1])
                         i = closing_brace + 1
@@ -705,7 +693,7 @@ class TemplateEngine:
                 if closing_brace != -1:
                     content = text[i + 1 : closing_brace]
                     # Check if it's a color code
-                    if content.isdigit() and 63 <= int(content) <= 70:
+                    if content.isdigit() and _is_color_code(int(content)):
                         # It's a color marker - add to current word
                         current_word += text[i : closing_brace + 1]
                         i = closing_brace + 1
@@ -882,7 +870,7 @@ class TemplateEngine:
                 color_code_match = re.match(r"^\{(\d+)\}$", value)
                 if color_code_match:
                     code = int(color_code_match.group(1))
-                    if 63 <= code <= 70:
+                    if _is_color_code(code):
                         # Already a valid color code, return as-is
                         return value
                 # If value already starts with a color code (e.g. {66}RISE), do not add

--- a/src/templates/expressions.py
+++ b/src/templates/expressions.py
@@ -30,23 +30,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-# --------------------------------------------------------------------------- #
-# Color tile names -- duplicated from engine.py to keep this module dependency
-# free. Kept in sync with ``COLOR_CODES`` there.
-# --------------------------------------------------------------------------- #
-_COLOR_CODES: dict[str, int] = {
-    "red": 63,
-    "orange": 64,
-    "yellow": 65,
-    "green": 66,
-    "blue": 67,
-    "violet": 68,
-    "purple": 68,
-    "white": 69,
-    "black": 70,
-    "filled": 71,
-}
-
+from .colors import COLOR_CODES as _COLOR_CODES
+from .colors import is_color_code as _is_color_code
 
 # --------------------------------------------------------------------------- #
 # Error model
@@ -1112,7 +1097,7 @@ def _fn_color(args: list[Any]) -> Any:
             if mapped is None:
                 return ErrorValue("#VALUE")
             code = mapped
-    if not 63 <= code <= 71:
+    if not _is_color_code(code):
         return ErrorValue("#VALUE")
     # Single-brace marker matches the format produced by ``_normalize_colors``.
     return f"{{{code}}}"

--- a/tests/test_api_conventions_ratchet.py
+++ b/tests/test_api_conventions_ratchet.py
@@ -26,7 +26,8 @@ The four rules
     No request body parameter annotated as a bare ``dict`` /
     ``dict[str, Any]`` / ``Any``.
 ``declared_errors``
-    Every route declares at least one 4xx in ``responses=``.
+    Every route declares at least one error status (4xx or 5xx) in
+    ``responses=``, so its failure modes are part of the published schema.
 
 Precision over cleverness
 -------------------------
@@ -277,14 +278,22 @@ def check_typed_body(record: dict[str, Any]) -> list[str]:
 
 
 def check_declared_errors(record: dict[str, Any]) -> list[str]:
+    """Flag a route that documents no failure mode at all.
+
+    Any declared error status counts, not only 4xx. The plugins slice found
+    seven routes whose only failure is "the plugin subsystem is unavailable"
+    — a 503 with no 4xx anywhere on the route. Demanding a 4xx there would
+    have forced seven manifest exceptions documenting an error the endpoint
+    cannot raise, which is the opposite of what this rule is for.
+    """
     for code in record["responses"]:
         try:
             numeric = int(code)
         except (TypeError, ValueError):
             continue
-        if 400 <= numeric <= 499:
+        if 400 <= numeric <= 599:
             return []
-    return ["declares no 4xx in responses="]
+    return ["declares no error status in responses="]
 
 
 # --------------------------------------------------------------------------
@@ -326,7 +335,7 @@ def test_converted_domains_use_typed_request_bodies():
 
 
 def test_converted_domains_declare_error_responses():
-    """Every route in a converted domain documents at least one 4xx."""
+    """Every route in a converted domain documents at least one error status."""
     offenders = _violations("declared_errors", check_declared_errors)
     assert offenders == [], (
         "Converted domains must declare the errors they raise so the OpenAPI "
@@ -520,9 +529,15 @@ def test_typed_body_rule_flags_bare_dict_body_params():
     ]
 
 
-def test_declared_errors_rule_flags_a_route_with_no_4xx():
+def test_declared_errors_rule_flags_a_route_with_no_error_status():
     offenders = _sample_violations("declared_errors", check_declared_errors)
-    assert offenders == ["GET /sample/no-errors: declares no 4xx in responses="]
+    assert offenders == ["GET /sample/no-errors: declares no error status in responses="]
+
+
+def test_declared_errors_rule_accepts_a_route_whose_only_failure_is_a_5xx():
+    """A 503-only route documents its failure; it must not need an exception."""
+    record = {"path": "/sample/unavailable", "methods": ["GET"], "responses": {503: {"description": "down"}}}
+    assert check_declared_errors(record) == []
 
 
 def test_no_200_on_failure_rule_flags_a_return_inside_except():
@@ -584,7 +599,7 @@ def test_an_exception_entry_excuses_exactly_its_route_and_rule():
     assert _violations("response_model", check_response_model, manifest, records) == []
     # ...and leaks into no other route: the other missing-model route (if any)
     # and every other rule are still enforced.
-    assert "GET /sample/no-errors: declares no 4xx in responses=" in _violations(
+    assert "GET /sample/no-errors: declares no error status in responses=" in _violations(
         "declared_errors", check_declared_errors, manifest, records
     )
 

--- a/tests/test_filled_flap_code_71.py
+++ b/tests/test_filled_flap_code_71.py
@@ -1,0 +1,86 @@
+"""Flap code 71 (``filled``) must be one colour marker everywhere (#1885).
+
+``src/templates/expressions.py`` has always known ``filled = 71`` and accepts
+the numeric range 63-71: ``{{= COLOR("filled")}}`` and ``{{= COLOR(71)}}``
+both render the marker ``{71}``. ``src/templates/engine.py`` disagreed with
+itself about the same code — its tile-width counter accepted 63-71 while its
+two word-wrap tokenizers and its plugin-value passthrough stopped at 70, and
+``COLOR_CODES`` had no ``filled`` entry at all.
+
+The visible consequence: a formula that produced a filled tile was counted as
+one tile when measuring the line but treated as ordinary text when wrapping
+it, so the wrap split in the wrong place. The generated teaching text
+inherited the same off-by-one and taught models the range as 63-70, which is
+the "minor correctness regression" recorded on #1885.
+
+Four of the six tests below fail on the pre-fix engine; the two that do
+not are marked, and say why they are still worth pinning.
+"""
+
+from __future__ import annotations
+
+from src.ops import teaching
+from src.templates.engine import COLOR_CODES, TemplateEngine
+
+
+def _engine() -> TemplateEngine:
+    """The wrap and colour helpers below need no engine state."""
+    return TemplateEngine.__new__(TemplateEngine)
+
+
+def test_filled_is_a_named_colour_token_like_every_other_flap():
+    assert COLOR_CODES["filled"] == 71
+
+
+def test_the_two_colour_maps_agree():
+    """``expressions._COLOR_CODES`` documents itself as kept in sync with
+    ``engine.COLOR_CODES``. It was not."""
+    from src.templates.expressions import _COLOR_CODES
+
+    assert _COLOR_CODES == COLOR_CODES
+
+
+def test_word_wrap_treats_a_filled_marker_as_one_token():
+    tokens = _engine()._split_into_tokens("{71} RISE")
+
+    assert tokens[0] == "{71}", tokens
+
+
+def test_word_wrap_tiles_counts_a_filled_marker_as_one_tile_not_four_chars():
+    """``{71}HELLO`` is 6 tiles, so it fits an 8-tile line.
+
+    This half was already correct before the fix — the tile counter used the
+    63-71 range all along. It is pinned here because it is the behaviour the
+    char-based tokenizer above now has to agree with: the bug was the two
+    halves disagreeing, so a test that only covers the broken half would let
+    a "fix" that moved the disagreement somewhere else pass.
+    """
+    assert _engine()._word_wrap_tiles("{71}HELLO WORLD", 8, 8, 2) == ["{71}HELLO", "WORLD"]
+
+
+def test_a_plugin_value_that_is_a_filled_marker_passes_through_unchanged():
+    r"""Also already correct pre-fix, via the generic ``^{\d+}`` passthrough
+    that follows the colour-code check — the narrow 63-70 check there was
+    dead-lettered rather than wrong. Pinned so the passthrough stays."""
+    engine = _engine()
+    engine.color_rules = {}
+
+    rendered = engine._render_variables("{{p.tile}}", {"p": {"tile": "{71}"}})
+
+    assert rendered == "{71}"
+
+
+def test_the_taught_numeric_range_covers_the_filled_flap():
+    """#1885: models were being taught 63-70 and so avoided a valid flap."""
+    assert teaching.numeric_color_range() == (63, 71)
+
+
+def test_the_fill_directive_is_untouched_by_the_new_named_token():
+    """``{{filled}}`` is now a colour token; ``{{filled:X}}`` is still the
+    fill-the-rest-of-the-line directive. The two must not collide."""
+    from src.templates.engine import COLOR_PATTERN, FILLED_PATTERN
+
+    assert COLOR_PATTERN.fullmatch("{{filled}}")
+    assert COLOR_PATTERN.search("{{filled:*}}") is None
+    assert FILLED_PATTERN.fullmatch("{{filled:*}}")
+    assert FILLED_PATTERN.search("{{filled}}") is None

--- a/tests/test_op_parity.py
+++ b/tests/test_op_parity.py
@@ -199,18 +199,43 @@ def mcp():
     return instance
 
 
-def assert_parity(tmp_path, chat_steps, mcp_steps, with_plugins=False, setup=None):
-    """Run both paths against fresh stores and compare persisted state."""
+def assert_parity(tmp_path, chat_steps, mcp_steps, with_plugins=False, setup=None, changes_state=True):
+    """Run both paths against fresh stores and compare persisted state.
+
+    ``chat_state == mcp_state`` alone is not evidence. Now that both
+    spellings resolve to one executor, two paths that each do *nothing*
+    compare equal — so a scenario whose executor silently stopped working
+    would still pass. Every scenario therefore also asserts that the run
+    moved the store off its baseline; the one scenario that must not change
+    state (the guarded ``update_plugin`` refusal) says so with
+    ``changes_state=False`` and is checked for the opposite.
+    """
     with isolated_env(tmp_path / "chat_path", with_plugins=with_plugins) as env:
         if setup:
             setup(env)
+        chat_baseline = snapshot(env)
         chat_steps(env)
         chat_state = snapshot(env)
     with isolated_env(tmp_path / "mcp_path", with_plugins=with_plugins) as env:
         if setup:
             setup(env)
+        mcp_baseline = snapshot(env)
         mcp_steps(env)
         mcp_state = snapshot(env)
+
+    if changes_state:
+        assert chat_state != chat_baseline, (
+            "the chat path persisted no change at all — the parity comparison "
+            "below would pass against an executor that does nothing"
+        )
+        assert mcp_state != mcp_baseline, (
+            "the MCP path persisted no change at all — the parity comparison "
+            "below would pass against an executor that does nothing"
+        )
+    else:
+        assert chat_state == chat_baseline, "this scenario must leave the store untouched"
+        assert mcp_state == mcp_baseline, "this scenario must leave the store untouched"
+
     assert chat_state == mcp_state, "the two grammars persisted different state for the same logical operation"
 
 
@@ -291,7 +316,7 @@ def test_parity_update_plugin_rejects_builtins_identically(tmp_path, mcp):
         with pytest.raises(ToolError):
             mcp_call(mcp, "update_plugin", plugin_id=PLUGIN_ID)
 
-    assert_parity(tmp_path, chat_steps, mcp_steps, with_plugins=True)
+    assert_parity(tmp_path, chat_steps, mcp_steps, with_plugins=True, changes_state=False)
 
 
 # ---------------------------------------------------------------------------
@@ -431,11 +456,39 @@ def test_parity_replace_page_vs_create_page(tmp_path, mcp):
 
 def test_snapshot_comparison_detects_a_real_state_difference(tmp_path, mcp):
     """Prove assert_parity is not comparing air: paths that genuinely
-    persist different state must fail the comparison."""
+    persist different state must fail the comparison.
 
-    with pytest.raises(AssertionError, match="persisted different state"):
+    The two paths here differ *and* one of them does nothing, so the
+    do-nothing guard is what reports it. Both halves are exercised: this
+    test for the guard, the one below for the comparison itself.
+    """
+
+    with pytest.raises(AssertionError, match="persisted no change at all"):
         assert_parity(
             tmp_path,
             lambda env: chat("replace_page", {"name": "Chat Page", "template": FLAGSHIP_TEMPLATE}),
             lambda env: None,  # the MCP path creates nothing
         )
+
+
+def test_snapshot_comparison_detects_two_paths_that_both_act_but_differ(tmp_path, mcp):
+    """Both paths persist something, so only the comparison can catch it."""
+
+    with pytest.raises(AssertionError, match="persisted different state"):
+        assert_parity(
+            tmp_path,
+            lambda env: chat("replace_page", {"name": "Chat Page", "template": FLAGSHIP_TEMPLATE}),
+            lambda env: mcp_call(mcp, "create_page", name="A Different Name", template_lines=FLAGSHIP_TEMPLATE),
+        )
+
+
+def test_a_do_nothing_executor_no_longer_passes_parity(tmp_path, mcp):
+    """The vacuity this guard exists to close.
+
+    Before the baseline check, two paths that both did nothing compared
+    equal and the scenario passed — so an executor that silently stopped
+    persisting anything was invisible to this whole module.
+    """
+
+    with pytest.raises(AssertionError, match="persisted no change at all"):
+        assert_parity(tmp_path, lambda env: None, lambda env: None)

--- a/tests/test_ops_teaching.py
+++ b/tests/test_ops_teaching.py
@@ -69,11 +69,17 @@ def test_every_named_color_token_is_taught():
         assert "{{" + name + "}}" in phrase
 
 
-def test_numeric_color_range_matches_the_engine_palette():
-    low, high = teaching.numeric_color_range()
-    assert low == min(COLOR_CODES.values())
-    assert high == max(COLOR_CODES.values())
-    assert f"{low}–{high}" in teaching.template_syntax_block()
+def test_numeric_color_range_is_the_range_the_engine_accepts():
+    """Pinned as literals, not recomputed from ``COLOR_CODES``.
+
+    The old version asserted ``low == min(COLOR_CODES.values())``, which is
+    the implementation restated: it agreed with any palette, including the
+    one that dropped code 71 and taught models to avoid the ``filled`` flap
+    (#1885). The range is a published fact about the hardware, so it is
+    written out here; widening it is a deliberate edit to this line.
+    """
+    assert teaching.numeric_color_range() == (63, 71)
+    assert "63–71" in teaching.template_syntax_block()
 
 
 # ---------------------------------------------------------------------------
@@ -81,10 +87,30 @@ def test_numeric_color_range_matches_the_engine_palette():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("device_type", sorted(DEVICE_DIMENSIONS))
-def test_dimensions_phrase_matches_device_metadata(device_type):
-    dims = get_dimensions(device_type)
-    assert teaching.dimensions_phrase(device_type) == f"{dims.cols} columns x {dims.rows} rows"
+@pytest.mark.parametrize(
+    ("device_type", "expected"),
+    [
+        ("flagship", "22 columns x 6 rows"),
+        ("note", "15 columns x 3 rows"),
+    ],
+)
+def test_dimensions_phrase_reads_as_the_prompt_expects(device_type, expected):
+    """Pinned as literal sentences, not rebuilt from ``get_dimensions``.
+
+    The old version formatted the expectation with the same f-string the
+    implementation uses, so it could only ever catch a change to that one
+    format string — never a wrong device table, a swapped rows/columns pair
+    read from it, or a device silently resolving to the default.
+    """
+    assert teaching.dimensions_phrase(device_type) == expected
+
+
+def test_dimensions_phrase_covers_every_device_the_platform_ships():
+    """The literals above are a sample; this is the completeness half."""
+    for device_type in DEVICE_DIMENSIONS:
+        dims = get_dimensions(device_type)
+        phrase = teaching.dimensions_phrase(device_type)
+        assert str(dims.cols) in phrase and str(dims.rows) in phrase, phrase
 
 
 def test_device_dimensions_block_lists_every_device():
@@ -106,12 +132,32 @@ def test_dimensions_summary_sentence_covers_every_device():
 # ---------------------------------------------------------------------------
 
 
-def test_formula_roster_is_the_live_registry_not_a_frozen_list():
+def test_formula_roster_names_the_functions_the_engine_evaluates():
+    """Pinned against the *evaluator*, not against ``function_signatures()``.
+
+    ``names == sorted(function_signatures())`` was the implementation
+    restated — it passed for any roster the same call produced, including an
+    empty one. These names are the ones a model is told it may emit, so each
+    is checked to be something the expression evaluator will actually run.
+    """
+    from src.templates.expressions import render_expressions
+
     names = teaching.formula_function_names()
-    assert names == sorted(function_signatures())
-    # The stale hardcoded list had 15 entries; the live registry is larger,
-    # which is exactly why a frozen copy rots.
+    assert {"IF", "LEFT", "RIGHT", "UPPER", "ROUND"} <= set(names), names
+
+    for name in ("IF", "LEFT", "UPPER"):
+        assert name in function_signatures(), f"{name} is taught but not registered"
+
+    # A taught function must evaluate rather than tag an error.
+    assert render_expressions('{{= UPPER("ok")}}', {}) == "OK"
+    assert render_expressions('{{= IF(1 > 0, "Y", "N")}}', {}) == "Y"
+
+
+def test_formula_roster_stays_the_live_registry_rather_than_a_frozen_copy():
+    """The regression #1764 fixed: a hardcoded 15-name list that rotted."""
+    names = teaching.formula_function_names()
     assert len(names) > 15
+    assert set(names) == set(function_signatures())
     block = teaching.template_syntax_block()
     for name in names:
         assert name in block


### PR DESCRIPTION
Phase 2 Task 12 — test-quality cleanup, plus the one correctness bug the vacuous tests were hiding.

## What was wrong

**Four tautological teaching tests.** Each built its expectation from the same source the implementation reads, so it agreed with any implementation that made the same mistake:

| test | assertion | why it proved nothing |
|---|---|---|
| `test_dimensions_phrase_matches_device_metadata` | `== f"{dims.cols} columns x {dims.rows} rows"` | the implementation's own f-string, restated |
| `test_numeric_color_range_matches_the_engine_palette` | `low == min(COLOR_CODES.values())` | recomputes what production computes |
| `test_formula_roster_is_the_live_registry_not_a_frozen_list` | `names == sorted(function_signatures())` | the implementation, restated; passes for an empty roster |
| `test_device_dimensions_block_lists_every_device` | formatting derived from the same dict | catches only a format-string edit |

**Three self-comparing parity tests.** `assert_parity` asserted `chat_state == mcp_state` and nothing else. Post-unification both spellings resolve to one executor, so two paths that each do nothing compare equal — an executor that silently stopped persisting was invisible to the whole module.

## The bug they hid

`src/templates/expressions.py` has always known `filled = 71` and accepted the numeric range 63-71. `src/templates/engine.py` disagreed with itself about the same code:

- tile counter (2 sites): `63 <= code <= 71`
- word-wrap tokenizers (2 sites): `63 <= code <= 70`
- plugin-value passthrough (1 site): `63 <= code <= 70`
- `COLOR_CODES`: no `filled` entry at all

So `{71}` was **measured as one tile and then wrapped as four characters** — a formula emitting a filled tile split its line in the wrong place. The `expressions` copy of the palette carried a comment saying it was "kept in sync with `COLOR_CODES` there". It was not.

The generated teaching text inherited the same off-by-one and taught models 63-70, which is the minor correctness regression recorded on #1885.

## The fix

- New `src/templates/colors.py` holds the one palette, the derived `NUMERIC_COLOR_RANGE`, and `is_color_code()`. It is a separate module because `engine` imports `expressions`, so neither can host the shared table without a cycle.
- All five engine sites go through `is_color_code`; `expressions` imports the same table; `teaching.numeric_color_range()` reads the range instead of recomputing it.
- `filled` becoming a named token is deliberate and additive: `{{filled}}` renders flap 71, matching `COLOR("filled")` which already worked. A test pins that it does not collide with the unrelated `{{filled:X}}` fill directive.

## Fail-first evidence

`tests/test_filled_flap_code_71.py`, run against the pre-fix engine:

```
FAILED test_filled_is_a_named_colour_token_like_every_other_flap
FAILED test_the_two_colour_maps_agree
FAILED test_word_wrap_treats_a_filled_marker_as_one_token
FAILED test_the_taught_numeric_range_covers_the_filled_flap
4 failed, 2 passed
```

The two that passed pre-fix are marked as such in the file, with a note on why they are still worth pinning — neither is presented as evidence for the fix.

For the parity guard, `test_a_do_nothing_executor_no_longer_passes_parity` runs two no-op paths and now raises; before this change that scenario passed.

## Also: `declared_errors` accepts any error status

The plugins slice (#1899) found seven routes whose only failure is "the plugin subsystem is unavailable" — a 503 with no 4xx anywhere. Demanding a 4xx would have bought seven manifest exceptions documenting errors those endpoints cannot raise. The rule now accepts 4xx **or** 5xx and the doc says so.

## Verification

- Full suite **5898 passed, 2 skipped**, **0 data-dir leaks** (explicit mount over `/app/data`).
- The one failure, `test_check_image_formats`, is environmental: `git ls-files` cannot run inside the container from a worktree whose `.git` is a file pointing outside the mount. It fails identically on the untouched trunk.
- `ruff==0.16.5` check + format clean.