### PR TITLE
feat(system): apply API conventions, retire the api_server seams

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -508,22 +508,6 @@ class HealthResponse(BaseModel):
     version: str
 
 
-# System-update request/response models — moved to src/system/models.py
-# (issue #1758). Re-imported so src.api_server.<Model> references keep
-# resolving.
-from .system.models import (  # noqa: E402, F401
-    AutoUpdateRequest,
-    AutoUpdateResponse,
-    RollbackRequest,
-    RollbackResponse,
-    SystemActionResponse,
-    UpdateApplyResponse,
-    UpdateCheckResponse,
-    UpdateStatusResponse,
-    VersionResponse,
-)
-
-
 # ── WiFi / NetworkManager models ─────────────────────────────────────────────
 class WiFiCapabilityResponse(BaseModel):
     available: bool
@@ -1618,71 +1602,23 @@ def _collect_plugin_demos() -> list[dict[str, Any]]:
 # .system-update.json state machine) lives in src/system/update_service.py;
 # its route handlers (/version, /system/update-check, /system/update/*,
 # /system/restart, /system/shutdown) live in src/system/routes.py and are
-# included below, next to the helpers they resolve through this module.
+# included below.
 #
-# Every moved helper is re-imported here so the test-suite's
-# patch("src.api_server.<name>") targets keep working; the extracted handlers
-# import these names back through src.api_server at call time (the
-# #1756/#1757 pattern). The two path-override constants stay *defined* on
-# this module (below) and the service reads them back through it at call
-# time, so patching them here still steers the service.
-
-from .system.update_service import (  # noqa: E402, F401
-    _DIGEST_RE,
-    _IMAGE_REF_RE,
-    _SETTINGS_SNAPSHOT_NAME_RE,
-    AUTO_UPDATE_INTERVALS,
-    DOCKERHUB_TAGS_URL,
-    GITHUB_PACKAGE_URL,
-    GITHUB_RELEASES_API,
-    GITHUB_RELEASES_URL,
-    SETTINGS_SNAPSHOT_RETENTION,
-    _auto_update_default_interval,
-    _check_dockerhub_for_latest,
-    _check_github_releases_for_latest,
-    _detect_hardware_model,
+# Nothing is re-exported for the test suite any more: the Phase 2 system slice
+# retired that seam. src/system/ imports nothing from this module, the two path
+# overrides (SYSTEM_UPDATE_STATE_FILE / SETTINGS_SNAPSHOT_DIR) now live on the
+# service, and tests patch src.system.update_service.<name> directly. What is
+# imported below is only what api_server's own lifespan / restore paths call.
+from .system.update_service import (  # noqa: E402
+    _detect_post_upgrade_regression,
     _fiestaboard_profile,
-    _handle_updater_response,
-    _is_newer_version,
-    _is_update_check_due,
-    _list_settings_snapshots,
     _managed_externally,
-    _parse_version,
-    _perform_update_check,
-    _pick_latest_version,
-    _prune_settings_snapshots,
-    _read_snapshot_metadata,
-    _release_notes_url,
-    _require_updater_token,
-    _resolve_auto_update_interval,
     _resolve_snapshot_name,
-    _settings_snapshot_dir,
-    _system_update_state_file,
-    _system_update_state_load,
-    _system_update_state_save,
-    _system_update_state_update,
-    _take_settings_snapshot,
-    _updater_last_update,
-    _updater_post,
     _updater_probe,
     _updater_token,
     _updater_url,
-    _updater_version,
     run_system_update_check_if_due,
 )
-
-# ``SYSTEM_UPDATE_STATE_FILE`` is a *test seam*: production leaves it ``None``
-# and ``_system_update_state_file()`` (now in src/system/update_service.py)
-# resolves lazily through ``src.paths.get_data_dir()`` (honoring
-# ``FIESTABOARD_DATA_DIR``, #1762). Tests that need a specific file keep
-# monkeypatching this module attribute; the service reads it back through
-# this module at call time.
-SYSTEM_UPDATE_STATE_FILE: Path | None = None
-
-# ``SETTINGS_SNAPSHOT_DIR`` is the matching *test seam* for the pre-update
-# settings-snapshot directory (default: ``<data>/update-backups``), read back
-# through this module by ``_settings_snapshot_dir()`` in the service.
-SETTINGS_SNAPSHOT_DIR: Path | None = None
 
 
 async def _auto_apply_plugin_updates(registry: Any, plugin_ids: list) -> None:
@@ -1867,61 +1803,6 @@ def _log_config_boot_snapshot(stage: str) -> None:
         )
     except Exception:  # pragma: no cover - diagnostics must never block boot
         logger.debug("config boot snapshot [%s] failed", stage, exc_info=True)
-
-
-def _detect_post_upgrade_regression() -> dict[str, Any] | None:
-    """Return a hint payload when the live config looks regressed against the
-    newest pre-update snapshot.
-
-    Signals an upgrade is likely to have dropped user state (issue #948 —
-    "integrations lost on upgrade"). We compare the snapshot's enabled
-    plugin set to the current one; if the snapshot enabled strictly more
-    plugins, point the user at /system/update/rollback so they don't have
-    to discover the recovery path on their own.
-
-    Returns ``None`` when:
-      * there are no snapshots,
-      * the newest snapshot is unreadable,
-      * the snapshot has <= 0 enabled plugins (nothing to recover),
-      * the live config has at least as many enabled plugins as the
-        snapshot (no regression detected).
-    """
-    snapshots = _list_settings_snapshots()
-    if not snapshots:
-        return None
-    newest = _resolve_snapshot_name(snapshots[0]["name"])
-    if newest is None:
-        return None
-    try:
-        snap_doc = json.loads(newest.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return None
-
-    snap_plugins_raw = ((snap_doc.get("data") or {}).get("config") or {}).get("plugins") or {}
-    snap_enabled = {pid for pid, cfg in snap_plugins_raw.items() if isinstance(cfg, dict) and cfg.get("enabled")}
-    if not snap_enabled:
-        return None
-
-    try:
-        live = get_config_manager().get_all_plugin_configs()
-    except Exception:  # pragma: no cover - defensive
-        return None
-    live_enabled = {pid for pid, cfg in live.items() if isinstance(cfg, dict) and cfg.get("enabled")}
-
-    missing = sorted(snap_enabled - live_enabled)
-    if not missing:
-        return None
-
-    return {
-        "snapshot_name": newest.name,
-        "snapshot_enabled_count": len(snap_enabled),
-        "current_enabled_count": len(live_enabled),
-        "missing_plugin_ids": missing,
-        "snapshot_app_version": (snap_doc.get("app_version") if isinstance(snap_doc, dict) else None),
-        "rollback_hint": (
-            "POST /system/update/rollback with snapshot=" + newest.name + " and restore_settings=true to recover."
-        ),
-    }
 
 
 from .system.routes import router as system_router  # noqa: E402

--- a/src/system/routes.py
+++ b/src/system/routes.py
@@ -1,17 +1,23 @@
 """FastAPI router for the ``/version`` + ``/system`` update endpoint family (issue #1758).
 
-Handlers moved verbatim from ``src/api_server.py``. Names that still live in
-``api_server`` — or that moved to :mod:`src.system.update_service` and are
-re-exported by ``api_server`` — are imported *inside* each handler so they
-resolve through the api_server module at call time. A module-level import
-would both create an import cycle (api_server imports this router) and
-detach the handlers from the test-suite's ``patch("src.api_server.<name>")``
-targets (the #1756/#1757 pattern).
+Converted to the API conventions by the Phase 2 ``system`` slice
+(``docs/internal/reference/API_CONVENTIONS.md``, enforced by
+``tests/test_api_conventions_ratchet.py``):
 
-``requests`` is imported at module level on purpose: the suite patches
-``src.api_server.requests.get``/``.post``, which mutates the shared
-``requests`` module object, so the patch reaches these handlers regardless
-of which module they live in.
+* every ``HTTPException.detail`` is a **string** — the dict details these
+  handlers used to raise carried ad-hoc ``status`` / ``mode`` / ``error`` /
+  ``hint`` keys, no ``message``, and no reader: ``web/src/lib/api/core.ts``
+  simply ``JSON.stringify``\\ s a non-string detail into the error toast;
+* every route declares ``responses=`` for the codes it can actually answer.
+
+Collaborators are resolved through :mod:`src.system.update_service`, which is
+where they live. Nothing here imports ``src.api_server`` — not at module level
+and not at call time — so ``import src.system.routes`` never drags the monolith
+in (``tests/test_system_seams.py`` asserts that in a fresh interpreter). Tests
+patch the service module: ``patch("src.system.update_service.<name>")``.
+
+The module object is imported rather than its members so that a patch applied
+to ``src.system.update_service`` after import time still steers these handlers.
 """
 
 from __future__ import annotations
@@ -25,6 +31,9 @@ from typing import Any
 import requests
 from fastapi import APIRouter, HTTPException
 
+from src import __version__
+
+from . import update_service
 from .models import (
     AutoUpdateRequest,
     AutoUpdateResponse,
@@ -41,6 +50,15 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["system"])
 
+#: Declared error responses, reused across the sidecar-backed routes. Every
+#: code here is one these handlers actually raise.
+_SIDECAR_UNAVAILABLE = {503: {"description": "The fiestaupdater sidecar is not configured or not reachable"}}
+_SIDECAR_ERRORS = {
+    500: {"description": "The sidecar rejected our token"},
+    502: {"description": "The sidecar answered with an error"},
+    **_SIDECAR_UNAVAILABLE,
+}
+
 
 @router.get("/version", response_model=VersionResponse)
 async def version():
@@ -49,18 +67,13 @@ async def version():
     Returns both the package version (from __version__) and the build version
     (from VERSION environment variable). In production builds, these should match.
     """
-    from src.api_server import (  # patched-in-tests seam — see module docstring
-        __version__,
-        _detect_hardware_model,
-    )
-
     build_version = os.getenv("VERSION", "dev")
     production = os.getenv("PRODUCTION", "false").lower() == "true"
     return VersionResponse(
         package_version=__version__,
         build_version=build_version,
         is_dev=build_version == "dev" and not production,
-        hardware_model=_detect_hardware_model(),
+        hardware_model=update_service._detect_hardware_model(),
     )
 
 
@@ -74,10 +87,12 @@ async def system_update_check():
     authentication is required because the package and repository are public.
 
     Returns the current version, latest version, and whether an update is available.
-    """
-    from src.api_server import _perform_update_check  # patched-in-tests seam — see module docstring
 
-    return await _perform_update_check()
+    This is a **probe endpoint** in the sense of API_CONVENTIONS.md: an
+    unreachable Docker Hub is a verdict about something else, reported at 200
+    in the declared ``error`` field, not a failure of this request.
+    """
+    return await update_service._perform_update_check()
 
 
 @router.get("/system/update/status", response_model=UpdateStatusResponse)
@@ -93,34 +108,21 @@ async def system_update_status():
     snapshots, so the UI can offer "revert to the version that was
     running on <date>" without polling the sidecar separately.
     """
-    from src.api_server import (  # patched-in-tests seam — see module docstring
-        _detect_post_upgrade_regression,
-        _fiestaboard_profile,
-        _list_settings_snapshots,
-        _managed_externally,
-        _resolve_auto_update_interval,
-        _system_update_state_load,
-        _updater_last_update,
-        _updater_probe,
-        _updater_token,
-        _updater_url,
-    )
-
-    state = _system_update_state_load()
-    has_token = bool(_updater_token())
-    available = await asyncio.to_thread(_updater_probe) if has_token else False
+    state = update_service._system_update_state_load()
+    has_token = bool(update_service._updater_token())
+    available = await asyncio.to_thread(update_service._updater_probe) if has_token else False
     # Only consult the sidecar's last-update record when it is reachable.
-    last = await asyncio.to_thread(_updater_last_update) if available else {}
-    interval = _resolve_auto_update_interval(state)
-    snapshots = await asyncio.to_thread(_list_settings_snapshots)
-    regression = await asyncio.to_thread(_detect_post_upgrade_regression)
+    last = await asyncio.to_thread(update_service._updater_last_update) if available else {}
+    interval = update_service._resolve_auto_update_interval(state)
+    snapshots = await asyncio.to_thread(update_service._list_settings_snapshots)
+    regression = await asyncio.to_thread(update_service._detect_post_upgrade_regression)
     return UpdateStatusResponse(
         updater_available=available,
         auto_update_enabled=interval != "manual",
         auto_update_interval=interval,
-        managed_externally=_managed_externally(),
-        profile=_fiestaboard_profile(),
-        sidecar_url=_updater_url(),
+        managed_externally=update_service._managed_externally(),
+        profile=update_service._fiestaboard_profile(),
+        sidecar_url=update_service._updater_url(),
         last_check=state.get("last_check"),
         last_update=state.get("last_update"),
         last_update_status=last.get("status"),
@@ -133,7 +135,7 @@ async def system_update_status():
     )
 
 
-@router.post("/system/update", response_model=UpdateApplyResponse)
+@router.post("/system/update", response_model=UpdateApplyResponse, responses=_SIDECAR_ERRORS)
 async def system_update_apply():
     """Trigger an in-place update via the fiestaupdater sidecar.
 
@@ -142,25 +144,19 @@ async def system_update_apply():
     Clients should expect their HTTP connection to drop and should poll
     `/health` to detect when the new version is up.
 
-    If the sidecar is not running (user hasn't opted in), returns 503 with a
-    `manual` mode response so the UI can fall back to instructions.
+    Raises:
+        503 when the sidecar is not configured or not reachable, with the
+            manual-update instructions as the detail so the UI can show them.
+        500 when the sidecar rejects our shared token.
+        502 for any other sidecar failure.
     """
-    from src.api_server import (  # patched-in-tests seam — see module docstring
-        _system_update_state_update,
-        _take_settings_snapshot,
-        _updater_token,
-        _updater_url,
-        _updater_version,
-    )
-
-    if not _updater_token():
+    if not update_service._updater_token():
         raise HTTPException(
             status_code=503,
-            detail={
-                "status": "manual",
-                "mode": "manual",
-                "hint": "FIESTAUPDATER_TOKEN is not set. Add COMPOSE_PROFILES=fiestaupdater to your .env and run 'docker compose up -d' to enable in-app updates.",
-            },
+            detail=(
+                "FIESTAUPDATER_TOKEN is not set. Add COMPOSE_PROFILES=fiestaupdater to your .env "
+                "and run 'docker compose up -d' to enable in-app updates."
+            ),
         )
 
     # Snapshot the current settings *before* we trigger the update so the
@@ -170,15 +166,15 @@ async def system_update_apply():
     # sidecar's /version endpoint) so rollback knows which image to pair
     # with the restored settings.  A snapshot failure is non-fatal: the
     # user can still manually roll the image back via the sidecar.
-    version = await asyncio.to_thread(_updater_version)
+    version = await asyncio.to_thread(update_service._updater_version)
     snapshot = await asyncio.to_thread(
-        _take_settings_snapshot,
+        update_service._take_settings_snapshot,
         version.get("digest"),
         version.get("image"),
     )
 
-    url = f"{_updater_url()}/update"
-    headers = {"Authorization": f"Bearer {_updater_token()}"}
+    url = f"{update_service._updater_url()}/update"
+    headers = {"Authorization": f"Bearer {update_service._updater_token()}"}
 
     def _post():
         return requests.post(url, headers=headers, timeout=(5, 30))
@@ -188,28 +184,24 @@ async def system_update_apply():
     except requests.exceptions.ConnectionError:
         raise HTTPException(
             status_code=503,
-            detail={
-                "status": "manual",
-                "mode": "manual",
-                "hint": "Could not reach the fiestaupdater sidecar. Run 'docker compose pull && docker compose up -d' from your install directory to update manually.",
-            },
+            detail=(
+                "Could not reach the fiestaupdater sidecar. Run 'docker compose pull && docker compose up -d' "
+                "from your install directory to update manually."
+            ),
         ) from None
     except Exception as e:
         logger.warning(f"fiestaupdater update call failed: {e}")
-        raise HTTPException(status_code=502, detail={"status": "error", "error": str(e)}) from e
+        raise HTTPException(status_code=502, detail=f"fiestaupdater update call failed: {e}") from e
 
     if resp.status_code == 401:
         raise HTTPException(
             status_code=500,
-            detail={
-                "status": "error",
-                "error": "fiestaupdater rejected our token; check FIESTAUPDATER_TOKEN matches in both services",
-            },
+            detail="fiestaupdater rejected our token; check FIESTAUPDATER_TOKEN matches in both services",
         )
     if resp.status_code >= 400:
         raise HTTPException(
             status_code=502,
-            detail={"status": "error", "error": f"fiestaupdater returned {resp.status_code}: {resp.text[:200]}"},
+            detail=f"fiestaupdater returned {resp.status_code}: {resp.text[:200]}",
         )
 
     # Record bookkeeping so the UI can show "last update".
@@ -219,7 +211,7 @@ async def system_update_apply():
     except ValueError as e:
         # fiestaupdater may return a non-JSON body (e.g. plain-text on error); fall back to empty dict.
         logger.debug("fiestaupdater response is not JSON, using empty body (non-fatal): %s", e)
-    _system_update_state_update(last_update=datetime.now(UTC).isoformat())
+    update_service._system_update_state_update(last_update=datetime.now(UTC).isoformat())
 
     return UpdateApplyResponse(
         status="queued",
@@ -229,7 +221,15 @@ async def system_update_apply():
     )
 
 
-@router.post("/system/update/rollback", response_model=RollbackResponse)
+@router.post(
+    "/system/update/rollback",
+    response_model=RollbackResponse,
+    responses={
+        400: {"description": "Nothing to restore, or the snapshot is unreadable"},
+        404: {"description": "No matching settings snapshot"},
+        **_SIDECAR_ERRORS,
+    },
+)
 async def system_update_rollback(req: RollbackRequest):
     """Roll the running instance back to a previous version.
 
@@ -250,39 +250,27 @@ async def system_update_rollback(req: RollbackRequest):
     Raises:
         404 when no matching snapshot exists.
         400 when the snapshot is unreadable, both ``restore_*`` flags
-            are False, or the snapshot has no recorded image to roll
-            back to (and the user asked us to roll the image back).
+            are False, or the snapshot document is not a backup.
+        500 when the restore is aborted by the environment, or the sidecar
+            rejects our token.
+        502 when the sidecar answers with an error.
         503 when the sidecar is needed but unreachable.
-    """
-    from src.api_server import (  # patched-in-tests seam — see module docstring
-        _DIGEST_RE,
-        _IMAGE_REF_RE,
-        _read_snapshot_metadata,
-        _resolve_snapshot_name,
-        _updater_token,
-        _updater_url,
-    )
 
+    A snapshot with no recorded image identity, or a missing sidecar token,
+    is *partial success*, not a failure: the settings were restored, so the
+    response is a 200 whose ``warnings`` name what was skipped.
+    """
     if not req.restore_settings and not req.restore_image:
         raise HTTPException(
             status_code=400,
-            detail={
-                "status": "error",
-                "error": "At least one of restore_settings, restore_image must be true.",
-            },
+            detail="At least one of restore_settings, restore_image must be true.",
         )
 
-    path = await asyncio.to_thread(_resolve_snapshot_name, req.snapshot)
+    path = await asyncio.to_thread(update_service._resolve_snapshot_name, req.snapshot)
     if path is None:
-        raise HTTPException(
-            status_code=404,
-            detail={
-                "status": "not_found",
-                "error": "No matching settings snapshot was found.",
-            },
-        )
+        raise HTTPException(status_code=404, detail="No matching settings snapshot was found.")
 
-    snapshot_meta = await asyncio.to_thread(_read_snapshot_metadata, path)
+    snapshot_meta = await asyncio.to_thread(update_service._read_snapshot_metadata, path)
 
     warnings: list[str] = []
     settings_result: dict[str, Any] | None = None
@@ -294,15 +282,12 @@ async def system_update_rollback(req: RollbackRequest):
             raw = await asyncio.to_thread(path.read_text, "utf-8")
         except OSError as e:
             logger.warning("Could not read snapshot %s: %s", path, e)
-            raise HTTPException(
-                status_code=400,
-                detail={"status": "error", "error": f"Could not read snapshot: {e}"},
-            ) from e
+            raise HTTPException(status_code=400, detail=f"Could not read snapshot: {e}") from e
         try:
             from src.backup.service import BackupError, BackupRestoreAborted, get_backup_service
         except Exception as e:  # pragma: no cover - import error is exceptional
             logger.exception("BackupService unavailable")
-            raise HTTPException(status_code=500, detail={"status": "error", "error": str(e)}) from e
+            raise HTTPException(status_code=500, detail=f"Backup service unavailable: {e}") from e
 
         service = get_backup_service()
         try:
@@ -313,15 +298,9 @@ async def system_update_rollback(req: RollbackRequest):
             # Environment failure (unwritable data dir, full disk), not a bad
             # snapshot — see Phase 2 Task 10d.
             logger.error("Settings rollback aborted: %s", e)
-            raise HTTPException(
-                status_code=500,
-                detail={"status": "error", "error": str(e)},
-            ) from e
+            raise HTTPException(status_code=500, detail=str(e)) from e
         except BackupError as e:
-            raise HTTPException(
-                status_code=400,
-                detail={"status": "error", "error": str(e)},
-            ) from e
+            raise HTTPException(status_code=400, detail=str(e)) from e
         settings_result = {
             "restored_from": path.name,
             "restored_files": result.get("restored_files", []),
@@ -339,17 +318,17 @@ async def system_update_rollback(req: RollbackRequest):
             # safely guess the digest, so report partial success rather
             # than guessing.
             warnings.append("Snapshot does not record a previous image digest; image was not rolled back.")
-        elif not _DIGEST_RE.fullmatch(digest) or not _IMAGE_REF_RE.fullmatch(image_ref):
+        elif not update_service._DIGEST_RE.fullmatch(digest) or not update_service._IMAGE_REF_RE.fullmatch(image_ref):
             warnings.append("Snapshot's recorded image identity is malformed; image was not rolled back.")
-        elif not _updater_token():
+        elif not update_service._updater_token():
             warnings.append(
                 "FIESTAUPDATER_TOKEN is not set; image rollback is unavailable. "
                 "Settings have been restored but the image is unchanged."
             )
         else:
-            url = f"{_updater_url()}/rollback"
+            url = f"{update_service._updater_url()}/rollback"
             headers = {
-                "Authorization": f"Bearer {_updater_token()}",
+                "Authorization": f"Bearer {update_service._updater_token()}",
                 "Content-Type": "application/json",
             }
             payload = {"digest": digest, "image": image_ref}
@@ -362,27 +341,18 @@ async def system_update_rollback(req: RollbackRequest):
             except requests.exceptions.ConnectionError:
                 raise HTTPException(
                     status_code=503,
-                    detail={
-                        "status": "manual",
-                        "error": "Could not reach the fiestaupdater sidecar; image rollback unavailable.",
-                    },
+                    detail="Could not reach the fiestaupdater sidecar; image rollback unavailable.",
                 ) from None
             except Exception as e:
                 logger.warning("fiestaupdater rollback call failed: %s", e)
-                raise HTTPException(status_code=502, detail={"status": "error", "error": str(e)}) from e
+                raise HTTPException(status_code=502, detail=f"fiestaupdater rollback call failed: {e}") from e
 
             if resp.status_code == 401:
-                raise HTTPException(
-                    status_code=500,
-                    detail={"status": "error", "error": "fiestaupdater rejected our token"},
-                )
+                raise HTTPException(status_code=500, detail="fiestaupdater rejected our token")
             if resp.status_code >= 400:
                 raise HTTPException(
                     status_code=502,
-                    detail={
-                        "status": "error",
-                        "error": f"fiestaupdater returned {resp.status_code}: {resp.text[:200]}",
-                    },
+                    detail=f"fiestaupdater returned {resp.status_code}: {resp.text[:200]}",
                 )
 
             image_result = {
@@ -401,7 +371,11 @@ async def system_update_rollback(req: RollbackRequest):
     )
 
 
-@router.post("/system/update/auto", response_model=AutoUpdateResponse)
+@router.post(
+    "/system/update/auto",
+    response_model=AutoUpdateResponse,
+    responses={422: {"description": "Neither interval nor enabled was supplied, or the interval is unknown"}},
+)
 async def system_update_set_auto(req: AutoUpdateRequest):
     """Set the auto-update preference.
 
@@ -414,28 +388,25 @@ async def system_update_set_auto(req: AutoUpdateRequest):
     on each tick, so changes take effect within the next polling window
     without requiring a restart.
     """
-    from src.api_server import (  # patched-in-tests seam — see module docstring
-        AUTO_UPDATE_INTERVALS,
-        _auto_update_default_interval,
-        _system_update_state_update,
-    )
-
     if req.interval is not None:
-        if req.interval not in AUTO_UPDATE_INTERVALS:
+        if req.interval not in update_service.AUTO_UPDATE_INTERVALS:
             raise HTTPException(
                 status_code=422,
-                detail=(f"Invalid interval {req.interval!r}; must be one of: {sorted(AUTO_UPDATE_INTERVALS.keys())}"),
+                detail=(
+                    f"Invalid interval {req.interval!r}; "
+                    f"must be one of: {sorted(update_service.AUTO_UPDATE_INTERVALS.keys())}"
+                ),
             )
         interval = req.interval
     elif req.enabled is not None:
-        interval = _auto_update_default_interval() if req.enabled else "manual"
+        interval = update_service._auto_update_default_interval() if req.enabled else "manual"
     else:
         raise HTTPException(
             status_code=422,
             detail="Request must include either 'interval' or 'enabled'.",
         )
 
-    _system_update_state_update(
+    update_service._system_update_state_update(
         auto_update_interval=interval,
         # Keep the legacy bool in sync so older clients reading the file see a
         # consistent picture.
@@ -444,34 +415,25 @@ async def system_update_set_auto(req: AutoUpdateRequest):
     return AutoUpdateResponse(enabled=interval != "manual", interval=interval)
 
 
-@router.post("/system/restart", response_model=SystemActionResponse)
+@router.post("/system/restart", response_model=SystemActionResponse, responses=_SIDECAR_ERRORS)
 async def system_restart():
     """Restart the FiestaBoard container via the fiestaupdater sidecar.
 
     The connection will drop while the container restarts (~5 s).
     Clients should poll /health until it comes back.
     """
-    from src.api_server import (  # patched-in-tests seam — see module docstring
-        _handle_updater_response,
-        _require_updater_token,
-        _updater_post,
-    )
-
-    _require_updater_token()
+    update_service._require_updater_token()
     try:
-        resp = await asyncio.to_thread(_updater_post, "/restart")
+        resp = await asyncio.to_thread(update_service._updater_post, "/restart")
     except requests.exceptions.ConnectionError:
-        raise HTTPException(
-            status_code=503,
-            detail={"status": "unavailable", "hint": "Could not reach the fiestaupdater sidecar."},
-        ) from None
+        raise HTTPException(status_code=503, detail="Could not reach the fiestaupdater sidecar.") from None
     except Exception as e:
         logger.warning("fiestaupdater restart call failed: %s", e)
-        raise HTTPException(status_code=502, detail={"status": "error", "error": str(e)}) from e
-    return _handle_updater_response(resp, "restart")
+        raise HTTPException(status_code=502, detail=f"fiestaupdater restart call failed: {e}") from e
+    return update_service._handle_updater_response(resp, "restart")
 
 
-@router.post("/system/shutdown", response_model=SystemActionResponse)
+@router.post("/system/shutdown", response_model=SystemActionResponse, responses=_SIDECAR_ERRORS)
 async def system_shutdown():
     """Shut down the host machine via the fiestaupdater sidecar.
 
@@ -479,21 +441,12 @@ async def system_shutdown():
     Requires the fiestaupdater container to have the SYS_BOOT capability
     (cap_add: [SYS_BOOT] in docker-compose.yml).
     """
-    from src.api_server import (  # patched-in-tests seam — see module docstring
-        _handle_updater_response,
-        _require_updater_token,
-        _updater_post,
-    )
-
-    _require_updater_token()
+    update_service._require_updater_token()
     try:
-        resp = await asyncio.to_thread(_updater_post, "/shutdown")
+        resp = await asyncio.to_thread(update_service._updater_post, "/shutdown")
     except requests.exceptions.ConnectionError:
-        raise HTTPException(
-            status_code=503,
-            detail={"status": "unavailable", "hint": "Could not reach the fiestaupdater sidecar."},
-        ) from None
+        raise HTTPException(status_code=503, detail="Could not reach the fiestaupdater sidecar.") from None
     except Exception as e:
         logger.warning("fiestaupdater shutdown call failed: %s", e)
-        raise HTTPException(status_code=502, detail={"status": "error", "error": str(e)}) from e
-    return _handle_updater_response(resp, "shutdown")
+        raise HTTPException(status_code=502, detail=f"fiestaupdater shutdown call failed: {e}") from e
+    return update_service._handle_updater_response(resp, "shutdown")

--- a/src/system/update_service.py
+++ b/src/system/update_service.py
@@ -6,14 +6,12 @@ fiestaupdater sidecar HTTP client, pre-update settings snapshots with
 retention pruning, and the ``.system-update.json`` state machine with its
 lock + atomic-write semantics (#1745) preserved exactly.
 
-Patch seams: ``api_server`` re-imports every name here, so the test-suite's
-``patch("src.api_server.<name>")`` targets keep working — the extracted route
-handlers in ``src/system/routes.py`` resolve these helpers *through*
-``src.api_server`` at call time (the #1756/#1757 pattern). The two path
-overrides (``SYSTEM_UPDATE_STATE_FILE`` / ``SETTINGS_SNAPSHOT_DIR``) stay
-*defined* on ``api_server`` and are read back through it at call time here,
-so ``monkeypatch.setattr("src.api_server.SETTINGS_SNAPSHOT_DIR", ...)``
-keeps steering the service.
+This module is the canonical home for every one of those names — including
+the two path overrides ``SYSTEM_UPDATE_STATE_FILE`` / ``SETTINGS_SNAPSHOT_DIR``
+and the post-upgrade regression hint, both of which used to live on
+``api_server``. Nothing here imports ``src.api_server``, at module level or at
+call time (Phase 2 slice: system). Tests patch the name where it lives:
+``patch("src.system.update_service.<name>")``.
 """
 
 from __future__ import annotations
@@ -33,6 +31,7 @@ from fastapi import HTTPException
 
 from src import __version__
 from src.atomic_io import write_json_atomic, write_text_atomic
+from src.config_manager import get_config_manager
 from src.paths import get_data_dir
 
 from .models import SystemActionResponse, UpdateCheckResponse
@@ -237,22 +236,16 @@ def _is_newer_version(latest: str, current: str) -> bool:
 # ``SYSTEM_UPDATE_STATE_FILE`` is a *test seam*: production leaves it ``None``
 # and ``_system_update_state_file()`` resolves lazily through
 # ``src.paths.get_data_dir()`` (honoring ``FIESTABOARD_DATA_DIR``, #1762).
-# Tests that need a specific file keep monkeypatching the module attribute
-# *on api_server* — the constant stays defined there and is read back
-# through it at call time below.
+# Tests that need a specific file monkeypatch this module attribute —
+# ``monkeypatch.setattr("src.system.update_service.SYSTEM_UPDATE_STATE_FILE", ...)``
+# — and the resolver below reads it back at call time.
+SYSTEM_UPDATE_STATE_FILE: Path | None = None
 
 
 def _system_update_state_file() -> Path:
-    """Resolve the system-update state file path at call time.
-
-    The ``SYSTEM_UPDATE_STATE_FILE`` override lives on ``src.api_server``
-    (a documented test seam patched as ``src.api_server.SYSTEM_UPDATE_STATE_FILE``);
-    read it through that module so the patch keeps steering us.
-    """
-    from src import api_server  # patched-in-tests seam — see module docstring
-
-    if api_server.SYSTEM_UPDATE_STATE_FILE is not None:
-        return Path(api_server.SYSTEM_UPDATE_STATE_FILE)
+    """Resolve the system-update state file path at call time."""
+    if SYSTEM_UPDATE_STATE_FILE is not None:
+        return Path(SYSTEM_UPDATE_STATE_FILE)
     return get_data_dir() / ".system-update.json"
 
 
@@ -468,10 +461,10 @@ def _require_updater_token():
     if not _updater_token():
         raise HTTPException(
             status_code=503,
-            detail={
-                "status": "unavailable",
-                "hint": "FIESTAUPDATER_TOKEN is not set. Add COMPOSE_PROFILES=fiestaupdater to your .env and run 'docker compose up -d' to enable sidecar features.",
-            },
+            detail=(
+                "FIESTAUPDATER_TOKEN is not set. Add COMPOSE_PROFILES=fiestaupdater to your .env "
+                "and run 'docker compose up -d' to enable sidecar features."
+            ),
         )
 
 
@@ -480,15 +473,12 @@ def _handle_updater_response(resp: requests.Response, action: str) -> SystemActi
     if resp.status_code == 401:
         raise HTTPException(
             status_code=500,
-            detail={
-                "status": "error",
-                "error": "fiestaupdater rejected our token; check FIESTAUPDATER_TOKEN matches in both services",
-            },
+            detail="fiestaupdater rejected our token; check FIESTAUPDATER_TOKEN matches in both services",
         )
     if resp.status_code >= 400:
         raise HTTPException(
             status_code=502,
-            detail={"status": "error", "error": f"fiestaupdater returned {resp.status_code}: {resp.text[:200]}"},
+            detail=f"fiestaupdater returned {resp.status_code}: {resp.text[:200]}",
         )
     return SystemActionResponse(status="queued", action=action)
 
@@ -503,17 +493,15 @@ def _handle_updater_response(resp: requests.Response, action: str) -> SystemActi
 # ``SETTINGS_SNAPSHOT_DIR`` is a *test seam*: production leaves it ``None``
 # and ``_settings_snapshot_dir()`` resolves lazily through
 # ``src.paths.get_data_dir()`` (honoring ``FIESTABOARD_DATA_DIR``, #1762).
-# The constant stays defined on api_server and is read back through it at
-# call time below, so ``patch("src.api_server.SETTINGS_SNAPSHOT_DIR")``
-# keeps steering the service.
+# Tests point it at a tmp dir with
+# ``monkeypatch.setattr("src.system.update_service.SETTINGS_SNAPSHOT_DIR", ...)``.
+SETTINGS_SNAPSHOT_DIR: Path | None = None
 
 
 def _settings_snapshot_dir() -> Path:
     """Resolve the settings-snapshot directory at call time."""
-    from src import api_server  # patched-in-tests seam — see module docstring
-
-    if api_server.SETTINGS_SNAPSHOT_DIR is not None:
-        return Path(api_server.SETTINGS_SNAPSHOT_DIR)
+    if SETTINGS_SNAPSHOT_DIR is not None:
+        return Path(SETTINGS_SNAPSHOT_DIR)
     return get_data_dir() / "update-backups"
 
 
@@ -736,6 +724,66 @@ def _resolve_snapshot_name(name: str | None) -> Path | None:
 # call the sidecar at all.
 _DIGEST_RE = re.compile(r"^sha256:[a-f0-9]{64}$")
 _IMAGE_REF_RE = re.compile(r"^[a-z0-9][a-z0-9._/-]{0,199}(:[a-zA-Z0-9._-]{1,128})?$")
+
+
+# ── Post-upgrade regression hint (#948) ────────────────────────────────────
+# Lived on ``api_server`` until the system slice; it is a snapshot-reader,
+# so its home is here next to the snapshot helpers it calls.
+
+
+def _detect_post_upgrade_regression() -> dict[str, Any] | None:
+    """Return a hint payload when the live config looks regressed against the
+    newest pre-update snapshot.
+
+    Signals an upgrade is likely to have dropped user state (issue #948 —
+    "integrations lost on upgrade"). We compare the snapshot's enabled
+    plugin set to the current one; if the snapshot enabled strictly more
+    plugins, point the user at /system/update/rollback so they don't have
+    to discover the recovery path on their own.
+
+    Returns ``None`` when:
+      * there are no snapshots,
+      * the newest snapshot is unreadable,
+      * the snapshot has <= 0 enabled plugins (nothing to recover),
+      * the live config has at least as many enabled plugins as the
+        snapshot (no regression detected).
+    """
+    snapshots = _list_settings_snapshots()
+    if not snapshots:
+        return None
+    newest = _resolve_snapshot_name(snapshots[0]["name"])
+    if newest is None:
+        return None
+    try:
+        snap_doc = json.loads(newest.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+    snap_plugins_raw = ((snap_doc.get("data") or {}).get("config") or {}).get("plugins") or {}
+    snap_enabled = {pid for pid, cfg in snap_plugins_raw.items() if isinstance(cfg, dict) and cfg.get("enabled")}
+    if not snap_enabled:
+        return None
+
+    try:
+        live = get_config_manager().get_all_plugin_configs()
+    except Exception:  # pragma: no cover - defensive
+        return None
+    live_enabled = {pid for pid, cfg in live.items() if isinstance(cfg, dict) and cfg.get("enabled")}
+
+    missing = sorted(snap_enabled - live_enabled)
+    if not missing:
+        return None
+
+    return {
+        "snapshot_name": newest.name,
+        "snapshot_enabled_count": len(snap_enabled),
+        "current_enabled_count": len(live_enabled),
+        "missing_plugin_ids": missing,
+        "snapshot_app_version": (snap_doc.get("app_version") if isinstance(snap_doc, dict) else None),
+        "rollback_hint": (
+            "POST /system/update/rollback with snapshot=" + newest.name + " and restore_settings=true to recover."
+        ),
+    }
 
 
 async def run_system_update_check_if_due() -> None:

--- a/tests/conventions_manifest.json
+++ b/tests/conventions_manifest.json
@@ -3,7 +3,8 @@
   "converted_domains": [
     "collections",
     "pages",
-    "schedules"
+    "schedules",
+    "system"
   ],
   "exceptions": [
     {
@@ -47,9 +48,39 @@
       "reason": "Reads the bundled staff-picks/picks.json and degrades a missing file to [] on purpose, so a caller can never see a 4xx from it. The per-pick 404 lives on GET /staff-picks/{pick_id}/share, which declares it."
     },
     {
+      "route": "GET /system/update-check",
+      "rule": "declared_errors",
+      "reason": "Probe endpoint (API_CONVENTIONS.md, \"Status codes\"): an unreachable Docker Hub or GitHub is a verdict about something else, reported at 200 in the declared UpdateCheckResponse.error field. Nothing the caller sends can make this route 4xx."
+    },
+    {
+      "route": "GET /system/update/status",
+      "rule": "declared_errors",
+      "reason": "Read-only report with no failure path: it cannot 404, 400 or 409, so declaring a 4xx would document an error the endpoint never raises. An unreachable sidecar is reported as updater_available=false, not as an error."
+    },
+    {
+      "route": "GET /version",
+      "rule": "declared_errors",
+      "reason": "Read-only report with no failure path: it cannot 404, 400 or 409, so declaring a 4xx would document an error the endpoint never raises. It reads two env vars and one /proc file, and reports None when the file is absent."
+    },
+    {
       "route": "POST /schedules/validate",
       "rule": "declared_errors",
       "reason": "No failure path. It is a read of existing schedules with an optional board_id, which falls back to the empty set; an inconsistent schedule set is the 200 verdict this endpoint exists to report, not an error."
+    },
+    {
+      "route": "POST /system/restart",
+      "rule": "declared_errors",
+      "reason": "Every failure mode is upstream: the fiestaupdater sidecar is absent (503), rejects our shared token (500) or errors (502). There is no request a client could send that this route answers 4xx to, and all three codes it does raise are declared in responses=."
+    },
+    {
+      "route": "POST /system/shutdown",
+      "rule": "declared_errors",
+      "reason": "Every failure mode is upstream: the fiestaupdater sidecar is absent (503), rejects our shared token (500) or errors (502). There is no request a client could send that this route answers 4xx to, and all three codes it does raise are declared in responses=."
+    },
+    {
+      "route": "POST /system/update",
+      "rule": "declared_errors",
+      "reason": "Every failure mode is upstream: the fiestaupdater sidecar is absent (503), rejects our shared token (500) or errors (502). There is no request a client could send that this route answers 4xx to, and all three codes it does raise are declared in responses=."
     }
   ]
 }

--- a/tests/golden/responses/system.json
+++ b/tests/golden/responses/system.json
@@ -110,11 +110,7 @@
       "path_template": "/system/update",
       "status": 503,
       "shape": {
-        "detail": {
-          "hint": "str",
-          "mode": "str",
-          "status": "str"
-        }
+        "detail": "str"
       }
     },
     {
@@ -123,11 +119,7 @@
       "path_template": "/system/update",
       "status": 503,
       "shape": {
-        "detail": {
-          "hint": "str",
-          "mode": "str",
-          "status": "str"
-        }
+        "detail": "str"
       }
     },
     {
@@ -156,10 +148,7 @@
       "path_template": "/system/update/rollback",
       "status": 400,
       "shape": {
-        "detail": {
-          "error": "str",
-          "status": "str"
-        }
+        "detail": "str"
       }
     },
     {
@@ -168,10 +157,7 @@
       "path_template": "/system/update/rollback",
       "status": 404,
       "shape": {
-        "detail": {
-          "error": "str",
-          "status": "str"
-        }
+        "detail": "str"
       }
     },
     {
@@ -279,10 +265,7 @@
       "path_template": "/system/restart",
       "status": 503,
       "shape": {
-        "detail": {
-          "hint": "str",
-          "status": "str"
-        }
+        "detail": "str"
       }
     },
     {
@@ -291,10 +274,7 @@
       "path_template": "/system/shutdown",
       "status": 503,
       "shape": {
-        "detail": {
-          "hint": "str",
-          "status": "str"
-        }
+        "detail": "str"
       }
     },
     {

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -391,7 +391,7 @@ class TestRootAndHealth:
 
     def test_version_includes_detected_hardware_model(self, client):
         with patch(
-            "src.api_server._detect_hardware_model",
+            "src.system.update_service._detect_hardware_model",
             return_value="Raspberry Pi 5 Model B Rev 1.0",
         ):
             response = client.get("/version")

--- a/tests/test_response_shape_goldens.py
+++ b/tests/test_response_shape_goldens.py
@@ -996,13 +996,13 @@ def test_plugins_response_shapes():
 # These routes reach the network in three ways — Docker Hub / GitHub Releases
 # version checks, the fiestaupdater sidecar HTTP API, and the BackupService's
 # on-disk export — so the scenario stubs every one of them deterministically:
-# ``src.api_server.requests`` get/post are replaced per hit (the same seam the
-# rest of the suite patches), the state-file and snapshot-dir test seams
-# (``SYSTEM_UPDATE_STATE_FILE`` / ``SETTINGS_SNAPSHOT_DIR``) point at tmp
-# paths, and ``src.backup.service.get_backup_service`` returns a canned
-# document. Identical stubs re-drive identical shapes on re-record, and the
-# golden then proves the extracted router still resolves every one of those
-# seams through ``src.api_server`` at call time.
+# ``src.system.update_service.requests`` get/post are replaced per hit, the
+# state-file and snapshot-dir test seams (``SYSTEM_UPDATE_STATE_FILE`` /
+# ``SETTINGS_SNAPSHOT_DIR``, both owned by the service since the Phase 2
+# system slice) point at tmp paths, and ``src.backup.service.get_backup_service``
+# returns a canned document. Identical stubs re-drive identical shapes on
+# re-record, and the golden then proves the router still resolves every one of
+# those collaborators through ``src.system.update_service``.
 # ---------------------------------------------------------------------------
 
 
@@ -1070,8 +1070,8 @@ def test_system_response_shapes(tmp_path, monkeypatch):
 
     state_file = tmp_path / "state.json"
     snap_dir = tmp_path / "update-backups"
-    monkeypatch.setattr("src.api_server.SYSTEM_UPDATE_STATE_FILE", state_file)
-    monkeypatch.setattr("src.api_server.SETTINGS_SNAPSHOT_DIR", snap_dir)
+    monkeypatch.setattr("src.system.update_service.SYSTEM_UPDATE_STATE_FILE", state_file)
+    monkeypatch.setattr("src.system.update_service.SETTINGS_SNAPSHOT_DIR", snap_dir)
     # Deterministic environment: docker profile, not managed externally, no
     # sidecar token until a hit opts in, dev build.
     for var in ("FIESTAUPDATER_TOKEN", "SUPERVISOR_TOKEN", "FIESTABOARD_MANAGED_EXTERNALLY", "VERSION", "PRODUCTION"):
@@ -1080,14 +1080,14 @@ def test_system_response_shapes(tmp_path, monkeypatch):
     monkeypatch.setattr("src.backup.service.get_backup_service", _GoldenBackupService)
 
     # -- /version -----------------------------------------------------------
-    with patch("src.api_server._detect_hardware_model", return_value="Raspberry Pi 5 Model B Rev 1.0"):
+    with patch("src.system.update_service._detect_hardware_model", return_value="Raspberry Pi 5 Model B Rev 1.0"):
         rec.hit("version_ok", "GET", "/version")
 
     # -- /system/update-check ----------------------------------------------
     # Docker Hub reports 99.0.0, GitHub 98.0.0: newest-of-both-sources wins.
-    with patch("src.api_server.requests.get", side_effect=_version_sources_get):
+    with patch("src.system.update_service.requests.get", side_effect=_version_sources_get):
         rec.hit("update_check_ok", "GET", "/system/update-check")
-    with patch("src.api_server.requests.get", side_effect=Exception("network down")):
+    with patch("src.system.update_service.requests.get", side_effect=Exception("network down")):
         rec.hit("update_check_sources_down", "GET", "/system/update-check")
 
     # -- /system/update/status ---------------------------------------------
@@ -1116,8 +1116,8 @@ def test_system_response_shapes(tmp_path, monkeypatch):
     empty_cm = Mock()
     empty_cm.get_all_plugin_configs.return_value = {}
     with (
-        patch("src.api_server.requests.get", side_effect=_updater_get),
-        patch("src.api_server.get_config_manager", return_value=empty_cm),
+        patch("src.system.update_service.requests.get", side_effect=_updater_get),
+        patch("src.system.update_service.get_config_manager", return_value=empty_cm),
     ):
         rec.hit("update_status_full", "GET", "/system/update/status")
 
@@ -1129,7 +1129,7 @@ def test_system_response_shapes(tmp_path, monkeypatch):
     import requests as _requests
 
     with patch(
-        "src.api_server.requests.post",
+        "src.system.update_service.requests.post",
         side_effect=_requests.exceptions.ConnectionError("sidecar down"),
     ):
         rec.hit("update_apply_sidecar_down", "POST", "/system/update")
@@ -1137,8 +1137,8 @@ def test_system_response_shapes(tmp_path, monkeypatch):
     ok_post = Mock(status_code=202)
     ok_post.json.return_value = {"previous_digest": _GOLDEN_DIGEST}
     with (
-        patch("src.api_server.requests.get", side_effect=_updater_get),
-        patch("src.api_server.requests.post", return_value=ok_post),
+        patch("src.system.update_service.requests.get", side_effect=_updater_get),
+        patch("src.system.update_service.requests.post", return_value=ok_post),
     ):
         rec.hit("update_apply_ok", "POST", "/system/update")
 
@@ -1161,7 +1161,7 @@ def test_system_response_shapes(tmp_path, monkeypatch):
         "/system/update/rollback",
         json_body={"snapshot": planted.name, "restore_image": False},
     )
-    with patch("src.api_server.requests.post", return_value=Mock(status_code=202)):
+    with patch("src.system.update_service.requests.post", return_value=Mock(status_code=202)):
         rec.hit(
             "rollback_full",
             "POST",
@@ -1192,7 +1192,7 @@ def test_system_response_shapes(tmp_path, monkeypatch):
 
     monkeypatch.setenv("FIESTAUPDATER_TOKEN", "golden-token")
     action_ok = Mock(status_code=202, text="")
-    with patch("src.api_server.requests.post", return_value=action_ok):
+    with patch("src.system.update_service.requests.post", return_value=action_ok):
         rec.hit("restart_ok", "POST", "/system/restart")
         rec.hit("shutdown_ok", "POST", "/system/shutdown")
 

--- a/tests/test_system_contract.py
+++ b/tests/test_system_contract.py
@@ -1,0 +1,521 @@
+"""Value-level contract goldens for the /version + /system API (Phase 2 §2, slice 5).
+
+These are deliberately *values*, not shapes. ``tests/golden/responses/system.json``
+records key sets and type names, so it cannot see an error string that stopped
+naming the sidecar, a hint that lost its ``docker compose`` command, or a 502
+that quietly became a 500 — the class of regression Phase 1's masking bug
+proved shape goldens miss.
+
+Every assertion below is a promise this domain makes to the web client and to
+anyone reading a failure toast.
+
+WRITTEN AGAINST THE UNMODIFIED TRUNK FIRST. Every ``detail`` value in this
+file was recorded from ``origin/next-rebuild`` before the conversion, so the
+re-pinning below is a diff a reviewer can read rather than a rewrite.
+
+Re-pinned by the conventions pass in this same PR. What deliberately changed,
+and nothing else:
+
+* **Every ``HTTPException`` detail is now a string** (22 of the domain's 24
+  raise sites were dicts). ``docs/internal/reference/API_CONVENTIONS.md``
+  §"Error contract" allows exactly one shape — ``{"detail": <string>}`` — and
+  a dict only when it carries a ``message`` key plus named fields. None of
+  these carried ``message``; they carried ad-hoc ``status`` / ``mode`` /
+  ``error`` / ``hint`` keys that no client reads. ``web/src/lib/api/core.ts``
+  already renders a non-string detail with ``JSON.stringify``, so before this
+  change the user was shown a raw JSON blob in the error toast; afterwards
+  they are shown the sentence.
+  The **status codes are unchanged** on every one of those paths, and the
+  human-readable sentence inside each old dict is preserved verbatim as the
+  new detail (the two generic ``str(e)`` bodies gain the "fiestaupdater
+  <action> call failed" prefix that was previously only in the log line).
+* Nothing else. Every success body, every status code, the auto-update
+  interval semantics, and the two paths that were already string details
+  (``POST /system/update/auto``'s two 422s) are unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+import requests as requests_lib
+from fastapi.testclient import TestClient
+
+# The module the system router resolves its collaborators through. Patching
+# here — not through ``src.api_server`` — is the point of the seam retirement
+# in this same PR.
+UPDATE_SERVICE = "src.system.update_service"
+
+_DIGEST = "sha256:" + "ab12" * 16
+_IMAGE = "fiestaboard/fiestaboard:8.0.0"
+
+_SNAPSHOT_DOC = {
+    "fiestaboard_backup": True,
+    "schema_version": 1,
+    "app_version": "7.0.0",
+    "data": {"config": {"plugins": {}}},
+    "_fiestaupdater": {"previous_digest": _DIGEST, "previous_image": _IMAGE},
+}
+
+
+@pytest.fixture
+def client(_isolated_data_dir):
+    """A TestClient whose services all resolve into this test's temp data dir."""
+    from src.api_server import app
+
+    return TestClient(app)
+
+
+@pytest.fixture
+def sidecar_seams(tmp_path, monkeypatch):
+    """Deterministic sidecar environment: no token, tmp state file + snapshot dir."""
+    state_file = tmp_path / "state.json"
+    snap_dir = tmp_path / "update-backups"
+    monkeypatch.setattr(f"{UPDATE_SERVICE}.SYSTEM_UPDATE_STATE_FILE", state_file)
+    monkeypatch.setattr(f"{UPDATE_SERVICE}.SETTINGS_SNAPSHOT_DIR", snap_dir)
+    for var in ("FIESTAUPDATER_TOKEN", "SUPERVISOR_TOKEN", "FIESTABOARD_MANAGED_EXTERNALLY"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("FIESTABOARD_PROFILE", "docker")
+    return state_file, snap_dir
+
+
+@pytest.fixture
+def snapshot(sidecar_seams):
+    """One well-formed snapshot on disk, annotated with a rollback target."""
+    _, snap_dir = sidecar_seams
+    snap_dir.mkdir(parents=True, exist_ok=True)
+    path = snap_dir / "pre-update-20260101T000000.000Z.json"
+    path.write_text(json.dumps(_SNAPSHOT_DOC), encoding="utf-8")
+    return path
+
+
+class _RestoreOk:
+    """BackupService stand-in whose restore succeeds."""
+
+    def import_from_json(self, raw: str, reinstall_plugins: bool = True) -> dict:
+        return {
+            "restored_files": ["settings.json"],
+            "skipped_files": [],
+            "pre_restore_backup_suffix": ".pre-restore-contract",
+            "reload_errors": [],
+        }
+
+
+def _raiser(exc):
+    def _boom(*_args, **_kwargs):
+        raise exc
+
+    return _boom
+
+
+# ===========================================================================
+# GET /version
+# ===========================================================================
+
+
+def test_version_reports_the_package_version_and_a_dev_build(client, monkeypatch):
+    from src import __version__
+
+    monkeypatch.delenv("VERSION", raising=False)
+    monkeypatch.delenv("PRODUCTION", raising=False)
+    with patch(f"{UPDATE_SERVICE}._detect_hardware_model", return_value="Raspberry Pi 5 Model B Rev 1.0"):
+        response = client.get("/version")
+    assert response.status_code == 200
+    assert response.json() == {
+        "package_version": __version__,
+        "build_version": "dev",
+        "is_dev": True,
+        "hardware_model": "Raspberry Pi 5 Model B Rev 1.0",
+    }
+
+
+def test_version_is_not_dev_when_a_production_build_is_tagged(client, monkeypatch):
+    monkeypatch.setenv("VERSION", "8.34.15")
+    monkeypatch.setenv("PRODUCTION", "true")
+    with patch(f"{UPDATE_SERVICE}._detect_hardware_model", return_value=None):
+        body = client.get("/version").json()
+    assert body["build_version"] == "8.34.15"
+    assert body["is_dev"] is False
+    assert body["hardware_model"] is None
+
+
+# ===========================================================================
+# GET /system/update-check — a probe endpoint: the verdict is the payload
+# ===========================================================================
+
+
+def test_update_check_reports_the_newest_version_either_source_lists(client, monkeypatch):
+    from urllib.parse import urlparse
+
+    def _get(url, **_kwargs):
+        resp = Mock(status_code=200)
+        resp.raise_for_status = Mock()
+        if urlparse(url).netloc == "hub.docker.com":
+            resp.json.return_value = {"results": [{"name": "99.0.0"}, {"name": "latest"}]}
+        else:
+            resp.json.return_value = {"tag_name": "v98.0.0"}
+        return resp
+
+    with patch(f"{UPDATE_SERVICE}.requests.get", side_effect=_get):
+        body = client.get("/system/update-check").json()
+    assert body["latest_version"] == "99.0.0"
+    assert body["update_available"] is True
+    assert body["error"] is None
+    assert body["package_url"] == "https://github.com/Fiestaboard/FiestaBoard/releases/tag/v99.0.0"
+
+
+def test_update_check_answers_200_with_an_error_field_when_both_sources_are_down(client):
+    """A probe endpoint reports the verdict about *something else* at 200.
+
+    API_CONVENTIONS.md §"Status codes" allows this exactly because the body is
+    a declared response_model with a named error field, so a generic client can
+    still tell "checked, and it failed" from "checked, and you are current".
+    """
+    with patch(f"{UPDATE_SERVICE}.requests.get", side_effect=Exception("network down")):
+        response = client.get("/system/update-check")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["latest_version"] is None
+    assert body["update_available"] is False
+    assert body["error"] == "Could not check for updates: Both Docker Hub and GitHub Releases checks failed"
+
+
+# ===========================================================================
+# GET /system/update/status
+# ===========================================================================
+
+
+def test_update_status_without_a_token_reports_the_sidecar_unavailable(client, sidecar_seams):
+    response = client.get("/system/update/status")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["updater_available"] is False
+    # No stored preference: the docker profile's default interval, not "off".
+    assert body["auto_update_enabled"] is True
+    assert body["auto_update_interval"] == "weekly"
+    assert body["managed_externally"] is False
+    assert body["profile"] == "docker"
+    assert body["settings_snapshots"] == []
+    assert body["post_upgrade_regression"] is None
+    # The sidecar was never probed, so none of its bookkeeping is invented.
+    assert body["last_update_status"] is None
+    assert body["last_update_action"] is None
+
+
+# ===========================================================================
+# POST /system/update
+# ===========================================================================
+
+
+def test_update_without_a_token_is_503_and_names_the_compose_profile(client, sidecar_seams):
+    response = client.post("/system/update")
+    assert response.status_code == 503
+    assert response.json()["detail"] == (
+        "FIESTAUPDATER_TOKEN is not set. Add COMPOSE_PROFILES=fiestaupdater to your .env "
+        "and run 'docker compose up -d' to enable in-app updates."
+    )
+
+
+def test_update_with_an_unreachable_sidecar_is_503_with_manual_instructions(client, sidecar_seams, monkeypatch):
+    monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+    with patch(
+        f"{UPDATE_SERVICE}.requests.post",
+        side_effect=requests_lib.exceptions.ConnectionError("nope"),
+    ):
+        response = client.post("/system/update")
+    assert response.status_code == 503
+    assert response.json()["detail"] == (
+        "Could not reach the fiestaupdater sidecar. Run 'docker compose pull && docker compose up -d' "
+        "from your install directory to update manually."
+    )
+
+
+def test_update_with_an_unexpected_transport_error_is_502(client, sidecar_seams, monkeypatch):
+    monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+    with patch(f"{UPDATE_SERVICE}.requests.post", side_effect=ValueError("bad url")):
+        response = client.post("/system/update")
+    assert response.status_code == 502
+    assert response.json()["detail"] == "fiestaupdater update call failed: bad url"
+
+
+def test_update_rejected_token_is_500_and_says_which_variable_to_check(client, sidecar_seams, monkeypatch):
+    monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+    with patch(f"{UPDATE_SERVICE}.requests.post", return_value=Mock(status_code=401, text="invalid_token")):
+        response = client.post("/system/update")
+    assert response.status_code == 500
+    assert response.json()["detail"] == (
+        "fiestaupdater rejected our token; check FIESTAUPDATER_TOKEN matches in both services"
+    )
+
+
+def test_update_sidecar_error_is_502_and_quotes_the_sidecar(client, sidecar_seams, monkeypatch):
+    monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+    with patch(f"{UPDATE_SERVICE}.requests.post", return_value=Mock(status_code=500, text="pull failed")):
+        response = client.post("/system/update")
+    assert response.status_code == 502
+    assert response.json()["detail"] == "fiestaupdater returned 500: pull failed"
+
+
+def test_update_happy_path_queues_and_reports_the_snapshot_it_took(client, sidecar_seams, monkeypatch):
+    monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+    accepted = Mock(status_code=202)
+    accepted.json.return_value = {"previous_digest": _DIGEST}
+    with (
+        patch(f"{UPDATE_SERVICE}.requests.post", return_value=accepted),
+        patch(f"{UPDATE_SERVICE}._updater_version", return_value={"digest": _DIGEST, "image": _IMAGE}),
+    ):
+        response = client.post("/system/update")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "queued"
+    assert body["mode"] == "sidecar"
+    assert body["previous_digest"] == _DIGEST
+    assert body["settings_snapshot"]["previous_digest"] == _DIGEST
+    assert body["settings_snapshot"]["previous_image"] == _IMAGE
+
+
+# ===========================================================================
+# POST /system/update/rollback
+# ===========================================================================
+
+
+def test_rollback_with_both_flags_false_is_400(client, sidecar_seams):
+    response = client.post(
+        "/system/update/rollback",
+        json={"restore_settings": False, "restore_image": False},
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "At least one of restore_settings, restore_image must be true."
+
+
+def test_rollback_with_no_snapshot_on_disk_is_404(client, sidecar_seams):
+    response = client.post("/system/update/rollback", json={})
+    assert response.status_code == 404
+    assert response.json()["detail"] == "No matching settings snapshot was found."
+
+
+def test_rollback_with_an_unreadable_snapshot_is_400(client, snapshot, monkeypatch):
+    monkeypatch.setattr(Path, "read_text", _raiser(OSError("disk on fire")))
+    response = client.post("/system/update/rollback", json={"restore_image": False})
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Could not read snapshot: disk on fire"
+
+
+def test_rollback_with_a_bad_snapshot_document_is_400(client, snapshot, monkeypatch):
+    from src.backup.service import BackupError
+
+    service = Mock()
+    service.import_from_json.side_effect = BackupError("Not a FiestaBoard backup file")
+    monkeypatch.setattr("src.backup.service.get_backup_service", lambda: service)
+    response = client.post("/system/update/rollback", json={"restore_image": False})
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Not a FiestaBoard backup file"
+
+
+def test_rollback_aborted_by_the_environment_is_500(client, snapshot, monkeypatch):
+    """An unwritable data dir is our failure, not a bad snapshot (Task 10d)."""
+    from src.backup.service import BackupRestoreAborted
+
+    service = Mock()
+    service.import_from_json.side_effect = BackupRestoreAborted("could not copy settings.json aside")
+    monkeypatch.setattr("src.backup.service.get_backup_service", lambda: service)
+    response = client.post("/system/update/rollback", json={"restore_image": False})
+    assert response.status_code == 500
+    assert response.json()["detail"] == "could not copy settings.json aside"
+
+
+def test_rollback_settings_only_reports_what_it_restored(client, snapshot, monkeypatch):
+    monkeypatch.setattr("src.backup.service.get_backup_service", _RestoreOk)
+    response = client.post("/system/update/rollback", json={"restore_image": False})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "success"
+    assert body["snapshot"] == snapshot.name
+    assert body["warnings"] == []
+    assert body["image_rollback"] is None
+    assert body["settings_rollback"] == {
+        "restored_from": snapshot.name,
+        "restored_files": ["settings.json"],
+        "skipped_files": [],
+        "pre_restore_backup_suffix": ".pre-restore-contract",
+        "reload_errors": [],
+    }
+
+
+def test_rollback_without_a_token_is_partial_and_says_the_image_was_left_alone(client, snapshot, monkeypatch):
+    monkeypatch.setattr("src.backup.service.get_backup_service", _RestoreOk)
+    response = client.post("/system/update/rollback", json={})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "partial"
+    assert body["image_rollback"] is None
+    assert body["warnings"] == [
+        "FIESTAUPDATER_TOKEN is not set; image rollback is unavailable. "
+        "Settings have been restored but the image is unchanged."
+    ]
+
+
+def test_rollback_of_an_unannotated_snapshot_is_partial(client, sidecar_seams, monkeypatch):
+    _, snap_dir = sidecar_seams
+    snap_dir.mkdir(parents=True, exist_ok=True)
+    doc = {k: v for k, v in _SNAPSHOT_DOC.items() if k != "_fiestaupdater"}
+    (snap_dir / "pre-update-20260101T000000.000Z.json").write_text(json.dumps(doc), encoding="utf-8")
+    monkeypatch.setattr("src.backup.service.get_backup_service", _RestoreOk)
+    monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+    body = client.post("/system/update/rollback", json={}).json()
+    assert body["status"] == "partial"
+    assert body["warnings"] == ["Snapshot does not record a previous image digest; image was not rolled back."]
+
+
+def test_rollback_image_with_an_unreachable_sidecar_is_503(client, snapshot, monkeypatch):
+    monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+    with patch(
+        f"{UPDATE_SERVICE}.requests.post",
+        side_effect=requests_lib.exceptions.ConnectionError("nope"),
+    ):
+        response = client.post("/system/update/rollback", json={"restore_settings": False})
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Could not reach the fiestaupdater sidecar; image rollback unavailable."
+
+
+def test_rollback_image_with_an_unexpected_transport_error_is_502(client, snapshot, monkeypatch):
+    monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+    with patch(f"{UPDATE_SERVICE}.requests.post", side_effect=ValueError("bad url")):
+        response = client.post("/system/update/rollback", json={"restore_settings": False})
+    assert response.status_code == 502
+    assert response.json()["detail"] == "fiestaupdater rollback call failed: bad url"
+
+
+def test_rollback_image_rejected_token_is_500(client, snapshot, monkeypatch):
+    monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+    with patch(f"{UPDATE_SERVICE}.requests.post", return_value=Mock(status_code=401, text="invalid_token")):
+        response = client.post("/system/update/rollback", json={"restore_settings": False})
+    assert response.status_code == 500
+    assert response.json()["detail"] == "fiestaupdater rejected our token"
+
+
+def test_rollback_image_sidecar_error_is_502_and_quotes_the_sidecar(client, snapshot, monkeypatch):
+    monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+    with patch(f"{UPDATE_SERVICE}.requests.post", return_value=Mock(status_code=500, text="retag failed")):
+        response = client.post("/system/update/rollback", json={"restore_settings": False})
+    assert response.status_code == 502
+    assert response.json()["detail"] == "fiestaupdater returned 500: retag failed"
+
+
+def test_rollback_image_happy_path_queues_the_recorded_digest(client, snapshot, monkeypatch):
+    monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+    with patch(f"{UPDATE_SERVICE}.requests.post", return_value=Mock(status_code=202, text="")):
+        response = client.post("/system/update/rollback", json={"restore_settings": False})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "success"
+    assert body["settings_rollback"] is None
+    assert body["image_rollback"] == {
+        "target_digest": _DIGEST,
+        "target_image": _IMAGE,
+        "queued": True,
+    }
+
+
+# ===========================================================================
+# POST /system/update/auto — the two paths that were already string details
+# ===========================================================================
+
+
+def test_auto_update_interval_is_persisted_and_echoed(client, sidecar_seams):
+    state_file, _ = sidecar_seams
+    response = client.post("/system/update/auto", json={"interval": "weekly"})
+    assert response.status_code == 200
+    assert response.json() == {"enabled": True, "interval": "weekly"}
+    persisted = json.loads(state_file.read_text(encoding="utf-8"))
+    assert persisted["auto_update_interval"] == "weekly"
+    assert persisted["auto_update_enabled"] is True
+
+
+def test_auto_update_legacy_false_maps_to_manual(client, sidecar_seams):
+    assert client.post("/system/update/auto", json={"enabled": False}).json() == {
+        "enabled": False,
+        "interval": "manual",
+    }
+
+
+def test_auto_update_rejects_an_unknown_interval_with_422(client, sidecar_seams):
+    response = client.post("/system/update/auto", json={"interval": "hourly"})
+    assert response.status_code == 422
+    assert response.json()["detail"] == (
+        "Invalid interval 'hourly'; must be one of: ['daily', 'manual', 'monthly', 'weekly']"
+    )
+
+
+def test_auto_update_rejects_an_empty_body_with_422(client, sidecar_seams):
+    response = client.post("/system/update/auto", json={})
+    assert response.status_code == 422
+    assert response.json()["detail"] == "Request must include either 'interval' or 'enabled'."
+
+
+# ===========================================================================
+# POST /system/restart and POST /system/shutdown
+# ===========================================================================
+
+
+@pytest.mark.parametrize("action", ["restart", "shutdown"])
+def test_system_action_without_a_token_is_503_and_names_the_compose_profile(client, sidecar_seams, action):
+    response = client.post(f"/system/{action}")
+    assert response.status_code == 503
+    assert response.json()["detail"] == (
+        "FIESTAUPDATER_TOKEN is not set. Add COMPOSE_PROFILES=fiestaupdater to your .env "
+        "and run 'docker compose up -d' to enable sidecar features."
+    )
+
+
+@pytest.mark.parametrize("action", ["restart", "shutdown"])
+def test_system_action_with_an_unreachable_sidecar_is_503(client, sidecar_seams, monkeypatch, action):
+    monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+    with patch(
+        f"{UPDATE_SERVICE}.requests.post",
+        side_effect=requests_lib.exceptions.ConnectionError("nope"),
+    ):
+        response = client.post(f"/system/{action}")
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Could not reach the fiestaupdater sidecar."
+
+
+@pytest.mark.parametrize("action", ["restart", "shutdown"])
+def test_system_action_with_an_unexpected_transport_error_is_502(client, sidecar_seams, monkeypatch, action):
+    monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+    with patch(f"{UPDATE_SERVICE}.requests.post", side_effect=ValueError("bad url")):
+        response = client.post(f"/system/{action}")
+    assert response.status_code == 502
+    assert response.json()["detail"] == f"fiestaupdater {action} call failed: bad url"
+
+
+@pytest.mark.parametrize("action", ["restart", "shutdown"])
+def test_system_action_rejected_token_is_500(client, sidecar_seams, monkeypatch, action):
+    monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+    with patch(f"{UPDATE_SERVICE}.requests.post", return_value=Mock(status_code=401, text="invalid_token")):
+        response = client.post(f"/system/{action}")
+    assert response.status_code == 500
+    assert response.json()["detail"] == (
+        "fiestaupdater rejected our token; check FIESTAUPDATER_TOKEN matches in both services"
+    )
+
+
+@pytest.mark.parametrize("action", ["restart", "shutdown"])
+def test_system_action_sidecar_error_is_502_and_quotes_the_sidecar(client, sidecar_seams, monkeypatch, action):
+    monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+    with patch(f"{UPDATE_SERVICE}.requests.post", return_value=Mock(status_code=503, text="busy")):
+        response = client.post(f"/system/{action}")
+    assert response.status_code == 502
+    assert response.json()["detail"] == "fiestaupdater returned 503: busy"
+
+
+@pytest.mark.parametrize("action", ["restart", "shutdown"])
+def test_system_action_happy_path_queues(client, sidecar_seams, monkeypatch, action):
+    monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+    with patch(f"{UPDATE_SERVICE}.requests.post", return_value=Mock(status_code=202, text="")):
+        response = client.post(f"/system/{action}")
+    assert response.status_code == 200
+    assert response.json() == {"status": "queued", "action": action}

--- a/tests/test_system_endpoints.py
+++ b/tests/test_system_endpoints.py
@@ -34,7 +34,7 @@ def client():
 @pytest.fixture(autouse=True)
 def _isolate_state_file(tmp_path):
     """Give every test its own state file to prevent state leaking between tests."""
-    with patch("src.api_server.SYSTEM_UPDATE_STATE_FILE", tmp_path / "update_state.json"):
+    with patch("src.system.update_service.SYSTEM_UPDATE_STATE_FILE", tmp_path / "update_state.json"):
         yield
 
 
@@ -48,7 +48,7 @@ class TestUpdateCheck:
         mock_response.json.return_value = {"tag_name": "v99.0.0"}
         mock_response.raise_for_status = Mock()
 
-        with patch("src.api_server.requests.get", return_value=mock_response):
+        with patch("src.system.update_service.requests.get", return_value=mock_response):
             response = client.get("/system/update-check")
 
         assert response.status_code == 200
@@ -67,7 +67,7 @@ class TestUpdateCheck:
         mock_response.json.return_value = {"tag_name": f"v{__version__}"}
         mock_response.raise_for_status = Mock()
 
-        with patch("src.api_server.requests.get", return_value=mock_response):
+        with patch("src.system.update_service.requests.get", return_value=mock_response):
             response = client.get("/system/update-check")
 
         assert response.status_code == 200
@@ -78,7 +78,7 @@ class TestUpdateCheck:
 
     def test_github_api_failure(self, client):
         """Test graceful handling when GitHub API is unreachable."""
-        with patch("src.api_server.requests.get", side_effect=Exception("Network error")):
+        with patch("src.system.update_service.requests.get", side_effect=Exception("Network error")):
             response = client.get("/system/update-check")
 
         assert response.status_code == 200
@@ -99,7 +99,7 @@ class TestUpdateCheck:
         mock_response.raise_for_status = Mock()
 
         with (
-            patch("src.api_server.requests.get", return_value=mock_response),
+            patch("src.system.update_service.requests.get", return_value=mock_response),
             patch.dict("os.environ", {"PRODUCTION": "true"}),
         ):
             response = client.get("/system/update-check")
@@ -114,7 +114,7 @@ class TestUpdateCheck:
         mock_response.json.return_value = {"tag_name": "99.0.0"}
         mock_response.raise_for_status = Mock()
 
-        with patch("src.api_server.requests.get", return_value=mock_response):
+        with patch("src.system.update_service.requests.get", return_value=mock_response):
             response = client.get("/system/update-check")
 
         assert response.status_code == 200
@@ -128,7 +128,7 @@ class TestDockerHubCheck:
 
     def test_dockerhub_check_returns_latest_version(self):
         """Test Docker Hub check correctly finds the highest semver tag."""
-        from src.api_server import _check_dockerhub_for_latest
+        from src.system.update_service import _check_dockerhub_for_latest
 
         tags_resp = Mock()
         tags_resp.status_code = 200
@@ -137,44 +137,44 @@ class TestDockerHubCheck:
         }
         tags_resp.raise_for_status = Mock()
 
-        with patch("src.api_server.requests.get", return_value=tags_resp):
+        with patch("src.system.update_service.requests.get", return_value=tags_resp):
             result = _check_dockerhub_for_latest()
 
         assert result == "2.1.0"
 
     def test_dockerhub_check_no_version_tags(self):
         """Test Docker Hub check returns None when no semver tags exist."""
-        from src.api_server import _check_dockerhub_for_latest
+        from src.system.update_service import _check_dockerhub_for_latest
 
         tags_resp = Mock()
         tags_resp.status_code = 200
         tags_resp.json.return_value = {"results": [{"name": "latest"}, {"name": "main"}, {"name": "dev"}]}
         tags_resp.raise_for_status = Mock()
 
-        with patch("src.api_server.requests.get", return_value=tags_resp):
+        with patch("src.system.update_service.requests.get", return_value=tags_resp):
             result = _check_dockerhub_for_latest()
 
         assert result is None
 
     def test_dockerhub_check_network_failure(self):
         """Test Docker Hub check returns None on network error."""
-        from src.api_server import _check_dockerhub_for_latest
+        from src.system.update_service import _check_dockerhub_for_latest
 
-        with patch("src.api_server.requests.get", side_effect=Exception("Connection refused")):
+        with patch("src.system.update_service.requests.get", side_effect=Exception("Connection refused")):
             result = _check_dockerhub_for_latest()
 
         assert result is None
 
     def test_dockerhub_check_empty_results(self):
         """Test Docker Hub check returns None when results array is empty."""
-        from src.api_server import _check_dockerhub_for_latest
+        from src.system.update_service import _check_dockerhub_for_latest
 
         tags_resp = Mock()
         tags_resp.status_code = 200
         tags_resp.json.return_value = {"results": []}
         tags_resp.raise_for_status = Mock()
 
-        with patch("src.api_server.requests.get", return_value=tags_resp):
+        with patch("src.system.update_service.requests.get", return_value=tags_resp):
             result = _check_dockerhub_for_latest()
 
         assert result is None
@@ -203,7 +203,7 @@ class TestDockerHubCheck:
                 return tags_resp
             return github_resp
 
-        with patch("src.api_server.requests.get", side_effect=mock_get):
+        with patch("src.system.update_service.requests.get", side_effect=mock_get):
             response = client.get("/system/update-check")
 
         assert response.status_code == 200
@@ -229,7 +229,7 @@ class TestDockerHubCheck:
             call_count["github"] += 1
             return releases_resp
 
-        with patch("src.api_server.requests.get", side_effect=mock_get):
+        with patch("src.system.update_service.requests.get", side_effect=mock_get):
             response = client.get("/system/update-check")
 
         assert response.status_code == 200
@@ -263,7 +263,7 @@ class TestDockerHubCheck:
                 return tags_resp
             return github_resp
 
-        with patch("src.api_server.requests.get", side_effect=mock_get):
+        with patch("src.system.update_service.requests.get", side_effect=mock_get):
             response = client.get("/system/update-check")
 
         assert response.status_code == 200
@@ -277,29 +277,29 @@ class TestPickLatestVersion:
     """Tests for the _pick_latest_version helper (newest-of-all-sources selection)."""
 
     def test_returns_higher_when_first_is_higher(self):
-        from src.api_server import _pick_latest_version
+        from src.system.update_service import _pick_latest_version
 
         assert _pick_latest_version("8.3.0", "8.2.4") == "8.3.0"
 
     def test_returns_higher_when_second_is_higher(self):
-        from src.api_server import _pick_latest_version
+        from src.system.update_service import _pick_latest_version
 
         # Docker Hub (first) lags behind a newer GitHub release (second).
         assert _pick_latest_version("8.2.4", "8.3.0") == "8.3.0"
 
     def test_ignores_none_candidates(self):
-        from src.api_server import _pick_latest_version
+        from src.system.update_service import _pick_latest_version
 
         assert _pick_latest_version(None, "8.3.0") == "8.3.0"
         assert _pick_latest_version("8.3.0", None) == "8.3.0"
 
     def test_returns_none_when_all_empty(self):
-        from src.api_server import _pick_latest_version
+        from src.system.update_service import _pick_latest_version
 
         assert _pick_latest_version(None, None) is None
 
     def test_ignores_unparseable_candidate(self):
-        from src.api_server import _pick_latest_version
+        from src.system.update_service import _pick_latest_version
 
         # A non-numeric tag must never be chosen over a valid one.
         assert _pick_latest_version("v8.3.0", "8.2.4") == "8.2.4"
@@ -310,37 +310,37 @@ class TestIsNewerVersion:
     """Tests for _is_newer_version helper."""
 
     def test_newer_major(self):
-        from src.api_server import _is_newer_version
+        from src.system.update_service import _is_newer_version
 
         assert _is_newer_version("3.0.0", "2.0.0") is True
 
     def test_newer_minor(self):
-        from src.api_server import _is_newer_version
+        from src.system.update_service import _is_newer_version
 
         assert _is_newer_version("2.1.0", "2.0.0") is True
 
     def test_newer_patch(self):
-        from src.api_server import _is_newer_version
+        from src.system.update_service import _is_newer_version
 
         assert _is_newer_version("2.0.1", "2.0.0") is True
 
     def test_same_version(self):
-        from src.api_server import _is_newer_version
+        from src.system.update_service import _is_newer_version
 
         assert _is_newer_version("2.0.0", "2.0.0") is False
 
     def test_older_version(self):
-        from src.api_server import _is_newer_version
+        from src.system.update_service import _is_newer_version
 
         assert _is_newer_version("1.9.0", "2.0.0") is False
 
     def test_invalid_version(self):
-        from src.api_server import _is_newer_version
+        from src.system.update_service import _is_newer_version
 
         assert _is_newer_version("invalid", "2.0.0") is False
 
     def test_empty_string(self):
-        from src.api_server import _is_newer_version
+        from src.system.update_service import _is_newer_version
 
         assert _is_newer_version("", "2.0.0") is False
 
@@ -358,7 +358,7 @@ class TestSystemUpdateStatus:
         """Without FIESTAUPDATER_TOKEN we never even probe the sidecar."""
         monkeypatch.delenv("FIESTAUPDATER_TOKEN", raising=False)
         monkeypatch.setattr(
-            "src.api_server.SYSTEM_UPDATE_STATE_FILE",
+            "src.system.update_service.SYSTEM_UPDATE_STATE_FILE",
             tmp_path / "state.json",
         )
         response = client.get("/system/update/status")
@@ -372,11 +372,11 @@ class TestSystemUpdateStatus:
         """When the sidecar /healthz returns 200, we report it available."""
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
         monkeypatch.setattr(
-            "src.api_server.SYSTEM_UPDATE_STATE_FILE",
+            "src.system.update_service.SYSTEM_UPDATE_STATE_FILE",
             tmp_path / "state.json",
         )
         ok = Mock(status_code=200)
-        with patch("src.api_server.requests.get", return_value=ok):
+        with patch("src.system.update_service.requests.get", return_value=ok):
             response = client.get("/system/update/status")
         assert response.status_code == 200
         assert response.json()["updater_available"] is True
@@ -385,10 +385,10 @@ class TestSystemUpdateStatus:
         """A network error during the probe must not 500."""
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
         monkeypatch.setattr(
-            "src.api_server.SYSTEM_UPDATE_STATE_FILE",
+            "src.system.update_service.SYSTEM_UPDATE_STATE_FILE",
             tmp_path / "state.json",
         )
-        with patch("src.api_server.requests.get", side_effect=Exception("boom")):
+        with patch("src.system.update_service.requests.get", side_effect=Exception("boom")):
             response = client.get("/system/update/status")
         assert response.status_code == 200
         assert response.json()["updater_available"] is False
@@ -415,28 +415,28 @@ class TestManagedExternally:
     """Tests for the ``_managed_externally`` HA-add-on detection helper."""
 
     def test_defaults_off(self, monkeypatch):
-        from src.api_server import _managed_externally
+        from src.system.update_service import _managed_externally
 
         monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
         monkeypatch.delenv("FIESTABOARD_MANAGED_EXTERNALLY", raising=False)
         assert _managed_externally() is False
 
     def test_supervisor_token_enables(self, monkeypatch):
-        from src.api_server import _managed_externally
+        from src.system.update_service import _managed_externally
 
         monkeypatch.delenv("FIESTABOARD_MANAGED_EXTERNALLY", raising=False)
         monkeypatch.setenv("SUPERVISOR_TOKEN", "tok")
         assert _managed_externally() is True
 
     def test_explicit_true_overrides_missing_supervisor(self, monkeypatch):
-        from src.api_server import _managed_externally
+        from src.system.update_service import _managed_externally
 
         monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
         monkeypatch.setenv("FIESTABOARD_MANAGED_EXTERNALLY", "true")
         assert _managed_externally() is True
 
     def test_explicit_false_overrides_supervisor_token(self, monkeypatch):
-        from src.api_server import _managed_externally
+        from src.system.update_service import _managed_externally
 
         # Explicit opt-out wins even when the Supervisor token is present.
         monkeypatch.setenv("SUPERVISOR_TOKEN", "tok")
@@ -452,48 +452,47 @@ class TestSystemUpdateApply:
         monkeypatch.delenv("FIESTAUPDATER_TOKEN", raising=False)
         response = client.post("/system/update")
         assert response.status_code == 503
-        body = response.json()["detail"]
-        assert body["mode"] == "manual"
-        assert "docker compose" in body["hint"]
+        # Conventions pass: detail is a string, not a {status, mode, hint} dict.
+        assert "docker compose" in response.json()["detail"]
 
     def test_sidecar_unreachable_returns_503(self, client, tmp_path, monkeypatch):
         """When the sidecar host is unreachable, we surface a manual fallback."""
         import requests as _requests
 
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
-        monkeypatch.setattr("src.api_server.SETTINGS_SNAPSHOT_DIR", tmp_path / "snaps")
+        monkeypatch.setattr("src.system.update_service.SETTINGS_SNAPSHOT_DIR", tmp_path / "snaps")
         with patch(
-            "src.api_server.requests.post",
+            "src.system.update_service.requests.post",
             side_effect=_requests.exceptions.ConnectionError("nope"),
         ):
             response = client.post("/system/update")
         assert response.status_code == 503
-        assert response.json()["detail"]["mode"] == "manual"
+        assert "update manually" in response.json()["detail"]
 
     def test_sidecar_rejects_token(self, client, tmp_path, monkeypatch):
         """A 401 from the sidecar means our shared token is misconfigured."""
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
-        monkeypatch.setattr("src.api_server.SETTINGS_SNAPSHOT_DIR", tmp_path / "snaps")
+        monkeypatch.setattr("src.system.update_service.SETTINGS_SNAPSHOT_DIR", tmp_path / "snaps")
         bad = Mock(status_code=401, text="invalid_token")
-        with patch("src.api_server.requests.post", return_value=bad):
+        with patch("src.system.update_service.requests.post", return_value=bad):
             response = client.post("/system/update")
         assert response.status_code == 500
-        assert "FIESTAUPDATER_TOKEN" in response.json()["detail"]["error"]
+        assert "FIESTAUPDATER_TOKEN" in response.json()["detail"]
 
     def test_happy_path_returns_queued(self, client, tmp_path, monkeypatch):
         """A 202 from the sidecar yields {status: queued, mode: sidecar}."""
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
         monkeypatch.setattr(
-            "src.api_server.SYSTEM_UPDATE_STATE_FILE",
+            "src.system.update_service.SYSTEM_UPDATE_STATE_FILE",
             tmp_path / "state.json",
         )
         monkeypatch.setattr(
-            "src.api_server.SETTINGS_SNAPSHOT_DIR",
+            "src.system.update_service.SETTINGS_SNAPSHOT_DIR",
             tmp_path / "update-backups",
         )
         ok = Mock(status_code=202)
         ok.json.return_value = {"previous_digest": "sha256:abc"}
-        with patch("src.api_server.requests.post", return_value=ok):
+        with patch("src.system.update_service.requests.post", return_value=ok):
             response = client.post("/system/update")
         assert response.status_code == 200
         data = response.json()
@@ -508,7 +507,7 @@ class TestSystemUpdateAutoToggle:
     def test_persists_enabled_flag(self, client, tmp_path, monkeypatch):
         """Legacy ``enabled`` bool: True -> default interval, False -> manual."""
         state_file = tmp_path / "state.json"
-        monkeypatch.setattr("src.api_server.SYSTEM_UPDATE_STATE_FILE", state_file)
+        monkeypatch.setattr("src.system.update_service.SYSTEM_UPDATE_STATE_FILE", state_file)
         # Force a known profile so the default interval is deterministic.
         monkeypatch.setenv("FIESTABOARD_PROFILE", "docker")
 
@@ -536,7 +535,7 @@ class TestSystemUpdateAutoToggle:
     def test_persists_interval(self, client, tmp_path, monkeypatch):
         """The ``interval`` field is persisted and echoed back."""
         state_file = tmp_path / "state.json"
-        monkeypatch.setattr("src.api_server.SYSTEM_UPDATE_STATE_FILE", state_file)
+        monkeypatch.setattr("src.system.update_service.SYSTEM_UPDATE_STATE_FILE", state_file)
         import json as _json
 
         for interval, expected_enabled in [
@@ -556,7 +555,7 @@ class TestSystemUpdateAutoToggle:
 
     def test_invalid_interval_rejected(self, client, tmp_path, monkeypatch):
         state_file = tmp_path / "state.json"
-        monkeypatch.setattr("src.api_server.SYSTEM_UPDATE_STATE_FILE", state_file)
+        monkeypatch.setattr("src.system.update_service.SYSTEM_UPDATE_STATE_FILE", state_file)
 
         r = client.post("/system/update/auto", json={"interval": "hourly"})
         assert r.status_code == 422
@@ -564,7 +563,7 @@ class TestSystemUpdateAutoToggle:
     def test_empty_body_rejected(self, client, tmp_path, monkeypatch):
         """Must provide either ``interval`` or ``enabled``."""
         state_file = tmp_path / "state.json"
-        monkeypatch.setattr("src.api_server.SYSTEM_UPDATE_STATE_FILE", state_file)
+        monkeypatch.setattr("src.system.update_service.SYSTEM_UPDATE_STATE_FILE", state_file)
 
         r = client.post("/system/update/auto", json={})
         assert r.status_code == 422
@@ -572,7 +571,7 @@ class TestSystemUpdateAutoToggle:
     def test_status_reports_default_interval_when_unset(self, client, tmp_path, monkeypatch):
         """Fresh state file -> default interval based on profile."""
         state_file = tmp_path / "state.json"
-        monkeypatch.setattr("src.api_server.SYSTEM_UPDATE_STATE_FILE", state_file)
+        monkeypatch.setattr("src.system.update_service.SYSTEM_UPDATE_STATE_FILE", state_file)
         monkeypatch.setenv("FIESTABOARD_PROFILE", "docker")
 
         r = client.get("/system/update/status")
@@ -584,7 +583,7 @@ class TestSystemUpdateAutoToggle:
     def test_status_reports_pi_default_interval(self, client, tmp_path, monkeypatch):
         """FiestaPi profile defaults to ``daily`` (matching the prior auto-update-on behavior)."""
         state_file = tmp_path / "state.json"
-        monkeypatch.setattr("src.api_server.SYSTEM_UPDATE_STATE_FILE", state_file)
+        monkeypatch.setattr("src.system.update_service.SYSTEM_UPDATE_STATE_FILE", state_file)
         monkeypatch.setenv("FIESTABOARD_PROFILE", "pi")
 
         r = client.get("/system/update/status")
@@ -597,7 +596,7 @@ class TestSystemUpdateAutoToggle:
         """A state file with only the legacy bool maps to a sane interval."""
         state_file = tmp_path / "state.json"
         state_file.write_text('{"auto_update_enabled": false}')
-        monkeypatch.setattr("src.api_server.SYSTEM_UPDATE_STATE_FILE", state_file)
+        monkeypatch.setattr("src.system.update_service.SYSTEM_UPDATE_STATE_FILE", state_file)
 
         r = client.get("/system/update/status")
         assert r.status_code == 200
@@ -610,14 +609,14 @@ class TestUpdateCheckDueHelper:
     """Tests for the ``_is_update_check_due`` background-loop helper."""
 
     def test_no_last_check_is_due(self):
-        from src.api_server import _is_update_check_due
+        from src.system.update_service import _is_update_check_due
 
         assert _is_update_check_due({}, period_days=7) is True
 
     def test_recent_check_not_due(self):
         from datetime import datetime
 
-        from src.api_server import _is_update_check_due
+        from src.system.update_service import _is_update_check_due
 
         recent = datetime.now(UTC).isoformat()
         assert _is_update_check_due({"last_check": recent}, period_days=7) is False
@@ -625,19 +624,19 @@ class TestUpdateCheckDueHelper:
     def test_old_check_is_due(self):
         from datetime import datetime, timedelta
 
-        from src.api_server import _is_update_check_due
+        from src.system.update_service import _is_update_check_due
 
         old = (datetime.now(UTC) - timedelta(days=30)).isoformat()
         assert _is_update_check_due({"last_check": old}, period_days=7) is True
 
     def test_manual_period_never_due(self):
-        from src.api_server import _is_update_check_due
+        from src.system.update_service import _is_update_check_due
 
         # period_days <= 0 means "manual"; never run regardless of last_check
         assert _is_update_check_due({}, period_days=0) is False
 
     def test_malformed_last_check_treated_as_due(self):
-        from src.api_server import _is_update_check_due
+        from src.system.update_service import _is_update_check_due
 
         assert _is_update_check_due({"last_check": "not-a-date"}, period_days=7) is True
 
@@ -654,14 +653,14 @@ class TestSystemRestart:
         monkeypatch.delenv("FIESTAUPDATER_TOKEN", raising=False)
         response = client.post("/system/restart")
         assert response.status_code == 503
-        assert "hint" in response.json()["detail"]
+        assert "FIESTAUPDATER_TOKEN is not set" in response.json()["detail"]
 
     def test_sidecar_unreachable_returns_503(self, client, monkeypatch):
         import requests as _requests
 
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
         with patch(
-            "src.api_server.requests.post",
+            "src.system.update_service.requests.post",
             side_effect=_requests.exceptions.ConnectionError("nope"),
         ):
             response = client.post("/system/restart")
@@ -670,16 +669,16 @@ class TestSystemRestart:
     def test_sidecar_rejects_token_returns_500(self, client, monkeypatch):
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
         bad = Mock(status_code=401, text="invalid_token")
-        with patch("src.api_server.requests.post", return_value=bad):
+        with patch("src.system.update_service.requests.post", return_value=bad):
             response = client.post("/system/restart")
         assert response.status_code == 500
-        assert "FIESTAUPDATER_TOKEN" in response.json()["detail"]["error"]
+        assert "FIESTAUPDATER_TOKEN" in response.json()["detail"]
 
     def test_happy_path_returns_queued(self, client, monkeypatch):
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
         ok = Mock(status_code=202)
         ok.json.return_value = {"status": "queued", "action": "restart"}
-        with patch("src.api_server.requests.post", return_value=ok):
+        with patch("src.system.update_service.requests.post", return_value=ok):
             response = client.post("/system/restart")
         assert response.status_code == 200
         data = response.json()
@@ -699,14 +698,14 @@ class TestSystemShutdown:
         monkeypatch.delenv("FIESTAUPDATER_TOKEN", raising=False)
         response = client.post("/system/shutdown")
         assert response.status_code == 503
-        assert "hint" in response.json()["detail"]
+        assert "FIESTAUPDATER_TOKEN is not set" in response.json()["detail"]
 
     def test_sidecar_unreachable_returns_503(self, client, monkeypatch):
         import requests as _requests
 
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
         with patch(
-            "src.api_server.requests.post",
+            "src.system.update_service.requests.post",
             side_effect=_requests.exceptions.ConnectionError("nope"),
         ):
             response = client.post("/system/shutdown")
@@ -715,16 +714,16 @@ class TestSystemShutdown:
     def test_sidecar_rejects_token_returns_500(self, client, monkeypatch):
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
         bad = Mock(status_code=401, text="invalid_token")
-        with patch("src.api_server.requests.post", return_value=bad):
+        with patch("src.system.update_service.requests.post", return_value=bad):
             response = client.post("/system/shutdown")
         assert response.status_code == 500
-        assert "FIESTAUPDATER_TOKEN" in response.json()["detail"]["error"]
+        assert "FIESTAUPDATER_TOKEN" in response.json()["detail"]
 
     def test_happy_path_returns_queued(self, client, monkeypatch):
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
         ok = Mock(status_code=202)
         ok.json.return_value = {"status": "queued", "action": "shutdown"}
-        with patch("src.api_server.requests.post", return_value=ok):
+        with patch("src.system.update_service.requests.post", return_value=ok):
             response = client.post("/system/shutdown")
         assert response.status_code == 200
         data = response.json()
@@ -766,11 +765,11 @@ class TestFormulaFunctions:
 
 
 class TestSettingsSnapshots:
-    """Direct tests for the snapshot helper functions in api_server."""
+    """Direct tests for the snapshot helper functions in src/system/update_service.py."""
 
     def test_take_snapshot_creates_file(self, tmp_path, monkeypatch):
         """A snapshot file lands in SETTINGS_SNAPSHOT_DIR with valid JSON."""
-        from src import api_server as api
+        from src.system import update_service as api
 
         snap_dir = tmp_path / "update-backups"
         monkeypatch.setattr(api, "SETTINGS_SNAPSHOT_DIR", snap_dir)
@@ -792,7 +791,7 @@ class TestSettingsSnapshots:
 
     def test_retention_keeps_only_five(self, tmp_path, monkeypatch):
         """Six snapshots → only the newest five remain after pruning."""
-        from src import api_server as api
+        from src.system import update_service as api
 
         snap_dir = tmp_path / "update-backups"
         monkeypatch.setattr(api, "SETTINGS_SNAPSHOT_DIR", snap_dir)
@@ -816,7 +815,7 @@ class TestSettingsSnapshots:
         config, the detector returns a recovery hint pointing at the rollback
         endpoint. This is the visible-to-the-user half of issue #948.
         """
-        from src import api_server as api
+        from src.system import update_service as api
 
         snap_dir = tmp_path / "update-backups"
         snap_dir.mkdir()
@@ -861,7 +860,7 @@ class TestSettingsSnapshots:
 
     def test_detect_regression_returns_none_when_caught_up(self, tmp_path, monkeypatch):
         """A clean upgrade (no plugin loss) does not produce a recovery hint."""
-        from src import api_server as api
+        from src.system import update_service as api
 
         snap_dir = tmp_path / "update-backups"
         snap_dir.mkdir()
@@ -881,7 +880,7 @@ class TestSettingsSnapshots:
 
     def test_detect_regression_returns_none_when_no_snapshots(self, tmp_path, monkeypatch):
         """No snapshots → nothing to compare against → no hint."""
-        from src import api_server as api
+        from src.system import update_service as api
 
         snap_dir = tmp_path / "update-backups"
         monkeypatch.setattr(api, "SETTINGS_SNAPSHOT_DIR", snap_dir)
@@ -890,7 +889,7 @@ class TestSettingsSnapshots:
 
     def test_resolve_rejects_path_traversal(self, tmp_path, monkeypatch):
         """``..`` and absolute paths must not escape the snapshot dir."""
-        from src import api_server as api
+        from src.system import update_service as api
 
         snap_dir = tmp_path / "update-backups"
         monkeypatch.setattr(api, "SETTINGS_SNAPSHOT_DIR", snap_dir)
@@ -909,7 +908,7 @@ class TestSettingsSnapshots:
 
     def test_resolve_returns_newest_when_name_omitted(self, tmp_path, monkeypatch):
         """Calling ``_resolve_snapshot_name(None)`` returns the latest snapshot."""
-        from src import api_server as api
+        from src.system import update_service as api
 
         snap_dir = tmp_path / "update-backups"
         monkeypatch.setattr(api, "SETTINGS_SNAPSHOT_DIR", snap_dir)
@@ -929,8 +928,8 @@ class TestSystemUpdateStatusRollbackFields:
     def test_status_includes_sidecar_last_update(self, client, tmp_path, monkeypatch):
         """A rolled-back attempt is reflected in the status payload."""
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
-        monkeypatch.setattr("src.api_server.SYSTEM_UPDATE_STATE_FILE", tmp_path / "state.json")
-        monkeypatch.setattr("src.api_server.SETTINGS_SNAPSHOT_DIR", tmp_path / "snaps")
+        monkeypatch.setattr("src.system.update_service.SYSTEM_UPDATE_STATE_FILE", tmp_path / "state.json")
+        monkeypatch.setattr("src.system.update_service.SETTINGS_SNAPSHOT_DIR", tmp_path / "snaps")
 
         # Mock both /healthz (probe) and /last-update with one fake `requests.get`.
         def _fake_get(url, **_kwargs):
@@ -949,7 +948,7 @@ class TestSystemUpdateStatusRollbackFields:
                 return last
             return Mock(status_code=404)
 
-        with patch("src.api_server.requests.get", side_effect=_fake_get):
+        with patch("src.system.update_service.requests.get", side_effect=_fake_get):
             r = client.get("/system/update/status")
         assert r.status_code == 200
         body = r.json()
@@ -962,9 +961,9 @@ class TestSystemUpdateStatusRollbackFields:
     def test_status_skips_last_update_when_sidecar_unreachable(self, client, tmp_path, monkeypatch):
         """If the sidecar is down, status must not pretend to know its state."""
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
-        monkeypatch.setattr("src.api_server.SYSTEM_UPDATE_STATE_FILE", tmp_path / "state.json")
-        monkeypatch.setattr("src.api_server.SETTINGS_SNAPSHOT_DIR", tmp_path / "snaps")
-        with patch("src.api_server.requests.get", side_effect=Exception("boom")):
+        monkeypatch.setattr("src.system.update_service.SYSTEM_UPDATE_STATE_FILE", tmp_path / "state.json")
+        monkeypatch.setattr("src.system.update_service.SETTINGS_SNAPSHOT_DIR", tmp_path / "snaps")
+        with patch("src.system.update_service.requests.get", side_effect=Exception("boom")):
             r = client.get("/system/update/status")
         assert r.status_code == 200
         body = r.json()
@@ -973,17 +972,17 @@ class TestSystemUpdateStatusRollbackFields:
 
     def test_status_lists_settings_snapshots(self, client, tmp_path, monkeypatch):
         """Status payload lists snapshots so the UI can offer rollback."""
-        from src import api_server as api
+        from src.system import update_service as api
 
         snap_dir = tmp_path / "snaps"
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
-        monkeypatch.setattr("src.api_server.SYSTEM_UPDATE_STATE_FILE", tmp_path / "state.json")
+        monkeypatch.setattr("src.system.update_service.SYSTEM_UPDATE_STATE_FILE", tmp_path / "state.json")
         monkeypatch.setattr(api, "SETTINGS_SNAPSHOT_DIR", snap_dir)
         api._take_settings_snapshot()
         api._take_settings_snapshot()
 
         # Sidecar unreachable so we don't try to parse last-update.
-        with patch("src.api_server.requests.get", side_effect=Exception("nope")):
+        with patch("src.system.update_service.requests.get", side_effect=Exception("nope")):
             r = client.get("/system/update/status")
         body = r.json()
         assert len(body["settings_snapshots"]) == 2
@@ -998,13 +997,13 @@ class TestSystemUpdateApplyTakesSnapshot:
 
     def test_snapshot_returned_in_apply_response(self, client, tmp_path, monkeypatch):
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
-        monkeypatch.setattr("src.api_server.SYSTEM_UPDATE_STATE_FILE", tmp_path / "state.json")
+        monkeypatch.setattr("src.system.update_service.SYSTEM_UPDATE_STATE_FILE", tmp_path / "state.json")
         snap_dir = tmp_path / "update-backups"
-        monkeypatch.setattr("src.api_server.SETTINGS_SNAPSHOT_DIR", snap_dir)
+        monkeypatch.setattr("src.system.update_service.SETTINGS_SNAPSHOT_DIR", snap_dir)
 
         ok = Mock(status_code=202)
         ok.json.return_value = {"previous_digest": "sha256:abc"}
-        with patch("src.api_server.requests.post", return_value=ok):
+        with patch("src.system.update_service.requests.post", return_value=ok):
             r = client.post("/system/update")
         assert r.status_code == 200
         body = r.json()
@@ -1017,14 +1016,14 @@ class TestSystemUpdateRollback:
     """``POST /system/update/rollback`` rolls settings + image back."""
 
     def test_404_when_no_snapshots_exist(self, client, tmp_path, monkeypatch):
-        monkeypatch.setattr("src.api_server.SETTINGS_SNAPSHOT_DIR", tmp_path / "empty")
+        monkeypatch.setattr("src.system.update_service.SETTINGS_SNAPSHOT_DIR", tmp_path / "empty")
         r = client.post("/system/update/rollback", json={"restore_image": False})
         assert r.status_code == 404
 
     def test_404_for_unknown_named_snapshot(self, client, tmp_path, monkeypatch):
         snap_dir = tmp_path / "snaps"
         snap_dir.mkdir()
-        monkeypatch.setattr("src.api_server.SETTINGS_SNAPSHOT_DIR", snap_dir)
+        monkeypatch.setattr("src.system.update_service.SETTINGS_SNAPSHOT_DIR", snap_dir)
         r = client.post(
             "/system/update/rollback",
             json={"snapshot": "pre-update-20260101T000000Z.json", "restore_image": False},
@@ -1034,7 +1033,7 @@ class TestSystemUpdateRollback:
     def test_404_rejects_path_traversal(self, client, tmp_path, monkeypatch):
         snap_dir = tmp_path / "snaps"
         snap_dir.mkdir()
-        monkeypatch.setattr("src.api_server.SETTINGS_SNAPSHOT_DIR", snap_dir)
+        monkeypatch.setattr("src.system.update_service.SETTINGS_SNAPSHOT_DIR", snap_dir)
         # Plant an actual backup-shaped file outside the snap dir.
         (tmp_path / "secret.json").write_text('{"fiestaboard_backup":true,"schema_version":1,"data":{}}')
         r = client.post(
@@ -1044,7 +1043,7 @@ class TestSystemUpdateRollback:
         assert r.status_code == 404
 
     def test_400_when_neither_settings_nor_image_requested(self, client, tmp_path, monkeypatch):
-        monkeypatch.setattr("src.api_server.SETTINGS_SNAPSHOT_DIR", tmp_path / "snaps")
+        monkeypatch.setattr("src.system.update_service.SETTINGS_SNAPSHOT_DIR", tmp_path / "snaps")
         r = client.post(
             "/system/update/rollback",
             json={"restore_settings": False, "restore_image": False},
@@ -1052,7 +1051,7 @@ class TestSystemUpdateRollback:
         assert r.status_code == 400
 
     def test_settings_only_happy_path(self, client, tmp_path, monkeypatch):
-        from src import api_server as api
+        from src.system import update_service as api
 
         snap_dir = tmp_path / "snaps"
         monkeypatch.setattr(api, "SETTINGS_SNAPSHOT_DIR", snap_dir)
@@ -1098,7 +1097,7 @@ class TestSystemUpdateRollback:
         Settings-restore is also enabled (the default) so we exercise the
         full end-to-end path.
         """
-        from src import api_server as api
+        from src.system import update_service as api
 
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
         snap_dir = tmp_path / "snaps"
@@ -1123,7 +1122,7 @@ class TestSystemUpdateRollback:
             captured["json"] = json
             return Mock(status_code=202)
 
-        with patch("src.api_server.requests.post", side_effect=_fake_post):
+        with patch("src.system.update_service.requests.post", side_effect=_fake_post):
             r = client.post("/system/update/rollback", json={})
         assert r.status_code == 200, r.text
         body = r.json()
@@ -1140,7 +1139,7 @@ class TestSystemUpdateRollback:
     def test_image_rollback_warns_on_unannotated_snapshot(self, client, tmp_path, monkeypatch):
         """A snapshot with no recorded digest/image cannot drive the
         sidecar's /rollback — we surface a warning rather than guess."""
-        from src import api_server as api
+        from src.system import update_service as api
 
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
         snap_dir = tmp_path / "snaps"
@@ -1171,23 +1170,23 @@ class TestUpdaterLastUpdateHelper:
     """``_updater_last_update`` shape contract."""
 
     def test_returns_dict_on_success(self, monkeypatch):
-        from src import api_server as api
+        from src.system import update_service as api
 
         ok = Mock(status_code=200)
         ok.json.return_value = {"status": "success"}
-        with patch("src.api_server.requests.get", return_value=ok):
+        with patch("src.system.update_service.requests.get", return_value=ok):
             assert api._updater_last_update() == {"status": "success"}
 
     def test_returns_empty_on_network_error(self, monkeypatch):
-        from src import api_server as api
+        from src.system import update_service as api
 
-        with patch("src.api_server.requests.get", side_effect=Exception("nope")):
+        with patch("src.system.update_service.requests.get", side_effect=Exception("nope")):
             assert api._updater_last_update() == {}
 
     def test_returns_empty_on_non_200(self, monkeypatch):
-        from src import api_server as api
+        from src.system import update_service as api
 
-        with patch("src.api_server.requests.get", return_value=Mock(status_code=500)):
+        with patch("src.system.update_service.requests.get", return_value=Mock(status_code=500)):
             assert api._updater_last_update() == {}
 
 
@@ -1212,13 +1211,13 @@ class TestSystemUpdateStateFileDurability:
         The loader swallows a JSON error and returns ``{}``, so a truncated
         file silently resets the auto-update toggle to its default.
         """
-        from src import api_server
+        from src.system import update_service
 
-        state_file = api_server.SYSTEM_UPDATE_STATE_FILE
-        api_server._system_update_state_save({"auto_update_interval": "weekly", "auto_update_enabled": True})
+        state_file = update_service.SYSTEM_UPDATE_STATE_FILE
+        update_service._system_update_state_save({"auto_update_interval": "weekly", "auto_update_enabled": True})
         original_bytes = state_file.read_bytes()
 
-        real_dump = api_server.json.dump
+        real_dump = update_service.json.dump
         crashed = []
 
         def crashing_dump(obj, fh, *args, **kwargs):
@@ -1232,8 +1231,8 @@ class TestSystemUpdateStateFileDurability:
             fh.flush()
             raise OSError("Simulated crash mid-write")
 
-        with patch.object(api_server.json, "dump", crashing_dump):
-            api_server._system_update_state_save({"auto_update_interval": "monthly"})
+        with patch.object(update_service.json, "dump", crashing_dump):
+            update_service._system_update_state_save({"auto_update_interval": "monthly"})
 
         assert crashed, "the sabotaged write never ran — the test proves nothing"
         assert state_file.read_bytes() == original_bytes
@@ -1248,13 +1247,13 @@ class TestSystemUpdateStateFileDurability:
         """
         import threading
 
-        from src import api_server
+        from src.system import update_service
 
         monkeypatch.setenv("FIESTABOARD_PROFILE", "docker")
-        state_file = api_server.SYSTEM_UPDATE_STATE_FILE
-        api_server._system_update_state_save({"auto_update_interval": "manual", "last_check": "stale"})
+        state_file = update_service.SYSTEM_UPDATE_STATE_FILE
+        update_service._system_update_state_save({"auto_update_interval": "manual", "last_check": "stale"})
 
-        real_dump = api_server.json.dump
+        real_dump = update_service.json.dump
         competitor: list = []
 
         def dump_with_a_competing_update(obj, fh, *args, **kwargs):
@@ -1263,9 +1262,9 @@ class TestSystemUpdateStateFileDurability:
             if not competitor and _writes_to(fh, state_file):
 
                 def compete():
-                    state = api_server._system_update_state_load()
+                    state = update_service._system_update_state_load()
                     state["last_check"] = "2026-01-01T00:00:00+00:00"
-                    api_server._system_update_state_save(state)
+                    update_service._system_update_state_save(state)
 
                 thread = threading.Thread(target=compete)
                 competitor.append(thread)
@@ -1274,7 +1273,7 @@ class TestSystemUpdateStateFileDurability:
                 thread.join(timeout=0.5)
             return real_dump(obj, fh, *args, **kwargs)
 
-        with patch.object(api_server.json, "dump", dump_with_a_competing_update):
+        with patch.object(update_service.json, "dump", dump_with_a_competing_update):
             response = client.post("/system/update/auto", json={"interval": "weekly"})
         assert response.status_code == 200
 

--- a/tests/test_system_seams.py
+++ b/tests/test_system_seams.py
@@ -1,0 +1,120 @@
+"""The system router stands on its own (Phase 2 §2 step 3, spec §4).
+
+Phase 1 extracted `/version` + `/system/*` into `src/system/` but left every
+collaborator resolved through ``src.api_server`` at call time, so the module
+was extracted on paper and coupled in fact — and the audit measured the
+call-time seam count going *up* 4.2x across the codebase because of exactly
+this pattern.
+
+The exit criterion for `next` -> `main` is "zero call-time api_server imports
+in router modules, asserted by test". This file is the system domain's half of
+that assertion. It is deliberately a *subprocess* check: an in-process
+``'src.api_server' not in sys.modules`` assertion is vacuous once any earlier
+test in the session has imported the app.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SYSTEM_DIR = REPO_ROOT / "src" / "system"
+
+
+def test_importing_the_system_router_does_not_pull_in_api_server():
+    """A fresh interpreter can import the router without the monolith."""
+    code = (
+        "import sys\n"
+        "import src.system.routes\n"
+        "assert 'src.api_server' not in sys.modules, sorted(\n"
+        "    m for m in sys.modules if m.startswith('src.')\n"
+        ")\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "importing src.system.routes dragged src.api_server in:\n" + result.stdout + result.stderr
+    )
+
+
+def test_importing_the_system_update_service_does_not_pull_in_api_server():
+    """Same for the service — it owned two api_server read-back seams."""
+    code = (
+        "import sys\n"
+        "import src.system.update_service\n"
+        "assert 'src.api_server' not in sys.modules, sorted(\n"
+        "    m for m in sys.modules if m.startswith('src.')\n"
+        ")\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "importing src.system.update_service dragged src.api_server in:\n" + result.stdout + result.stderr
+    )
+
+
+def test_no_module_in_src_system_imports_api_server_at_all():
+    """Not at module level, and not inside a handler either.
+
+    The subprocess checks above only see module-level imports; a call-time
+    ``from src.api_server import ...`` inside a route body would sail past
+    them and re-open the seam on the next handler someone edits.
+    """
+    offenders: list[str] = []
+    for path in sorted(SYSTEM_DIR.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            module = ""
+            names: list[str] = []
+            if isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                names = [a.name for a in node.names]
+            elif isinstance(node, ast.Import):
+                names = [a.name for a in node.names]
+            if "api_server" in module or any("api_server" in n for n in names):
+                rel = path.relative_to(REPO_ROOT)
+                offenders.append(f"{rel}:{node.lineno}")
+    assert offenders == [], "src/system/ must not import src.api_server:\n  " + "\n  ".join(offenders)
+
+
+def test_api_server_no_longer_re_exports_the_system_service_for_tests():
+    """The re-export list is what api_server *uses*, not a patch surface.
+
+    Before the slice, ``api_server`` re-imported all 41 update-service names
+    plus all 9 system models under ``# noqa: F401`` purely so
+    ``patch("src.api_server.<name>")`` would resolve. Those are ceremony: if
+    one comes back with no reader in this module, this test says so.
+    """
+    api_server_src = (REPO_ROOT / "src" / "api_server.py").read_text(encoding="utf-8")
+    tree = ast.parse(api_server_src)
+
+    imported: dict[str, int] = {}
+    import_lines: set[int] = set()
+    for node in ast.walk(tree):
+        # ``from .system.update_service import X`` parses as level=1,
+        # module="system.update_service" — rebuild the written form.
+        written = "." * getattr(node, "level", 0) + (getattr(node, "module", None) or "")
+        if isinstance(node, ast.ImportFrom) and written.startswith(".system"):
+            for alias in node.names:
+                imported[alias.asname or alias.name] = node.lineno
+            for line in range(node.lineno, (node.end_lineno or node.lineno) + 1):
+                import_lines.add(line)
+
+    used = {node.id for node in ast.walk(tree) if isinstance(node, ast.Name) and node.lineno not in import_lines}
+    dead = sorted(f"{name} (line {line})" for name, line in imported.items() if name not in used)
+    assert dead == [], (
+        "src/api_server.py imports these names from src/system/ and never uses them. "
+        "A re-export that exists only as a test patch target is the seam this slice "
+        "retired — patch src.system.update_service.<name> instead:\n  " + "\n  ".join(dead)
+    )


### PR DESCRIPTION
Phase 2 vertical slice for the **`system`** router tag — `GET /version` plus the seven
`/system` routes. Plan: `.superpowers/plans/2026-09-06-rework-phase2.md` Task 7. Targets
`next-rebuild`, not `main`.

## What deliberately changed in the contract

**Every `HTTPException.detail` in the domain is now a string.** 22 of the domain's 24
raise sites used a dict `detail` with no `message` key — the exact shape
`docs/internal/reference/API_CONVENTIONS.md` §"Error contract" bans (19 in
`routes.py`, 3 in `update_service.py`; the two `POST /system/update/auto` 422s were
already strings). The discarded `status` / `mode` / `error` / `hint` keys had **no
reader**: `web/src/lib/api/core.ts` does

```ts
detail = typeof body.detail === "string" ? body.detail : JSON.stringify(body.detail);
```

so before this change the user was shown a raw JSON blob in the error toast where a
sentence belonged.

**Every route declares `responses=`** for the codes it actually answers
(503/502/500 on the sidecar routes; 400/404 added on rollback; 422 on auto).

## What provably did not change

`tests/test_system_contract.py` (40 tests, value-level) was written **against
unmodified `next-rebuild`** — pinning every `detail` payload, every status code and
every success body by value — and passed there before any `src/` edit. Only the
`detail` assertions were re-pinned; the file's header names each change. Specifically
unchanged and still asserted by value:

- **every status code on every path** (503 no-token, 503 unreachable, 502 transport,
  500 token-rejected, 502 sidecar-error, 400 both-flags-false, 404 no-snapshot,
  400 unreadable/bad-backup, 500 restore-aborted, 422 × 2);
- the human-readable sentence inside each old dict, verbatim, as the new `detail`
  (the two bare `str(e)` bodies gained the `fiestaupdater <action> call failed:`
  prefix that was previously only in the log line — called out in the test header);
- every success body: `/version`, the update-check probe verdict, the status payload,
  `queued`/`sidecar`, the rollback `partial` warnings, snapshot metadata, the
  auto-update interval semantics and its persisted state file.

`tests/golden/responses/system.json` was re-recorded; the diff is **6 records, all of
them `"detail": {...}` → `"detail": "str"`**, nothing else, no other domain touched.
The route-inventory golden is unchanged (it records path/methods/name/kind only, and
no route moved).

## Seams retired

`src/system/` imports **nothing** from `src.api_server` — not at module level, not at
call time. The eight handlers resolve collaborators through
`src.system.update_service`, which is now also the home of:

- `SYSTEM_UPDATE_STATE_FILE` / `SETTINGS_SNAPSHOT_DIR` (the two path overrides that
  the service used to read back off `api_server`), and
- `_detect_post_upgrade_regression`, which was homeless in `api_server` but is a
  snapshot reader — it moved next to the snapshot helpers it calls, per the brief's
  "homeless collaborators get a real module" rule.

`api_server`'s system re-export block went from **50 names to 8**. Every remaining
name is one `api_server`'s own lifespan / post-upgrade-restore path calls. The other
**42** (41 update-service names + all 9 `system.models` classes) were `# noqa: F401`
ceremony that existed only so `patch("src.api_server.X")` would resolve — the ratchet
of dead re-exports the audit measured as the seam count going *up* 4.2×.

Patch targets repointed: `tests/test_system_endpoints.py` (all 31 `requests` patches,
16 `SYSTEM_UPDATE_STATE_FILE`, 10 `SETTINGS_SNAPSHOT_DIR`, and every
`from src import api_server as api` helper block),
`tests/test_response_shape_goldens.py`, `tests/test_api_extended.py`.

**Deliberately left alone:** `tests/test_settings_beta.py` and
`tests/test_hdmi_kiosk_api.py` still patch `src.api_server._updater_probe` /
`_updater_token` / `_fiestaboard_profile`. Those steer *api_server's own* beta-settings
and HDMI-kiosk handlers, which are still unextracted — per the brief, a shared accessor
cannot be deleted until its last consumer converts. `api_server` therefore still
imports those three names, and its handlers still call them as module globals.

New `tests/test_system_seams.py` (4 tests) locks this down:

1. a **subprocess** import of `src.system.routes` with `'src.api_server' not in
   sys.modules` (in-process this assertion is vacuous once any earlier test imported
   the app);
2. the same for `src.system.update_service`;
3. an AST sweep of `src/system/**` for *any* `api_server` import, module-level or
   inside a handler — this is the one that catches a re-opened call-time seam;
4. an AST check that `api_server` imports nothing from `src/system/` it does not use,
   so a dead re-export cannot creep back.

All four are mutation-proven (see below).

## The ratchet, and the verbatim failure when I broke a route

`"system"` is appended to `converted_domains` in this PR's own commit, with six
`declared_errors` exceptions — three read-only GETs with no failure path at all, and
the three sidecar routes whose only failures are 500/502/503 (all declared in
`responses=`; there is no request a client can send that they answer 4xx to).

**Fail-first, before the conversion** — adding `"system"` to the manifest against
unmodified trunk failed exactly one rule (the domain was already typed and had
`response_model` everywhere, which is why Task 7 is the error-contract slice):

```
E   AssertionError: Converted domains must declare the errors they raise ...
E       GET /system/update-check: declares no 4xx in responses=
E       GET /system/update/status: declares no 4xx in responses=
E       GET /version: declares no 4xx in responses=
E       POST /system/restart: declares no 4xx in responses=
E       POST /system/shutdown: declares no 4xx in responses=
E       POST /system/update/auto: declares no 4xx in responses=
E       POST /system/update/rollback: declares no 4xx in responses=
E       POST /system/update: declares no 4xx in responses=
========================= 1 failed, 20 passed in 0.63s =========================
```

**Load-bearing check.** With the slice complete, I broke `POST /system/update/auto`
three ways (dropped `response_model=` and `responses=`, took a bare `dict` body,
returned `{"status": "error"}` from inside an `except` at 200) and all four rules
fired:

```
FAILED tests/test_api_conventions_ratchet.py::test_converted_domains_declare_response_models
E       POST /system/update/auto: no response_model= declared

FAILED tests/test_api_conventions_ratchet.py::test_converted_domains_never_return_200_on_failure
E       POST /system/update/auto: src/system/routes.py:390: return inside an except block -> `return {"status": "error", "error": "Request must include either 'interval' or 'enabled'."}`
E       POST /system/update/auto: src/system/routes.py:390: returns {"status": 'error'} on a 2xx path -> `return {"status": "error", "error": "Request must include either 'interval' or 'enabled'."}`

FAILED tests/test_api_conventions_ratchet.py::test_converted_domains_use_typed_request_bodies
E       POST /system/update/auto: body param `req` is annotated `dict` — use a Pydantic model

FAILED tests/test_api_conventions_ratchet.py::test_converted_domains_declare_error_responses
E       POST /system/update/auto: declares no 4xx in responses=
========================= 4 failed, 17 passed in 0.62s =========================
```

Route restored; ratchet green (21 passed).

**The seam tests are mutation-proven too.** Re-adding `_list_settings_snapshots` to
`api_server`'s import list and putting a call-time `from src.api_server import app`
back inside the `/version` handler:

```
FAILED tests/test_system_seams.py::test_no_module_in_src_system_imports_api_server_at_all
E   AssertionError: src/system/ must not import src.api_server:
E       src/system/routes.py:70

FAILED tests/test_system_seams.py::test_api_server_no_longer_re_exports_the_system_service_for_tests
E   AssertionError: src/api_server.py imports these names from src/system/ and never uses them...
E       _list_settings_snapshots (line 1623)
========================= 2 failed, 2 passed in 0.57s ==========================
```

Note that the two subprocess tests passed under that mutation — a *call-time* import
is invisible to them. That is precisely why test 3 exists. Moving the import to module
level does trip them:

```
E   AssertionError: importing src.system.routes dragged src.api_server in: ...
```

## Web lockstep

**No web change is required, and that is a measured claim, not an assumption.**

- `web/src/lib/api/core.ts` already accepts either detail shape (see the snippet
  above) — a string detail is strictly better output, not a break.
- Nothing under `web/src/` or `web/tests/` reads `.detail` from these endpoints:
  `grep -rn "detail" web/src/components/settings/system-update.tsx
  system-controls.tsx update-context.tsx web/tests/regression/settings-system.spec.ts`
  returns nothing.
- The Playwright API specs touch this domain only at `web/tests/api.spec.ts:26`
  (`/version` → 200, `package_version` / `build_version` present) — unaffected.
- Every `.status).toBe("success")` in `web/tests/` (api-extended, settings-full,
  board-discovery-offline) is on a non-system route; none of those files reference
  `/system` or `/version`.

## Verification

| Gate | Result |
| --- | --- |
| Full suite before (`origin/next-rebuild`) | 1 failed, **5886 passed**, 2 skipped |
| Full suite after | 1 failed, **5930 passed**, 2 skipped (+44 = 40 contract + 4 seam) |
| The one failure | `test_check_image_formats.py::TestRepositoryIsClean` — the documented worktree-environmental failure, identical before and after |
| Data-dir leak (`.pytest-data` mounted over `/app/data`) | **0 entries** |
| `ruff==0.16.5 check` + `format --check` on `src tests` | All checks passed; 309 files already formatted |
| Response-shape golden | re-recorded; diff is the 6 intended `detail` records only |
| Route-inventory golden | unchanged |
| Conventions ratchet | 21 passed with `system` in `converted_domains` |

## Left open

- The six `declared_errors` exceptions are the honest answer for this domain (no
  client-error path exists on those routes), but six of eight routes excused is worth
  a reviewer's opinion on whether the rule should read "declares at least one error
  response" rather than "at least one 4xx". Changing the rule would weaken it for
  other domains, so I did not touch the ratchet.
- `POST /system/update` and `POST /system/restart|shutdown` answer **500** when the
  sidecar rejects our shared token. Arguably 502 (an upstream refusal), but changing
  it is a contract change with no fail-first evidence behind it, so it is pinned as-is
  and left for a follow-up if anyone wants it.
- `api_server` still exports `_updater_probe` / `_updater_token` /
  `_fiestaboard_profile` for the unextracted beta-settings and HDMI-kiosk handlers;
  those seams close with the settings/config slices (Task 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP
