### PR TITLE
feat(ai): wire the ops layer for real — server-side chat op execution

### DIFF
--- a/src/ai/routes.py
+++ b/src/ai/routes.py
@@ -1,0 +1,141 @@
+"""FastAPI router for server-side execution of chat operations.
+
+Phase 2, Task 11. ``src/ops`` was built so "chat and MCP cannot diverge"
+(#1764), but until this endpoint existed only MCP called the executors:
+the browser ran its own ``switch (call.op)`` over a dozen REST endpoints,
+so the ops layer had **zero** production callers on the chat path and the
+two surfaces could still drift — and did (see
+``tests/test_chat_op_http_parity.py`` for the three divergences that were
+live in the shipped browser dispatcher).
+
+This router is the chat surface's execution seam. The web drawer posts a
+validated tool call here; the registry validates the args against the same
+pydantic models ``parse_tool_call`` uses and dispatches to the one
+canonical executor MCP already uses.
+
+Conventions (``docs/internal/reference/API_CONVENTIONS.md``): typed
+request model, declared ``response_model``, declared 4xx, and failures as
+``HTTPException`` — never a 200 carrying ``{"status": "error"}``. The
+executors' error envelope is deliberately *not* forwarded at 200: the
+browser's previous per-op REST calls raised on failure, and the chat
+drawer's ``chainAfter`` wrapper depends on that to build the
+``[Tool result: ... Failed: ...]`` transcript line.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Any, Literal
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.api_errors import errors
+from src.ops import registry
+from src.ops.grammar import ToolCallValidationError
+
+router = APIRouter(prefix="/ai", tags=["ai"])
+
+#: Envelope keys that become response fields of their own; everything else
+#: an executor returned (``schedule_id``, ``plugin_id``, ``config``, ...) is
+#: carried through in ``result``.
+_ENVELOPE_KEYS = ("status", "message", "error")
+
+
+class OperationRequest(BaseModel):
+    """One chat-grammar tool call: the op name plus its raw args.
+
+    ``args`` is intentionally free-form here — it is validated one layer
+    down against the op's own pydantic model (the exact schema the SSE
+    ``tool_call`` frame was validated with), so declaring a union of every
+    op's args on this model would duplicate the grammar and let the two
+    copies drift.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    op: str = Field(..., min_length=1, max_length=100, description="Chat-grammar operation name.")
+    args: dict[str, Any] = Field(default_factory=dict, description="Operation arguments, validated by the grammar.")
+
+
+class OperationResponse(BaseModel):
+    """The executed operation's success envelope.
+
+    ``status`` is a constant: a failed operation is an HTTP error, not a
+    200 with a sad payload.
+    """
+
+    op: str
+    status: Literal["success"] = "success"
+    message: str
+    result: dict[str, Any] = Field(default_factory=dict)
+
+
+async def _dispatch(op_name: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Run one operation, keeping blocking executors off the event loop.
+
+    Most executors are synchronous and do file IO (page/schedule/collection
+    stores, ``config.json``, plugin installs) — the ``asyncio.to_thread``
+    treatment the rest of the codebase gives blocking work. The async ones
+    (``install_plugin``, ``update_plugin``, ``update_setting``,
+    ``trigger_system_update``) are awaited directly.
+    """
+    operation = registry.get_operation(op_name)
+    if inspect.iscoroutinefunction(operation.executor):
+        return await registry.execute(op_name, args)
+    return await asyncio.to_thread(registry.execute_sync, op_name, args)
+
+
+@router.post(
+    "/operations",
+    response_model=OperationResponse,
+    responses=errors(400, 404, 422),
+    summary="Execute one chat-grammar operation server-side",
+)
+async def execute_operation(request: OperationRequest) -> OperationResponse:
+    """Validate and execute a chat tool call through the shared ops layer.
+
+    - unknown op, or an op the chat grammar does not spell → **404**
+    - an op the web UI applies in the browser → **400** naming the op
+    - args that fail the grammar's schema → **422** with pydantic's detail
+    - an executor that reported failure → **400** with its message
+    """
+    try:
+        operation = registry.get_operation(request.op)
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"Unknown operation: {request.op!r}.") from None
+
+    if operation.chat_name != request.op:
+        # Canonical/MCP-only spellings (send_message, delete_page, ...) are
+        # not part of the chat grammar; serving them here would grow a third
+        # surface with no validation schema behind it.
+        raise HTTPException(
+            status_code=404,
+            detail=f"Operation {request.op!r} is not part of the chat operation grammar.",
+        )
+
+    if operation.client_side:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Operation {request.op!r} is applied in the browser by the web UI and has no server-side executor."
+            ),
+        )
+
+    try:
+        envelope = await _dispatch(request.op, request.args)
+    except ToolCallValidationError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except registry.ClientSideOperationError as exc:  # pragma: no cover - guarded above
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    if envelope.get("status") != "success":
+        detail = envelope.get("error") or envelope.get("message") or f"Operation {request.op!r} failed."
+        raise HTTPException(status_code=400, detail=str(detail))
+
+    return OperationResponse(
+        op=request.op,
+        message=str(envelope.get("message", "")),
+        result={k: v for k, v in envelope.items() if k not in _ENVELOPE_KEYS},
+    )

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -1319,6 +1319,14 @@ async def test_ai_provider(request: Request):
     return result
 
 
+# Server-side execution of chat operations (Phase 2 Task 11): the web
+# drawer posts validated tool calls here so chat and MCP share one
+# executor per op instead of the browser re-implementing each one.
+from .ai.routes import router as ai_router  # noqa: E402
+
+app.include_router(ai_router)
+
+
 @app.get("/pages/ai/context")
 async def get_ai_context(device_type: str = "flagship"):
     """Return the variable list + exemplars that would be sent to the model.

--- a/src/ops/registry.py
+++ b/src/ops/registry.py
@@ -2,11 +2,16 @@
 
 Issue #1764: ``src/ai/chat_ops.py`` and ``src/mcp_server.py`` grew two
 parallel grammars for the same actions (``update_plugin_config`` vs
-``configure_plugin``, ``replace_page`` vs ``create_page``), each with its
-own implementation. This registry maps *both* name sets onto one canonical
-executor per operation (:mod:`src.ops.executors`), so the surfaces cannot
-diverge in behavior. Retiring the duplicate names is #1766-style follow-up
-work; here both grammars stay valid.
+``configure_plugin``), each with its own implementation. This registry maps
+*both* name sets onto one canonical executor per operation
+(:mod:`src.ops.executors`), so the surfaces cannot diverge in behavior.
+Retiring the duplicate names is #1766-style follow-up work; here both
+grammars stay valid.
+
+Phase 2 Task 11 made this load-bearing on the chat side too:
+``POST /ai/operations`` (:mod:`src.ai.routes`) executes chat ops through
+:func:`execute`, so the web drawer no longer re-implements one per REST
+endpoint.
 
 Three kinds of operation live here:
 
@@ -14,9 +19,10 @@ Three kinds of operation live here:
 - single-surface server ops — only one grammar names them today
   (``delete_page`` is MCP-only, ``update_setting`` is chat-only);
 - client-side chat ops — applied inside the web UI with no server-side
-  effect (``apply_patch`` edits the editor's draft, ``navigate_to_page``
-  routes). They are registered so the registry describes the *whole*
-  grammar, but carry no executor.
+  effect (``replace_page`` and ``apply_patch`` edit the editor's draft,
+  ``navigate_to_page`` routes). They are registered so the registry
+  describes the *whole* grammar, but carry no executor;
+  ``POST /ai/operations`` refuses them with a 4xx.
 
 ``execute()`` is the chat-grammar entry point: given a chat op name it
 validates the args against the op's chat schema (the same models
@@ -71,22 +77,6 @@ def _model_fields(args: Any, *names: str) -> dict[str, Any]:
     return out
 
 
-def _adapt_replace_page(args: Any) -> dict[str, Any]:
-    """``replace_page`` materializes a full page definition → create_page.
-
-    The chat surface knows the device from the editor context; server-side
-    execution falls back to the executor's flagship default.
-    """
-    kwargs: dict[str, Any] = {
-        "name": args.name,
-        "template_lines": args.template,
-        "duration_seconds": args.duration_seconds,
-    }
-    if args.line_metadata:
-        kwargs["line_metadata"] = [m.model_dump() for m in args.line_metadata]
-    return kwargs
-
-
 def _adapt_install_plugin(args: Any) -> dict[str, Any]:
     kwargs: dict[str, Any] = {"plugin_id": args.plugin_id, "auto_enable": args.auto_enable}
     if args.initial_config:
@@ -96,13 +86,7 @@ def _adapt_install_plugin(args: Any) -> dict[str, Any]:
 
 OPERATIONS: tuple[Operation, ...] = (
     # -- pages ------------------------------------------------------------
-    Operation(
-        name="create_page",
-        executor=executors.create_page,
-        chat_name="replace_page",
-        mcp_tool="create_page",
-        adapt_chat_args=_adapt_replace_page,
-    ),
+    Operation(name="create_page", executor=executors.create_page, mcp_tool="create_page"),
     Operation(name="update_page", executor=executors.update_page, mcp_tool="update_page"),
     Operation(name="delete_page", executor=executors.delete_page, mcp_tool="delete_page"),
     Operation(name="set_active_page", executor=executors.set_active_page, mcp_tool="set_active_page"),
@@ -223,6 +207,18 @@ OPERATIONS: tuple[Operation, ...] = (
         adapt_chat_args=lambda a: {},
     ),
     # -- client-side chat ops (no server effect) --------------------------
+    # ``replace_page`` is an EDITOR op, not "create a page" (Phase 2 Task 11).
+    # #1764 aliased it onto ``create_page``, but nothing on the chat path ever
+    # called the registry, so the mis-mapping never showed: the browser has
+    # always applied it to the page mounted in the editor, exactly like
+    # ``apply_patch``, and the system prompt teaches it that way — "use when
+    # the user asks for ... a full rewrite" of the page being edited,
+    # "replace_page is destructive", and the global drawer is told to
+    # navigate to the editor first rather than "write template content
+    # remotely". Executing it server-side would create a second page and
+    # leave the open editor untouched. ``create_page`` above keeps the
+    # executor for the MCP tool of that name.
+    Operation(name="replace_page", chat_name="replace_page", client_side=True),
     Operation(name="apply_patch", chat_name="apply_patch", client_side=True),
     Operation(name="suggest_variables", chat_name="suggest_variables", client_side=True),
     Operation(name="navigate_to_page", chat_name="navigate_to_page", client_side=True),

--- a/tests/conventions_manifest.json
+++ b/tests/conventions_manifest.json
@@ -1,6 +1,7 @@
 {
   "_comment": "API conventions ratchet (Phase 2, spec §2). Enforced by tests/test_api_conventions_ratchet.py; rules documented in docs/internal/reference/API_CONVENTIONS.md. Append a domain to converted_domains in the slice PR that converts it — never before. Every exception needs a route that exists, a known rule id, and a reason a reviewer can argue with.",
   "converted_domains": [
+    "ai",
     "collections",
     "pages",
     "schedules"

--- a/tests/golden/api_routes.json
+++ b/tests/golden/api_routes.json
@@ -10,6 +10,14 @@
       "kind": "APIRoute"
     },
     {
+      "path": "/ai/operations",
+      "methods": [
+        "POST"
+      ],
+      "name": "execute_operation",
+      "kind": "APIRoute"
+    },
+    {
       "path": "/auth/change-password",
       "methods": [
         "POST"

--- a/tests/test_chat_op_http_parity.py
+++ b/tests/test_chat_op_http_parity.py
@@ -492,7 +492,30 @@ def test_extra_top_level_keys_are_rejected():
 
 
 def test_parity_harness_can_fail(tmp_path):
-    """Non-vacuity: the snapshot comparison must be able to see a difference."""
+    """Non-vacuity: the harness must be able to see a difference.
+
+    One path here does nothing, so ``assert_parity``'s do-nothing guard is
+    what reports it — that guard runs before the snapshot comparison
+    precisely so "both paths were no-ops" can never read as parity.
+    """
+    ctx: dict[str, str] = {}
+
+    def setup(env):
+        ctx["page_id"] = _make_page(env)
+
+    with pytest.raises(AssertionError, match="persisted no change at all"):
+        assert_parity(
+            tmp_path,
+            lambda env: op(
+                _client(), "create_schedule", {"page_id": ctx["page_id"], "start_time": "07:00", "day_pattern": "all"}
+            ),
+            lambda env: None,
+            setup=setup,
+        )
+
+
+def test_parity_harness_sees_two_acting_paths_that_differ(tmp_path):
+    """And the comparison itself must fire when both paths act but disagree."""
     ctx: dict[str, str] = {}
 
     def setup(env):
@@ -504,7 +527,9 @@ def test_parity_harness_can_fail(tmp_path):
             lambda env: op(
                 _client(), "create_schedule", {"page_id": ctx["page_id"], "start_time": "07:00", "day_pattern": "all"}
             ),
-            lambda env: None,
+            lambda env: op(
+                _client(), "create_schedule", {"page_id": ctx["page_id"], "start_time": "09:30", "day_pattern": "all"}
+            ),
             setup=setup,
         )
 

--- a/tests/test_chat_op_http_parity.py
+++ b/tests/test_chat_op_http_parity.py
@@ -1,0 +1,518 @@
+"""The chat op path over HTTP vs. what the browser used to do itself.
+
+Phase 2, Task 11. Until this slice the web drawer executed every chat
+operation from a ``switch (call.op)`` of its own, calling a different REST
+endpoint per op. ``POST /ai/operations`` replaces those branches with the
+shared executors (:mod:`src.ops.executors`) MCP already used.
+
+Every test here runs the SAME logical operation twice against two fresh,
+isolated stores — once as the **browser sequence** (the exact REST calls
+``global-ai-chat-drawer.tsx`` made before this slice) and once through the
+new endpoint — and compares the persisted bytes with
+``tests/test_op_parity.py``'s snapshot harness.
+
+Why this shape: the zero-regression requirement is "what got created,
+changed or deleted must not move". The browser-sequence half of every
+test passes unmodified against the pre-slice trunk (it *is* the pre-slice
+behavior), so a parity assertion pins the new path to the old effect
+rather than to a freshly-written expectation.
+
+Three operations do **not** reach parity, and must not: the browser and
+the executor already disagreed, which is the bug this task exists to
+surface. Those three have their own tests below, each asserting both
+sides explicitly and naming which one was wrong.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mcp", reason="shared harness imports tests.test_mcp_state_effects")
+
+from fastapi.testclient import TestClient
+
+from src.collections.models import CollectionCreate, TimeModeConfig, VariableModeConfig, VariableRule
+from src.schedules.models import ScheduleCreate
+from tests.test_mcp_state_effects import PLUGIN_ID, UNINSTALLED_PLUGIN_ID
+from tests.test_op_parity import _make_page, assert_parity, isolated_env, snapshot
+
+
+def _client() -> TestClient:
+    from src.api_server import app
+
+    return TestClient(app)
+
+
+def op(client: TestClient, name: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Execute one chat op through the new endpoint, asserting it succeeded."""
+    response = client.post("/ai/operations", json={"op": name, "args": args})
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "success"
+    assert body["op"] == name
+    return body
+
+
+def _ok(response: Any) -> Any:
+    assert response.status_code in (200, 201), response.text
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Schedules
+# ---------------------------------------------------------------------------
+
+
+def test_create_schedule_persists_what_the_browser_rest_call_persisted(tmp_path):
+    ctx: dict[str, str] = {}
+
+    def setup(env):
+        ctx["page_id"] = _make_page(env)
+
+    def browser(env):
+        # drawer: handleCreateSchedule -> api.createSchedule(...)
+        _ok(
+            _client().post(
+                "/schedules",
+                json={
+                    "page_id": ctx["page_id"],
+                    "start_time": "07:00",
+                    "end_time": "09:00",
+                    "day_pattern": "weekdays",
+                    "enabled": True,
+                },
+            )
+        )
+
+    def endpoint(env):
+        op(
+            _client(),
+            "create_schedule",
+            {
+                "page_id": ctx["page_id"],
+                "start_time": "07:00",
+                "end_time": "09:00",
+                "day_pattern": "weekdays",
+                "enabled": True,
+            },
+        )
+
+    assert_parity(tmp_path, browser, endpoint, setup=setup)
+
+
+def test_create_schedule_with_custom_days_persists_identically(tmp_path):
+    ctx: dict[str, str] = {}
+
+    def setup(env):
+        ctx["page_id"] = _make_page(env)
+
+    args = lambda: {  # noqa: E731 - one shape, spelled once
+        "page_id": ctx["page_id"],
+        "start_time": "18:30",
+        "end_time": None,
+        "day_pattern": "custom",
+        "custom_days": ["monday", "thursday"],
+        "enabled": False,
+    }
+
+    def browser(env):
+        _ok(_client().post("/schedules", json=args()))
+
+    def endpoint(env):
+        op(_client(), "create_schedule", args())
+
+    assert_parity(tmp_path, browser, endpoint, setup=setup)
+
+
+def test_delete_schedule_removes_the_same_entry(tmp_path):
+    ctx: dict[str, str] = {}
+
+    def setup(env):
+        page_id = _make_page(env)
+        keep = env.schedules.create_schedule(
+            ScheduleCreate(page_id=page_id, start_time="06:00", end_time="07:00", day_pattern="all")
+        )
+        doomed = env.schedules.create_schedule(
+            ScheduleCreate(page_id=page_id, start_time="20:00", end_time="21:00", day_pattern="all")
+        )
+        ctx["keep_id"] = keep.id
+        ctx["doomed_id"] = doomed.id
+
+    def browser(env):
+        _ok(_client().delete(f"/schedules/{ctx['doomed_id']}"))
+
+    def endpoint(env):
+        op(_client(), "delete_schedule", {"schedule_id": ctx["doomed_id"]})
+
+    assert_parity(tmp_path, browser, endpoint, setup=setup)
+
+
+def test_update_schedule_applies_the_same_supplied_fields(tmp_path):
+    """A partial update the browser and the executor agree on.
+
+    ``end_time`` is deliberately absent from the tool call here — the case
+    where they *disagree* is
+    ``test_update_schedule_null_end_time_divergence`` below.
+    """
+    ctx: dict[str, str] = {}
+
+    def setup(env):
+        page_id = _make_page(env)
+        entry = env.schedules.create_schedule(
+            ScheduleCreate(page_id=page_id, start_time="07:00", end_time="09:00", day_pattern="weekdays")
+        )
+        ctx["schedule_id"] = entry.id
+
+    def browser(env):
+        # drawer: only the non-null fields are forwarded.
+        _ok(_client().put(f"/schedules/{ctx['schedule_id']}", json={"start_time": "08:00", "enabled": False}))
+
+    def endpoint(env):
+        op(_client(), "update_schedule", {"schedule_id": ctx["schedule_id"], "start_time": "08:00", "enabled": False})
+
+    assert_parity(tmp_path, browser, endpoint, setup=setup)
+
+
+# ---------------------------------------------------------------------------
+# Collections
+# ---------------------------------------------------------------------------
+
+
+def test_create_collection_persists_what_the_browser_rest_call_persisted(tmp_path):
+    ctx: dict[str, str] = {}
+
+    def setup(env):
+        ctx["p1"] = _make_page(env, "P1")
+        ctx["p2"] = _make_page(env, "P2")
+
+    def browser(env):
+        # drawer: handleCreateCollection pinned selection_mode "time".
+        _ok(
+            _client().post(
+                "/collections",
+                json={
+                    "name": "Morning",
+                    "page_ids": [ctx["p1"], ctx["p2"]],
+                    "selection_mode": "time",
+                    "time": {"interval_seconds": 45},
+                },
+            )
+        )
+
+    def endpoint(env):
+        op(
+            _client(),
+            "create_collection",
+            {"name": "Morning", "page_ids": [ctx["p1"], ctx["p2"]], "interval_seconds": 45},
+        )
+
+    assert_parity(tmp_path, browser, endpoint, setup=setup)
+
+
+def test_update_collection_page_list_persists_identically(tmp_path):
+    ctx: dict[str, str] = {}
+
+    def setup(env):
+        ctx["p1"] = _make_page(env, "P1")
+        ctx["p2"] = _make_page(env, "P2")
+        collection = env.collections.create_collection(
+            CollectionCreate(
+                name="Morning",
+                page_ids=[ctx["p1"], ctx["p2"]],
+                selection_mode="time",
+                time=TimeModeConfig(interval_seconds=30),
+            )
+        )
+        ctx["collection_id"] = collection.id
+
+    def browser(env):
+        _ok(_client().put(f"/collections/{ctx['collection_id']}", json={"page_ids": [ctx["p2"], ctx["p1"]]}))
+
+    def endpoint(env):
+        op(_client(), "update_collection", {"collection_id": ctx["collection_id"], "page_ids": [ctx["p2"], ctx["p1"]]})
+
+    assert_parity(tmp_path, browser, endpoint, setup=setup)
+
+
+# ---------------------------------------------------------------------------
+# Plugins
+# ---------------------------------------------------------------------------
+
+
+def test_enable_and_disable_plugin_persist_identically(tmp_path):
+    def browser(env):
+        client = _client()
+        _ok(client.post(f"/plugins/{PLUGIN_ID}/disable"))
+        _ok(client.post(f"/plugins/{PLUGIN_ID}/enable"))
+
+    def endpoint(env):
+        client = _client()
+        op(client, "disable_plugin", {"plugin_id": PLUGIN_ID})
+        op(client, "enable_plugin", {"plugin_id": PLUGIN_ID})
+
+    assert_parity(tmp_path, browser, endpoint, with_plugins=True)
+
+
+def test_uninstall_plugin_persists_identically(tmp_path):
+    def browser(env):
+        _ok(_client().delete(f"/plugins/{PLUGIN_ID}/uninstall"))
+
+    def endpoint(env):
+        op(_client(), "uninstall_plugin", {"plugin_id": PLUGIN_ID})
+
+    assert_parity(tmp_path, browser, endpoint, with_plugins=True)
+
+
+def test_install_plugin_persists_identically(tmp_path):
+    def browser(env):
+        # drawer: handleInstallPlugin -> install, then enable when
+        # auto_enable is not explicitly false.
+        client = _client()
+        _ok(client.post(f"/plugins/registry/{UNINSTALLED_PLUGIN_ID}/install"))
+        _ok(client.post(f"/plugins/{UNINSTALLED_PLUGIN_ID}/enable"))
+
+    def endpoint(env):
+        op(_client(), "install_plugin", {"plugin_id": UNINSTALLED_PLUGIN_ID, "auto_enable": True})
+
+    assert_parity(tmp_path, browser, endpoint, with_plugins=True)
+
+
+def test_configure_plugin_first_write_persists_identically(tmp_path):
+    """On a *first* write there is nothing to merge, so both agree.
+
+    The second write is where they part company — see
+    ``test_update_plugin_config_merge_divergence``.
+    """
+
+    def browser(env):
+        _ok(_client().put(f"/plugins/{PLUGIN_ID}/config", json={"config": {"station_id": "9447427"}}))
+
+    def endpoint(env):
+        op(_client(), "update_plugin_config", {"plugin_id": PLUGIN_ID, "config": {"station_id": "9447427"}})
+
+    assert_parity(tmp_path, browser, endpoint, with_plugins=True)
+
+
+# ---------------------------------------------------------------------------
+# The three divergences the browser dispatcher was hiding
+# ---------------------------------------------------------------------------
+
+
+def _stored_schedule(env, schedule_id: str) -> dict[str, Any]:
+    entry = env.schedules.get_schedule(schedule_id)
+    assert entry is not None
+    return entry.model_dump()
+
+
+def test_update_schedule_null_end_time_divergence(tmp_path):
+    """DIVERGENCE 1 — the browser wiped ``end_time`` on every partial update.
+
+    ``src/ai/chat.py`` emits the tool call as
+    ``tool.args.model_dump(mode="json")``, so an ``update_schedule`` the
+    model wrote without ``end_time`` still arrives at the browser as
+    ``end_time: null``. The drawer forwarded it with an ``"end_time" in
+    update`` test — present-and-null passes — turning every partial update
+    into "make this entry open-ended".
+
+    The executor was fixed for exactly this in #1764 (``None`` means
+    "unchanged"; ``clear_end_time`` is the explicit escape hatch), but
+    nothing on the chat path called the executor, so the defect stayed
+    live in the shipped UI. Routing chat through
+    ``POST /ai/operations`` retires it: the executor is correct, the
+    browser was wrong.
+    """
+    with isolated_env(tmp_path / "browser") as env:
+        page_id = _make_page(env)
+        entry = env.schedules.create_schedule(
+            ScheduleCreate(page_id=page_id, start_time="07:00", end_time="09:00", day_pattern="weekdays")
+        )
+        # The pre-slice drawer's body for {"schedule_id": ..., "start_time": "08:00"}
+        # after the SSE frame filled in every unset field as null.
+        _ok(_client().put(f"/schedules/{entry.id}", json={"start_time": "08:00", "end_time": None}))
+        assert _stored_schedule(env, entry.id)["end_time"] is None, (
+            "fixture no longer reproduces the browser behavior this test pins"
+        )
+
+    with isolated_env(tmp_path / "endpoint") as env:
+        page_id = _make_page(env)
+        entry = env.schedules.create_schedule(
+            ScheduleCreate(page_id=page_id, start_time="07:00", end_time="09:00", day_pattern="weekdays")
+        )
+        op(
+            _client(),
+            "update_schedule",
+            {"schedule_id": entry.id, "start_time": "08:00", "end_time": None},
+        )
+        stored = _stored_schedule(env, entry.id)
+        assert stored["start_time"] == "08:00"
+        assert stored["end_time"] == "09:00", "the endpoint must not wipe an end_time the caller did not send"
+
+
+def test_update_plugin_config_merge_divergence(tmp_path):
+    """DIVERGENCE 2 — the browser replaced the stored config; the executor merges.
+
+    ``PUT /plugins/{id}/config`` is the settings *form* endpoint: replace
+    is right there, because the form posts every field. A chat op sends
+    only the keys it is changing, so replace dropped everything the user
+    had configured earlier — and, when one of the dropped keys was
+    required, the second write did not even land: the endpoint answered
+    400 and the drawer surfaced "Failed" to the model.
+    ``configure_plugin`` merges — the semantics #1764 decided on and
+    ``tests/test_mcp_state_effects.py`` already pinned for MCP. The
+    browser was wrong.
+    """
+    with isolated_env(tmp_path / "browser", with_plugins=True) as env:
+        client = _client()
+        _ok(client.put(f"/plugins/{PLUGIN_ID}/config", json={"config": {"station_id": "9447427"}}))
+        second = client.put(f"/plugins/{PLUGIN_ID}/config", json={"config": {"api_key": "test_secret"}})
+        assert second.status_code == 400, "fixture no longer reproduces the browser's replace semantics"
+        assert "station_id is required" in str(second.json()["detail"])
+        stored = env.config.get_plugin_config(PLUGIN_ID, include_env_overrides=False) or {}
+        assert "api_key" not in stored, "the browser's second write was rejected, so nothing was stored"
+
+    with isolated_env(tmp_path / "endpoint", with_plugins=True) as env:
+        client = _client()
+        op(client, "update_plugin_config", {"plugin_id": PLUGIN_ID, "config": {"station_id": "9447427"}})
+        op(client, "update_plugin_config", {"plugin_id": PLUGIN_ID, "config": {"api_key": "test_secret"}})
+        stored = env.config.get_plugin_config(PLUGIN_ID, include_env_overrides=False) or {}
+        assert stored.get("station_id") == "9447427", "a partial chat config write must not drop earlier keys"
+        assert stored.get("api_key") == "test_secret"
+
+
+def test_update_collection_interval_only_divergence(tmp_path):
+    """DIVERGENCE 3 — the browser forced a variable-mode collection back to time mode.
+
+    ``handleUpdateCollection`` sent ``selection_mode: "time"`` alongside
+    any ``interval_seconds``, so asking the AI to "make that collection
+    rotate every 45 seconds" silently destroyed its variable rules. The
+    executor changes only the time config. Same defect
+    ``tests/test_op_parity.py`` recorded as fail-first divergence 2 for
+    the transcribed chat path; it was still live in the browser.
+    """
+    for name, run in (("browser", "browser"), ("endpoint", "endpoint")):
+        with isolated_env(tmp_path / name) as env:
+            page_id = _make_page(env)
+            collection = env.collections.create_collection(
+                CollectionCreate(
+                    name="VarCol",
+                    page_ids=[page_id],
+                    selection_mode="variable",
+                    time=TimeModeConfig(interval_seconds=30),
+                    variable=VariableModeConfig(
+                        rules=[VariableRule(expression="1", page_id=page_id)],
+                        default_page_id=page_id,
+                        poll_seconds=10,
+                    ),
+                )
+            )
+            if run == "browser":
+                _ok(
+                    _client().put(
+                        f"/collections/{collection.id}",
+                        json={"selection_mode": "time", "time": {"interval_seconds": 45}},
+                    )
+                )
+                after = env.collections.get_collection(collection.id)
+                assert after is not None
+                assert after.selection_mode == "time", (
+                    "fixture no longer reproduces the browser's mode-forcing behavior"
+                )
+            else:
+                op(_client(), "update_collection", {"collection_id": collection.id, "interval_seconds": 45})
+                after = env.collections.get_collection(collection.id)
+                assert after is not None
+                assert after.selection_mode == "variable", "an interval-only change must not flip the selection mode"
+                assert after.time.interval_seconds == 45
+
+
+# ---------------------------------------------------------------------------
+# The endpoint's own contract
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_op_is_a_404_naming_the_op():
+    response = _client().post("/ai/operations", json={"op": "make_coffee", "args": {}})
+    assert response.status_code == 404
+    assert "make_coffee" in response.json()["detail"]
+
+
+def test_mcp_only_op_is_not_reachable_over_the_chat_endpoint():
+    """``send_message`` has an executor but no chat spelling — 404, not a send."""
+    response = _client().post("/ai/operations", json={"op": "send_message", "args": {"text": "HI"}})
+    assert response.status_code == 404
+    assert "chat operation grammar" in response.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    "client_side_op",
+    ["apply_patch", "suggest_variables", "navigate_to_page", "navigate_to_schedule", "update_task_list"],
+)
+def test_client_side_op_is_a_4xx_naming_the_op_and_the_browser(client_side_op):
+    response = _client().post("/ai/operations", json={"op": client_side_op, "args": {}})
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert client_side_op in detail
+    assert "browser" in detail
+
+
+def test_invalid_args_are_a_422_carrying_the_pydantic_detail():
+    response = _client().post("/ai/operations", json={"op": "enable_plugin", "args": {}})
+    assert response.status_code == 422
+    assert "plugin_id" in response.json()["detail"]
+
+
+def test_a_failing_executor_is_a_4xx_not_a_200_carrying_an_error(tmp_path):
+    with isolated_env(tmp_path / "missing"):
+        response = _client().post(
+            "/ai/operations",
+            json={"op": "delete_schedule", "args": {"schedule_id": "does-not-exist"}},
+        )
+    assert response.status_code == 400
+    assert "does-not-exist" in response.json()["detail"]
+
+
+def test_the_success_envelope_carries_the_executor_fields(tmp_path):
+    with isolated_env(tmp_path / "created") as env:
+        page_id = _make_page(env)
+        body = op(
+            _client(),
+            "create_schedule",
+            {"page_id": page_id, "start_time": "07:00", "day_pattern": "all"},
+        )
+        schedule_id = body["result"]["schedule_id"]
+        assert env.schedules.get_schedule(schedule_id) is not None
+        assert body["message"].startswith("Schedule created")
+
+
+def test_extra_top_level_keys_are_rejected():
+    response = _client().post("/ai/operations", json={"op": "enable_plugin", "args": {}, "board_id": "b1"})
+    assert response.status_code == 422
+
+
+def test_parity_harness_can_fail(tmp_path):
+    """Non-vacuity: the snapshot comparison must be able to see a difference."""
+    ctx: dict[str, str] = {}
+
+    def setup(env):
+        ctx["page_id"] = _make_page(env)
+
+    with pytest.raises(AssertionError, match="persisted different state"):
+        assert_parity(
+            tmp_path,
+            lambda env: op(
+                _client(), "create_schedule", {"page_id": ctx["page_id"], "start_time": "07:00", "day_pattern": "all"}
+            ),
+            lambda env: None,
+            setup=setup,
+        )
+
+
+def test_snapshot_sees_the_stores_the_endpoint_writes(tmp_path):
+    """Guard the guard: an op executed over HTTP must show up in the snapshot."""
+    with isolated_env(tmp_path / "seen") as env:
+        before = snapshot(env)
+        page_id = _make_page(env)
+        op(_client(), "create_schedule", {"page_id": page_id, "start_time": "07:00", "day_pattern": "all"})
+        assert snapshot(env) != before

--- a/tests/test_op_parity.py
+++ b/tests/test_op_parity.py
@@ -487,8 +487,10 @@ def test_chat_has_no_server_side_page_creation_spelling(tmp_path, mcp):
     def mcp_steps(env):
         pass  # no MCP counterpart: create_page is a different operation
 
-    # Neither path may persist anything, so parity here is "both stores empty".
-    assert_parity(tmp_path, chat_steps, mcp_steps)
+    # Neither path may persist anything, so parity here is "both stores
+    # untouched" — which is the one case the do-nothing guard must not treat
+    # as vacuous, so it is declared rather than defaulted.
+    assert_parity(tmp_path, chat_steps, mcp_steps, changes_state=False)
 
 
 def test_parity_create_page_is_mcp_only(tmp_path, mcp):
@@ -546,9 +548,7 @@ def test_snapshot_comparison_detects_two_paths_that_both_act_but_differ(tmp_path
             lambda env: chat(
                 "create_schedule", {"page_id": ctx["page_id"], "start_time": "07:00", "day_pattern": "all"}
             ),
-            lambda env: mcp_call(
-                mcp, "create_schedule", page_id=ctx["page_id"], start_time="09:30", day_pattern="all"
-            ),
+            lambda env: mcp_call(mcp, "create_schedule", page_id=ctx["page_id"], start_time="09:30", day_pattern="all"),
             setup=lambda env: ctx.__setitem__("page_id", _make_page(env)),
         )
 

--- a/tests/test_op_parity.py
+++ b/tests/test_op_parity.py
@@ -54,7 +54,6 @@ from src.collections.service import CollectionService
 from src.collections.storage import CollectionStorage
 from src.config_manager import ConfigManager
 from src.mcp_server import _build_mcp_server
-from src.ops import execute
 from src.pages.models import PageCreate
 from src.pages.service import PageService
 from src.pages.storage import PageStorage
@@ -178,9 +177,38 @@ def snapshot(env: SimpleNamespace) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+class ChatOpFailure(AssertionError):
+    """The chat endpoint refused an operation. Carries the HTTP status + detail."""
+
+    def __init__(self, status_code: int, detail: Any) -> None:
+        super().__init__(f"{status_code}: {detail}")
+        self.status_code = status_code
+        self.detail = detail
+
+
 def chat(op: str, args: dict[str, Any]) -> Any:
-    """The chat-grammar path: chat spelling + chat-shaped args through the ops layer."""
-    return asyncio.run(execute(op, args))
+    """The chat-grammar path — over HTTP, exactly as the browser calls it.
+
+    Phase 2 Task 11: this driver used to call ``src.ops.execute`` in
+    process. That could not see the failure mode this suite exists to
+    prevent, because the shipped web client never called the ops layer at
+    all — it ran its own per-op REST dispatcher, and had drifted from the
+    executors in three places (see
+    ``tests/test_chat_op_http_parity.py``). Posting to
+    ``POST /ai/operations`` makes the "chat path" here the same code path
+    the product ships.
+
+    A refused operation raises, mirroring the MCP side's ``ToolError``.
+    """
+    from fastapi.testclient import TestClient
+
+    from src.api_server import app
+
+    response = TestClient(app).post("/ai/operations", json={"op": op, "args": args})
+    if response.status_code != 200:
+        raise ChatOpFailure(response.status_code, response.json().get("detail"))
+    body = response.json()
+    return {"status": "success", "message": body["message"], **body["result"]}
 
 
 def mcp_call(mcp: Any, tool: str, /, **kwargs: Any) -> Any:
@@ -304,8 +332,11 @@ def test_parity_update_plugin_rejects_builtins_identically(tmp_path, mcp):
     leave state untouched — the guarded error path is part of the contract."""
 
     def chat_steps(env):
-        result = chat("update_plugin", {"plugin_id": PLUGIN_ID})
-        assert result["status"] == "error"
+        # Task 11: the endpoint turns the executor's error envelope into a
+        # 400 rather than a 200 carrying {"status": "error"}.
+        with pytest.raises(ChatOpFailure) as refused:
+            chat("update_plugin", {"plugin_id": PLUGIN_ID})
+        assert refused.value.status_code == 400
 
     def mcp_steps(env):
         # #1765: the MCP surface converts the executor's error envelope into
@@ -432,11 +463,37 @@ def test_parity_collection_create_and_update(tmp_path, mcp):
 # ---------------------------------------------------------------------------
 
 
-def test_parity_replace_page_vs_create_page(tmp_path, mcp):
+def test_chat_has_no_server_side_page_creation_spelling(tmp_path, mcp):
+    """Was ``test_parity_replace_page_vs_create_page`` (Phase 2 Task 11).
+
+    That test asserted #1764's alias of ``replace_page`` onto
+    ``create_page``. The alias was wrong: ``replace_page`` rewrites the
+    page mounted in the editor — the system prompt calls it "destructive"
+    and tells the global drawer to navigate to the editor rather than
+    "write template content remotely" — and the shipped browser has always
+    applied it there. The alias survived only because nothing on the chat
+    path ever called the registry, and it "passed" parity only because
+    both paths created a page in an empty store.
+
+    The MCP tool keeps its executor; the chat endpoint refuses the op.
+    """
+
     def chat_steps(env):
-        chat("replace_page", {"name": "Weather", "template": FLAGSHIP_TEMPLATE, "duration_seconds": 120})
+        with pytest.raises(ChatOpFailure) as refused:
+            chat("replace_page", {"name": "Weather", "template": FLAGSHIP_TEMPLATE, "duration_seconds": 120})
+        assert refused.value.status_code == 400
+        assert "browser" in refused.value.detail
 
     def mcp_steps(env):
+        pass  # no MCP counterpart: create_page is a different operation
+
+    # Neither path may persist anything, so parity here is "both stores empty".
+    assert_parity(tmp_path, chat_steps, mcp_steps)
+
+
+def test_parity_create_page_is_mcp_only(tmp_path, mcp):
+    """``create_page`` still persists a page through the MCP spelling."""
+    with isolated_env(tmp_path / "mcp_only") as env:
         mcp_call(
             mcp,
             "create_page",
@@ -445,8 +502,7 @@ def test_parity_replace_page_vs_create_page(tmp_path, mcp):
             device_type="flagship",
             duration_seconds=120,
         )
-
-    assert_parity(tmp_path, chat_steps, mcp_steps)
+        assert [p.name for p in env.pages.list_pages()] == ["Weather"]
 
 
 # ---------------------------------------------------------------------------
@@ -462,23 +518,38 @@ def test_snapshot_comparison_detects_a_real_state_difference(tmp_path, mcp):
     do-nothing guard is what reports it. Both halves are exercised: this
     test for the guard, the one below for the comparison itself.
     """
+    ctx: dict[str, str] = {}
 
     with pytest.raises(AssertionError, match="persisted no change at all"):
         assert_parity(
             tmp_path,
-            lambda env: chat("replace_page", {"name": "Chat Page", "template": FLAGSHIP_TEMPLATE}),
+            lambda env: chat(
+                "create_schedule", {"page_id": ctx["page_id"], "start_time": "07:00", "day_pattern": "all"}
+            ),
             lambda env: None,  # the MCP path creates nothing
+            setup=lambda env: ctx.__setitem__("page_id", _make_page(env)),
         )
 
 
 def test_snapshot_comparison_detects_two_paths_that_both_act_but_differ(tmp_path, mcp):
-    """Both paths persist something, so only the comparison can catch it."""
+    """Both paths persist something, so only the comparison can catch it.
+
+    Deliberately not ``replace_page`` — that op is client-side since the ops
+    wiring, so the chat path would refuse rather than persist and the
+    do-nothing guard, not the comparison, would be what fired.
+    """
+    ctx: dict[str, str] = {}
 
     with pytest.raises(AssertionError, match="persisted different state"):
         assert_parity(
             tmp_path,
-            lambda env: chat("replace_page", {"name": "Chat Page", "template": FLAGSHIP_TEMPLATE}),
-            lambda env: mcp_call(mcp, "create_page", name="A Different Name", template_lines=FLAGSHIP_TEMPLATE),
+            lambda env: chat(
+                "create_schedule", {"page_id": ctx["page_id"], "start_time": "07:00", "day_pattern": "all"}
+            ),
+            lambda env: mcp_call(
+                mcp, "create_schedule", page_id=ctx["page_id"], start_time="09:30", day_pattern="all"
+            ),
+            setup=lambda env: ctx.__setitem__("page_id", _make_page(env)),
         )
 
 

--- a/tests/test_ops_registry.py
+++ b/tests/test_ops_registry.py
@@ -55,7 +55,14 @@ EXPECTED_CANONICAL = {
     # MCP-only server op since #1765 — the REST POST /send-message
     # equivalent; the chat grammar has no spelling for it today.
     "send_message",
-    # client-side chat ops, registered so the registry is the whole grammar
+    # client-side chat ops, registered so the registry is the whole grammar.
+    # ``replace_page`` joined them in Phase 2 Task 11: it edits the page
+    # mounted in the editor (like ``apply_patch``), which is what the system
+    # prompt teaches and what the browser has always done. #1764's alias onto
+    # ``create_page`` was never exercised — nothing on the chat path called
+    # the registry — and executing it server-side would create a second page
+    # while leaving the open editor untouched.
+    "replace_page",
     "apply_patch",
     "suggest_variables",
     "navigate_to_page",
@@ -97,7 +104,20 @@ def test_every_chat_named_executor_op_has_an_args_adapter():
 
 def test_alias_resolution_covers_both_spellings_of_shared_ops():
     assert get_operation("update_plugin_config") is get_operation("configure_plugin")
-    assert get_operation("replace_page") is get_operation("create_page")
+
+
+def test_replace_page_is_an_editor_op_not_an_alias_of_create_page():
+    """Phase 2 Task 11: the two are different operations, not two spellings.
+
+    ``create_page`` (MCP) persists a new page. ``replace_page`` (chat)
+    rewrites the page open in the editor and has no server executor —
+    resolving them to the same object would put "create a duplicate page"
+    behind a prompt that promises "rewrite what I am looking at".
+    """
+    assert get_operation("replace_page") is not get_operation("create_page")
+    assert get_operation("replace_page").client_side is True
+    assert get_operation("create_page").client_side is False
+    assert get_operation("create_page").chat_name is None
 
 
 def test_unknown_operation_name_raises():
@@ -181,18 +201,26 @@ def services(tmp_path, monkeypatch):
 FLAGSHIP_TEMPLATE = ["HELLO", "", "", "", "", ""]
 
 
-def test_execute_replace_page_creates_a_persisted_page(services):
-    result = _run(
-        execute(
-            "replace_page",
-            {"name": "From Chat Grammar", "template": FLAGSHIP_TEMPLATE, "duration_seconds": 120},
-        )
-    )
+def test_execute_replace_page_refuses_and_persists_nothing(services):
+    """Phase 2 Task 11: ``replace_page`` is applied in the editor, not here.
+
+    Was ``test_execute_replace_page_creates_a_persisted_page``, which
+    asserted the #1764 alias onto ``create_page``. That alias contradicted
+    both the system prompt and the shipped browser behavior; executing it
+    server-side would silently create a duplicate page.
+    """
+    with pytest.raises(ClientSideOperationError):
+        _run(execute("replace_page", {"name": "From Chat Grammar", "template": FLAGSHIP_TEMPLATE}))
+    assert services["pages"].list_pages() == []
+
+
+def test_execute_create_page_still_persists_a_page(services):
+    """The MCP spelling keeps its executor."""
+    result = _run(execute("create_page", {"name": "From MCP", "template_lines": FLAGSHIP_TEMPLATE}))
     assert result["status"] == "success"
     stored = services["pages"].get_page(result["page_id"])
     assert stored is not None
-    assert stored.name == "From Chat Grammar"
-    assert stored.duration_seconds == 120
+    assert stored.name == "From MCP"
 
 
 def test_execute_update_schedule_via_chat_name_changes_only_supplied_fields(services):

--- a/tests/test_ops_wiring.py
+++ b/tests/test_ops_wiring.py
@@ -1,0 +1,173 @@
+"""The ops layer is the live path for chat, and the browser cannot take it back.
+
+Phase 2, Task 11. ``src/ops`` was built so the chat and MCP surfaces could
+not diverge, but the web drawer never called it: it carried its own
+``switch (call.op)`` over a dozen REST endpoints. The layer had zero
+production callers on the chat path, and the two surfaces drifted anyway
+(three live divergences, pinned in ``tests/test_chat_op_http_parity.py``).
+
+Behavioural parity is asserted over HTTP in that file. What this file adds
+is the *structural* guard: a future edit that re-implements a server-side
+operation in ``global-ai-chat-drawer.tsx`` has to delete a test to land.
+
+Everything here reads the real TSX, so it fails on a rename rather than
+passing vacuously — ``test_the_source_scan_actually_found_the_dispatcher``
+proves the parser is looking at something.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from src.ops import OPERATIONS
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DRAWER = REPO_ROOT / "web/src/components/global-ai-chat-drawer.tsx"
+DRAWER_SOURCE = DRAWER.read_text(encoding="utf-8")
+
+#: REST client methods that existed only to execute a chat op in the browser.
+#: Each one was the body of a ``handle<Op>`` callback before Task 11; any of
+#: them reappearing in the drawer means an operation grew a second
+#: implementation next to its executor.
+FORBIDDEN_DIRECT_API_CALLS = {
+    "installRegistryPlugin",
+    "enablePlugin",
+    "disablePlugin",
+    "uninstallPlugin",
+    "updatePluginConfig",
+    "updatePlugin",
+    "createCollection",
+    "updateCollection",
+    "updateDisplaySettings",
+    "updateTransitionSettings",
+    "updateOutputSettings",
+    "updatePollingSettings",
+    "updateLocationSettings",
+    "updateSilenceSchedule",
+    "setActivePage",
+    "applyUpdate",
+}
+
+#: The schedule mutations the drawer may still call directly, and why. The
+#: chat grammar's ``create_schedule`` has no ``start_type`` /
+#: ``*_sun_offset`` fields, so restoring a deleted sunrise schedule through
+#: the ops endpoint would silently downgrade it to a fixed clock time.
+#: Confined to the toast helper — asserted below, not just documented.
+UNDO_ONLY_API_CALLS = {"createSchedule", "updateSchedule", "deleteSchedule"}
+
+
+def _chat_ops(*, client_side: bool) -> set[str]:
+    return {op.chat_name for op in OPERATIONS if op.chat_name and op.client_side is client_side}
+
+
+def _declared_server_ops() -> list[str]:
+    """The op names the drawer declares it delegates to the server."""
+    match = re.search(r"const SERVER_EXECUTED_OPS = \[(.*?)\] as const;", DRAWER_SOURCE, re.S)
+    assert match, "global-ai-chat-drawer.tsx no longer declares SERVER_EXECUTED_OPS"
+    return re.findall(r'"([a-z_]+)"', match.group(1))
+
+
+def _api_calls(source: str) -> set[str]:
+    return set(re.findall(r"\bapi\.([A-Za-z0-9_]+)\(", source))
+
+
+def _toast_helper_source() -> str:
+    start = DRAWER_SOURCE.index("const showServerOpToast = useCallback(")
+    end = DRAWER_SOURCE.index("const runServerOp = useCallback(")
+    return DRAWER_SOURCE[start:end]
+
+
+# ---------------------------------------------------------------------------
+# The drawer's op list and the registry are one list
+# ---------------------------------------------------------------------------
+
+
+def test_drawer_delegates_exactly_the_registrys_server_side_chat_ops():
+    """No op may be server-side in the registry but browser-side in the UI."""
+    declared = set(_declared_server_ops())
+    expected = _chat_ops(client_side=False)
+    assert declared == expected, (
+        "the drawer's SERVER_EXECUTED_OPS and src/ops/registry.py disagree.\n"
+        f"  drawer only:   {sorted(declared - expected)}\n"
+        f"  registry only: {sorted(expected - declared)}"
+    )
+
+
+def test_the_drawer_op_list_is_sorted_and_unique():
+    declared = _declared_server_ops()
+    assert declared == sorted(declared), "keep SERVER_EXECUTED_OPS sorted so diffs stay readable"
+    assert len(declared) == len(set(declared))
+
+
+def test_every_chat_op_is_either_server_executed_or_client_side():
+    """The grammar has no third category the UI could quietly invent."""
+    server = _chat_ops(client_side=False)
+    client = _chat_ops(client_side=True)
+    assert server & client == set()
+    from src.ops.grammar import _OP_REGISTRY
+
+    assert server | client == set(_OP_REGISTRY)
+
+
+def test_client_side_ops_are_not_delegated_to_the_server():
+    declared = set(_declared_server_ops())
+    assert declared & _chat_ops(client_side=True) == set()
+
+
+# ---------------------------------------------------------------------------
+# The browser cannot re-grow an executor
+# ---------------------------------------------------------------------------
+
+
+def test_no_server_executed_op_has_a_browser_side_rest_implementation():
+    """The REST calls the per-op handlers used are gone from the drawer."""
+    offenders = sorted(_api_calls(DRAWER_SOURCE) & FORBIDDEN_DIRECT_API_CALLS)
+    assert offenders == [], (
+        "global-ai-chat-drawer.tsx calls REST endpoints that belong to a "
+        "server-executed operation. Route the op through "
+        "api.executeAiOperation (POST /ai/operations) instead — that is the "
+        "seam that keeps the chat and MCP surfaces on one executor. "
+        f"Offending calls: {offenders}"
+    )
+
+
+def test_no_handle_callback_survives_for_a_server_executed_op():
+    """``const handleEnablePlugin = ...`` is the shape of the old dispatcher."""
+    camel = {"".join(part.title() for part in op.split("_")) for op in _declared_server_ops()}
+    offenders = sorted(name for name in camel if f"const handle{name}" in DRAWER_SOURCE)
+    assert offenders == [], f"server-executed ops must not have their own browser handler: {offenders}"
+
+
+def test_schedule_mutations_remain_confined_to_the_undo_affordances():
+    """The three allowed direct calls exist only inside the toast helper."""
+    helper = _toast_helper_source()
+    outside = _api_calls(DRAWER_SOURCE.replace(helper, "")) & UNDO_ONLY_API_CALLS
+    assert outside == set(), (
+        "schedule REST mutations may only appear in showServerOpToast's Undo "
+        f"actions; found {sorted(outside)} elsewhere in the drawer"
+    )
+    assert _api_calls(helper) & UNDO_ONLY_API_CALLS, "the Undo affordances disappeared from the toast helper"
+
+
+def test_the_ops_endpoint_is_the_drawers_only_execution_seam():
+    assert DRAWER_SOURCE.count("api.executeAiOperation(") == 1
+
+
+# ---------------------------------------------------------------------------
+# Guarding the guard
+# ---------------------------------------------------------------------------
+
+
+def test_the_source_scan_actually_found_the_dispatcher():
+    """A parser that matches nothing would make every test above vacuous."""
+    assert len(_declared_server_ops()) >= 13
+    assert "runServerOp" in DRAWER_SOURCE
+    assert len(_api_calls(DRAWER_SOURCE)) >= 5
+    assert "const showServerOpToast = useCallback(" in DRAWER_SOURCE
+
+
+def test_the_forbidden_call_scan_can_see_a_forbidden_call():
+    """Non-vacuity for the guard above: plant one and watch the scan find it."""
+    planted = DRAWER_SOURCE + "\n// await api.enablePlugin(id);\n"
+    assert _api_calls(planted) & FORBIDDEN_DIRECT_API_CALLS == {"enablePlugin"}

--- a/web/src/components/global-ai-chat-drawer.tsx
+++ b/web/src/components/global-ai-chat-drawer.tsx
@@ -17,20 +17,18 @@ import type {
   ChatTurnContext,
   CreateCollectionArgs,
   CreateScheduleArgs,
-  DeleteScheduleArgs,
   DisablePluginArgs,
   EnablePluginArgs,
   InstallPluginArgs,
+  SettingCategory,
   TaskItem,
   ToolCall,
   UninstallPluginArgs,
-  UpdateCollectionArgs,
   UpdatePluginArgs,
   UpdatePluginConfigArgs,
-  UpdateScheduleArgs,
   UpdateSettingArgs,
 } from "@/lib/ai-chat-types";
-import { type AISettings, api } from "@/lib/api";
+import { type AiOperationResult, type AISettings, api, type ScheduleEntry } from "@/lib/api";
 import { isChromelessPath } from "@/lib/chromeless";
 import { cn } from "@/lib/utils";
 
@@ -105,6 +103,86 @@ function buildToolResultText(call: ToolCall, success: boolean, errorMsg?: string
     default:
       return `[Tool result: ${(call as ToolCall).op} → ${status}.]`;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Server-executed operations (Phase 2 Task 11)
+//
+// Every op listed here is executed by the server through
+// `POST /ai/operations` (src/ai/routes.py -> src/ops/registry.execute), which
+// runs the same canonical executor the MCP tools call. The browser's job is
+// confirmation UX, cache invalidation and the toast — not a second
+// implementation of the operation. Before this, the drawer dispatched each op
+// to a different REST endpoint itself, and had drifted from the executors in
+// three places (see tests/test_chat_op_http_parity.py).
+//
+// The ops NOT listed are the six the registry marks `client_side=True`:
+// replace_page and apply_patch edit the mounted editor, suggest_variables
+// surfaces a list, navigate_to_page / navigate_to_schedule route, and
+// update_task_list drives the task panel. They have no server effect and the
+// endpoint refuses them with a 400.
+//
+// tests/test_ops_wiring.py fails the build if this list and the registry
+// disagree, or if a server-executed op regrows a browser-side implementation.
+// ---------------------------------------------------------------------------
+
+const SERVER_EXECUTED_OPS = [
+  "create_collection",
+  "create_schedule",
+  "delete_schedule",
+  "disable_plugin",
+  "enable_plugin",
+  "install_plugin",
+  "trigger_system_update",
+  "uninstall_plugin",
+  "update_collection",
+  "update_plugin",
+  "update_plugin_config",
+  "update_schedule",
+  "update_setting",
+] as const;
+
+type ServerExecutedOp = (typeof SERVER_EXECUTED_OPS)[number];
+type ServerExecutedCall = ToolCall & { op: ServerExecutedOp };
+
+function isServerExecutedCall(call: ToolCall): call is ServerExecutedCall {
+  return (SERVER_EXECUTED_OPS as readonly string[]).includes(call.op);
+}
+
+/** Which cached queries each op invalidates — unchanged from the old handlers. */
+const OP_QUERY_KEYS: Record<Exclude<ServerExecutedOp, "update_setting">, readonly string[]> = {
+  create_collection: ["collections"],
+  create_schedule: ["schedules"],
+  delete_schedule: ["schedules"],
+  disable_plugin: ["plugins"],
+  enable_plugin: ["plugins"],
+  install_plugin: ["plugins"],
+  // A system update recreates the container; nothing local is worth refetching.
+  trigger_system_update: [],
+  uninstall_plugin: ["plugins"],
+  update_collection: ["collections"],
+  update_plugin: ["plugins"],
+  update_plugin_config: ["plugins"],
+  update_schedule: ["schedules"],
+};
+
+/** update_setting refreshes only the category it touched. */
+const SETTING_QUERY_KEY: Record<SettingCategory, string> = {
+  display: "display-settings",
+  transitions: "transition-settings",
+  output: "output-settings",
+  polling: "polling-settings",
+  location: "location-settings",
+  silence_schedule: "silence-schedule",
+  active_page: "active-page",
+};
+
+function queryKeysForOp(call: ServerExecutedCall): readonly string[] {
+  if (call.op === "update_setting") {
+    const key = SETTING_QUERY_KEY[(call.args as UpdateSettingArgs).category];
+    return key ? [key] : [];
+  }
+  return OP_QUERY_KEYS[call.op];
 }
 
 export function GlobalAiChatDrawer() {
@@ -297,103 +375,148 @@ export function GlobalAiChatDrawer() {
     };
   }, [pagesData, pluginsData, schedulesData, collectionsData, registryData, getEditorSnapshot]);
 
-  const handleCreateSchedule = useCallback(
-    async (args: CreateScheduleArgs) => {
-      const created = await api.createSchedule({
-        page_id: args.page_id,
-        start_time: args.start_time,
-        end_time: args.end_time ?? null,
-        day_pattern: args.day_pattern,
-        custom_days: args.custom_days ?? undefined,
-        enabled: args.enabled,
-      });
-      await queryClient.invalidateQueries({ queryKey: ["schedules"] });
-      toast.success("Schedule created.", {
-        action: {
-          label: "Undo",
-          onClick: () => {
-            void (async () => {
-              await api.deleteSchedule(created.id);
-              await queryClient.invalidateQueries({ queryKey: ["schedules"] });
-            })();
-          },
-        },
-        duration: 8000,
-      });
+  // ---------------------------------------------------------------------------
+  // Local UX after a server-executed op: the same toasts (and the same Undo
+  // affordances) the per-op handlers showed before execution moved server-side.
+  //
+  // Undo still goes over the plain REST client rather than the ops endpoint:
+  // the chat grammar's create_schedule has no `start_type` / `*_sun_offset`
+  // fields, so restoring a deleted sunrise/sunset schedule through it would
+  // silently downgrade the entry to a fixed clock time.
+  // ---------------------------------------------------------------------------
+  const showServerOpToast = useCallback(
+    (call: ServerExecutedCall, result: AiOperationResult, previousSchedule?: ScheduleEntry) => {
+      const refreshSchedules = () => queryClient.invalidateQueries({ queryKey: ["schedules"] });
+      switch (call.op) {
+        case "create_schedule": {
+          const createdId = result.result.schedule_id;
+          toast.success("Schedule created.", {
+            action:
+              typeof createdId === "string"
+                ? {
+                    label: "Undo",
+                    onClick: () => {
+                      void (async () => {
+                        await api.deleteSchedule(createdId);
+                        await refreshSchedules();
+                      })();
+                    },
+                  }
+                : undefined,
+            duration: 8000,
+          });
+          break;
+        }
+        case "update_schedule":
+          toast.success("Schedule updated.", {
+            action: previousSchedule
+              ? {
+                  label: "Undo",
+                  onClick: () => {
+                    void (async () => {
+                      await api.updateSchedule(previousSchedule.id, {
+                        page_id: previousSchedule.page_id,
+                        start_time: previousSchedule.start_time,
+                        end_time: previousSchedule.end_time ?? null,
+                        day_pattern: previousSchedule.day_pattern,
+                        custom_days: previousSchedule.custom_days,
+                        enabled: previousSchedule.enabled,
+                      });
+                      await refreshSchedules();
+                    })();
+                  },
+                }
+              : undefined,
+            duration: 8000,
+          });
+          break;
+        case "delete_schedule":
+          toast.success("Schedule deleted.", {
+            action: previousSchedule
+              ? {
+                  label: "Undo",
+                  onClick: () => {
+                    void (async () => {
+                      await api.createSchedule({
+                        page_id: previousSchedule.page_id,
+                        start_time: previousSchedule.start_time,
+                        end_time: previousSchedule.end_time ?? null,
+                        day_pattern: previousSchedule.day_pattern,
+                        custom_days: previousSchedule.custom_days,
+                        enabled: previousSchedule.enabled,
+                        start_type: previousSchedule.start_type,
+                        start_sun_offset: previousSchedule.start_sun_offset,
+                        end_type: previousSchedule.end_type,
+                        end_sun_offset: previousSchedule.end_sun_offset,
+                      });
+                      await refreshSchedules();
+                    })();
+                  },
+                }
+              : undefined,
+            duration: 8000,
+          });
+          break;
+        case "install_plugin":
+          toast.success(`Plugin "${(call.args as InstallPluginArgs).plugin_id}" installed successfully.`);
+          break;
+        case "update_plugin_config":
+          toast.success(`Plugin "${(call.args as UpdatePluginConfigArgs).plugin_id}" configuration updated.`);
+          break;
+        case "update_plugin":
+          toast.success(`Plugin "${(call.args as UpdatePluginArgs).plugin_id}" updated successfully.`);
+          break;
+        case "enable_plugin":
+          toast.success(`Plugin "${(call.args as EnablePluginArgs).plugin_id}" enabled.`);
+          break;
+        case "disable_plugin":
+          toast.success(`Plugin "${(call.args as DisablePluginArgs).plugin_id}" disabled.`);
+          break;
+        case "uninstall_plugin":
+          toast.success(`Plugin "${(call.args as UninstallPluginArgs).plugin_id}" uninstalled.`);
+          break;
+        case "update_setting":
+          toast.success("Setting updated.");
+          break;
+        case "create_collection":
+          toast.success(`Collection "${(call.args as CreateCollectionArgs).name}" created.`);
+          break;
+        case "update_collection":
+          toast.success("Collection updated.");
+          break;
+        case "trigger_system_update":
+          toast.success("System update started. The board will restart shortly.");
+          break;
+      }
     },
     [queryClient],
   );
 
-  const handleUpdateSchedule = useCallback(
-    async (args: UpdateScheduleArgs) => {
-      const { schedule_id, ...update } = args;
-      const oldSchedule = schedulesData?.schedules?.find((s) => s.id === schedule_id);
-      await api.updateSchedule(schedule_id, {
-        ...(update.page_id != null && { page_id: update.page_id }),
-        ...(update.start_time != null && { start_time: update.start_time }),
-        ...("end_time" in update && { end_time: update.end_time ?? null }),
-        ...(update.day_pattern != null && { day_pattern: update.day_pattern }),
-        ...(update.custom_days != null && { custom_days: update.custom_days }),
-        ...(update.enabled != null && { enabled: update.enabled }),
-      });
-      await queryClient.invalidateQueries({ queryKey: ["schedules"] });
-      toast.success("Schedule updated.", {
-        action: oldSchedule
-          ? {
-              label: "Undo",
-              onClick: () => {
-                void (async () => {
-                  await api.updateSchedule(schedule_id, {
-                    page_id: oldSchedule.page_id,
-                    start_time: oldSchedule.start_time,
-                    end_time: oldSchedule.end_time ?? null,
-                    day_pattern: oldSchedule.day_pattern,
-                    custom_days: oldSchedule.custom_days,
-                    enabled: oldSchedule.enabled,
-                  });
-                  await queryClient.invalidateQueries({ queryKey: ["schedules"] });
-                })();
-              },
-            }
-          : undefined,
-        duration: 8000,
-      });
-    },
-    [queryClient, schedulesData],
-  );
+  // ---------------------------------------------------------------------------
+  // The single execution seam: one POST, then the local UX.
+  // ---------------------------------------------------------------------------
+  const runServerOp = useCallback(
+    async (call: ToolCall) => {
+      if (!isServerExecutedCall(call)) {
+        // Unreachable via the dispatchers below; a guard so an op added to the
+        // grammar cannot silently fall through to a no-op "success".
+        throw new Error(`${call.op} is not executed server-side`);
+      }
 
-  const handleDeleteSchedule = useCallback(
-    async (args: DeleteScheduleArgs) => {
-      const schedule = schedulesData?.schedules?.find((s) => s.id === args.schedule_id);
-      await api.deleteSchedule(args.schedule_id);
-      await queryClient.invalidateQueries({ queryKey: ["schedules"] });
-      toast.success("Schedule deleted.", {
-        action: schedule
-          ? {
-              label: "Undo",
-              onClick: () => {
-                void (async () => {
-                  await api.createSchedule({
-                    page_id: schedule.page_id,
-                    start_time: schedule.start_time,
-                    end_time: schedule.end_time ?? null,
-                    day_pattern: schedule.day_pattern,
-                    custom_days: schedule.custom_days,
-                    enabled: schedule.enabled,
-                    start_type: schedule.start_type,
-                    start_sun_offset: schedule.start_sun_offset,
-                    end_type: schedule.end_type,
-                    end_sun_offset: schedule.end_sun_offset,
-                  });
-                  await queryClient.invalidateQueries({ queryKey: ["schedules"] });
-                })();
-              },
-            }
-          : undefined,
-        duration: 8000,
-      });
+      // Undo needs the pre-mutation entry, so read it before the round trip.
+      const previousSchedule =
+        call.op === "update_schedule" || call.op === "delete_schedule"
+          ? schedulesData?.schedules?.find((s) => s.id === call.args.schedule_id)
+          : undefined;
+
+      const result = await api.executeAiOperation(call.op, call.args as unknown as Record<string, unknown>);
+
+      for (const key of queryKeysForOp(call)) {
+        await queryClient.invalidateQueries({ queryKey: [key] });
+      }
+      showServerOpToast(call, result, previousSchedule);
     },
-    [queryClient, schedulesData],
+    [queryClient, schedulesData, showServerOpToast],
   );
 
   // ---------------------------------------------------------------------------
@@ -496,16 +619,13 @@ export function GlobalAiChatDrawer() {
           })();
           break;
 
+        // Schedule ops run immediately (no confirmation card), exactly as
+        // before — only the execution moved from three REST calls in this
+        // file to one POST /ai/operations.
         case "create_schedule":
-          void chainAfter(call, () => handleCreateSchedule(call.args))();
-          break;
-
         case "update_schedule":
-          void chainAfter(call, () => handleUpdateSchedule(call.args))();
-          break;
-
         case "delete_schedule":
-          void chainAfter(call, () => handleDeleteSchedule(call.args))();
+          void chainAfter(call, () => runServerOp(call))();
           break;
 
         case "install_plugin":
@@ -534,158 +654,10 @@ export function GlobalAiChatDrawer() {
       waitForEditor,
       hasScheduleEditor,
       openScheduleForm,
-      handleCreateSchedule,
-      handleUpdateSchedule,
-      handleDeleteSchedule,
+      runServerOp,
       chainAfter,
     ],
   );
-
-  const handleInstallPlugin = useCallback(
-    async (args: InstallPluginArgs) => {
-      await api.installRegistryPlugin(args.plugin_id);
-      if (args.auto_enable !== false) {
-        await api.enablePlugin(args.plugin_id);
-      }
-      if (args.initial_config && Object.keys(args.initial_config).length > 0) {
-        await api.updatePluginConfig(args.plugin_id, args.initial_config);
-      }
-      await queryClient.invalidateQueries({ queryKey: ["plugins"] });
-      toast.success(`Plugin "${args.plugin_id}" installed successfully.`);
-    },
-    [queryClient],
-  );
-
-  const handleUpdatePluginConfig = useCallback(
-    async (args: UpdatePluginConfigArgs) => {
-      await api.updatePluginConfig(args.plugin_id, args.config);
-      await queryClient.invalidateQueries({ queryKey: ["plugins"] });
-      toast.success(`Plugin "${args.plugin_id}" configuration updated.`);
-    },
-    [queryClient],
-  );
-
-  const handleUpdatePlugin = useCallback(
-    async (args: UpdatePluginArgs) => {
-      await api.updatePlugin(args.plugin_id);
-      await queryClient.invalidateQueries({ queryKey: ["plugins"] });
-      toast.success(`Plugin "${args.plugin_id}" updated successfully.`);
-    },
-    [queryClient],
-  );
-
-  const handleEnablePlugin = useCallback(
-    async (args: EnablePluginArgs) => {
-      await api.enablePlugin(args.plugin_id);
-      await queryClient.invalidateQueries({ queryKey: ["plugins"] });
-      toast.success(`Plugin "${args.plugin_id}" enabled.`);
-    },
-    [queryClient],
-  );
-
-  const handleDisablePlugin = useCallback(
-    async (args: DisablePluginArgs) => {
-      await api.disablePlugin(args.plugin_id);
-      await queryClient.invalidateQueries({ queryKey: ["plugins"] });
-      toast.success(`Plugin "${args.plugin_id}" disabled.`);
-    },
-    [queryClient],
-  );
-
-  const handleUninstallPlugin = useCallback(
-    async (args: UninstallPluginArgs) => {
-      await api.uninstallPlugin(args.plugin_id);
-      await queryClient.invalidateQueries({ queryKey: ["plugins"] });
-      toast.success(`Plugin "${args.plugin_id}" uninstalled.`);
-    },
-    [queryClient],
-  );
-
-  const handleUpdateSetting = useCallback(
-    async (args: UpdateSettingArgs) => {
-      switch (args.category) {
-        case "display":
-          await api.updateDisplaySettings(args.values as Parameters<typeof api.updateDisplaySettings>[0]);
-          await queryClient.invalidateQueries({ queryKey: ["display-settings"] });
-          break;
-        case "transitions":
-          await api.updateTransitionSettings(args.values as Parameters<typeof api.updateTransitionSettings>[0]);
-          await queryClient.invalidateQueries({ queryKey: ["transition-settings"] });
-          break;
-        case "output": {
-          const target = (args.values as { target?: string }).target;
-          if (target === "ui" || target === "board" || target === "both") {
-            await api.updateOutputSettings(target);
-            await queryClient.invalidateQueries({ queryKey: ["output-settings"] });
-          }
-          break;
-        }
-        case "polling": {
-          const interval = (args.values as { interval_seconds?: number }).interval_seconds;
-          if (typeof interval === "number") {
-            // PUT /settings/polling takes an object of settings keys; passing
-            // the bare number serialized the body as `5` and the endpoint
-            // rejected it (issue #1586).
-            await api.updatePollingSettings({ interval_seconds: interval });
-            await queryClient.invalidateQueries({ queryKey: ["polling-settings"] });
-          }
-          break;
-        }
-        case "location":
-          await api.updateLocationSettings(args.values as Parameters<typeof api.updateLocationSettings>[0]);
-          await queryClient.invalidateQueries({ queryKey: ["location-settings"] });
-          break;
-        case "silence_schedule":
-          await api.updateSilenceSchedule(args.values as Parameters<typeof api.updateSilenceSchedule>[0]);
-          await queryClient.invalidateQueries({ queryKey: ["silence-schedule"] });
-          break;
-        case "active_page": {
-          const pageId = (args.values as { page_id?: string }).page_id ?? null;
-          await api.setActivePage(pageId);
-          await queryClient.invalidateQueries({ queryKey: ["active-page"] });
-          break;
-        }
-      }
-      toast.success("Setting updated.");
-    },
-    [queryClient],
-  );
-
-  const handleCreateCollection = useCallback(
-    async (args: CreateCollectionArgs) => {
-      await api.createCollection({
-        name: args.name,
-        page_ids: args.page_ids,
-        selection_mode: "time",
-        time: { interval_seconds: args.interval_seconds },
-      });
-      await queryClient.invalidateQueries({ queryKey: ["collections"] });
-      toast.success(`Collection "${args.name}" created.`);
-    },
-    [queryClient],
-  );
-
-  const handleUpdateCollection = useCallback(
-    async (args: UpdateCollectionArgs) => {
-      const { collection_id, ...update } = args;
-      await api.updateCollection(collection_id, {
-        ...(update.name != null && { name: update.name }),
-        ...(update.page_ids != null && { page_ids: update.page_ids }),
-        ...(update.interval_seconds != null && {
-          selection_mode: "time",
-          time: { interval_seconds: update.interval_seconds },
-        }),
-      });
-      await queryClient.invalidateQueries({ queryKey: ["collections"] });
-      toast.success("Collection updated.");
-    },
-    [queryClient],
-  );
-
-  const handleTriggerSystemUpdate = useCallback(async () => {
-    await api.applyUpdate();
-    toast.success("System update started. The board will restart shortly.");
-  }, []);
 
   const renderToolCallSupplement = useCallback(
     (call: ToolCall) => {
@@ -698,125 +670,27 @@ export function GlobalAiChatDrawer() {
 
       const autoAllow = chainingMode === "autonomous" && !isDestructive;
 
-      if (call.op === "install_plugin") {
-        return (
-          <AiActionConfirmation
-            call={call}
-            onAllow={chainAfter(call, () => handleInstallPlugin(call.args as InstallPluginArgs))}
-            onDeny={() => {}}
-            autoAllow={autoAllow}
-          />
-        );
-      }
-      if (call.op === "update_plugin_config") {
-        return (
-          <AiActionConfirmation
-            call={call}
-            onAllow={chainAfter(call, () => handleUpdatePluginConfig(call.args as UpdatePluginConfigArgs))}
-            onDeny={() => {}}
-            autoAllow={autoAllow}
-          />
-        );
-      }
-      if (call.op === "update_plugin") {
-        return (
-          <AiActionConfirmation
-            call={call}
-            onAllow={chainAfter(call, () => handleUpdatePlugin(call.args as UpdatePluginArgs))}
-            onDeny={() => {}}
-            autoAllow={autoAllow}
-          />
-        );
-      }
-      if (call.op === "enable_plugin") {
-        return (
-          <AiActionConfirmation
-            call={call}
-            onAllow={chainAfter(call, () => handleEnablePlugin(call.args as EnablePluginArgs))}
-            onDeny={() => {}}
-            autoAllow={autoAllow}
-          />
-        );
-      }
-      if (call.op === "disable_plugin") {
-        return (
-          <AiActionConfirmation
-            call={call}
-            onAllow={chainAfter(call, () => handleDisablePlugin(call.args as DisablePluginArgs))}
-            onDeny={() => {}}
-            autoAllow={autoAllow}
-          />
-        );
-      }
-      if (call.op === "uninstall_plugin") {
-        return (
-          <AiActionConfirmation
-            call={call}
-            onAllow={chainAfter(call, () => handleUninstallPlugin(call.args as UninstallPluginArgs))}
-            onDeny={() => {}}
-            autoAllow={autoAllow}
-          />
-        );
-      }
-      if (call.op === "update_setting") {
-        return (
-          <AiActionConfirmation
-            call={call}
-            onAllow={chainAfter(call, () => handleUpdateSetting(call.args as UpdateSettingArgs))}
-            onDeny={() => {}}
-            autoAllow={autoAllow}
-          />
-        );
-      }
-      if (call.op === "create_collection") {
-        return (
-          <AiActionConfirmation
-            call={call}
-            onAllow={chainAfter(call, () => handleCreateCollection(call.args as CreateCollectionArgs))}
-            onDeny={() => {}}
-            autoAllow={autoAllow}
-          />
-        );
-      }
-      if (call.op === "update_collection") {
-        return (
-          <AiActionConfirmation
-            call={call}
-            onAllow={chainAfter(call, () => handleUpdateCollection(call.args as UpdateCollectionArgs))}
-            onDeny={() => {}}
-            autoAllow={autoAllow}
-          />
-        );
-      }
+      // Schedule ops are applied immediately from handleToolCall (unchanged
+      // UX) — they have no confirmation card.
       if (call.op === "create_schedule" || call.op === "update_schedule" || call.op === "delete_schedule") {
         return null;
       }
-      if (call.op === "trigger_system_update") {
+
+      if (isServerExecutedCall(call)) {
         return (
           <AiActionConfirmation
             call={call}
-            onAllow={chainAfter(call, () => handleTriggerSystemUpdate())}
+            onAllow={chainAfter(call, () => runServerOp(call))}
             onDeny={() => {}}
-            autoAllow={autoAllow} // always false because isDestructive
+            // Always false for the destructive ops above (uninstall_plugin,
+            // trigger_system_update): autonomous mode never skips those.
+            autoAllow={autoAllow}
           />
         );
       }
       return null;
     },
-    [
-      chainingMode,
-      chainAfter,
-      handleInstallPlugin,
-      handleUpdatePluginConfig,
-      handleUpdatePlugin,
-      handleEnablePlugin,
-      handleDisablePlugin,
-      handleUninstallPlugin,
-      handleUpdateSetting,
-      handleCreateCollection,
-      handleUpdateCollection,
-      handleTriggerSystemUpdate,
-    ],
+    [chainingMode, chainAfter, runServerOp],
   );
 
   const hasProviders = (aiSettings?.providers?.length ?? 0) > 0;

--- a/web/src/lib/api/ai.ts
+++ b/web/src/lib/api/ai.ts
@@ -53,7 +53,45 @@ export interface AIGenerateResult {
   };
 }
 
+/**
+ * The result of one chat operation executed server-side.
+ *
+ * Mirrors `OperationResponse` in `src/ai/routes.py`. `status` is always
+ * `"success"` — a failed operation is an HTTP error, so `fetchApi` throws
+ * an `ApiError` carrying the executor's message and the caller never sees
+ * a sad 200. `result` carries whatever the executor returned beyond the
+ * envelope (`schedule_id`, `plugin_id`, `collection_id`, ...).
+ */
+export interface AiOperationResult {
+  op: string;
+  status: "success";
+  message: string;
+  result: Record<string, unknown>;
+}
+
 export const aiApi = {
+  /**
+   * Execute one chat-grammar tool call on the server.
+   *
+   * The single seam replacing the drawer's former per-op REST dispatcher
+   * (Phase 2 Task 11). The server validates `args` against the same
+   * pydantic schema that validated the SSE `tool_call` frame, then runs
+   * the one canonical executor the MCP tools also use — which is what
+   * stops the two AI surfaces drifting.
+   *
+   * Client-side ops (`apply_patch`, `replace_page`, `suggest_variables`,
+   * `navigate_to_page`, `navigate_to_schedule`, `update_task_list`) are
+   * refused with a 400: they edit the mounted editor or navigate, and are
+   * applied in the browser.
+   */
+  executeAiOperation: (op: string, args: Record<string, unknown>) =>
+    fetchApi<AiOperationResult>("/ai/operations", {
+      method: "POST",
+      body: JSON.stringify({ op, args }),
+      // Plugin installs clone a git repo; the default 30s is too tight.
+      timeoutMs: 120000,
+    }),
+
   // AI page-generation ("Gen AI" button) settings + endpoints. BYO-LLM:
   // users supply their own OpenAI-compatible endpoint and key. The API
   // key is masked on read; sending "***" preserves the stored value.


### PR DESCRIPTION
## What this is

Phase 2, Task 11 — wire the operation layer for real.

`src/ops/` (~1,900 lines) was built at #1764 so "chat and MCP cannot
diverge". MCP called the executors. **Chat did not.** The browser executed
every chat op itself, from a `switch (call.op)` in
`global-ai-chat-drawer.tsx` that hit a different REST endpoint per op. So
`registry.execute()` had **zero production callers on the chat path**, and
the two surfaces could still drift — the exact thing the layer exists to
prevent.

This adds the server-side execution endpoint, routes the browser through
it, and makes the parity suite able to see the browser.

## Ops that moved server-side (13)

`create_schedule`, `update_schedule`, `delete_schedule`,
`create_collection`, `update_collection`, `install_plugin`,
`update_plugin_config`, `update_plugin`, `enable_plugin`,
`disable_plugin`, `uninstall_plugin`, `update_setting`,
`trigger_system_update`.

All now go through one `runServerOp` → `POST /ai/operations` →
`src.ops.registry.execute` → the same executor the MCP tool calls.

## Ops that stayed client-side (6) and why

| Op | Why it stays |
| --- | --- |
| `apply_patch` | Edits the draft in the mounted page editor. No server effect. |
| `replace_page` | **Same** — see the divergence section; it was mis-classified. |
| `suggest_variables` | Renders a suggestion list in the chat thread. |
| `navigate_to_page` | Client routing (and an auto-save before unmount). |
| `navigate_to_schedule` | Client routing / opens the schedule form. |
| `update_task_list` | Drives the task panel; deliberately does not chain. |

The endpoint refuses all six with a 400 naming the op and saying the
browser applies it.

## Divergences found

This task exists to surface these. All three were **live in the shipped
browser** and invisible because nothing on the chat path called the ops
layer.

### 1. `update_schedule` wiped `end_time` on every partial update

`src/ai/chat.py` emits the tool call as `tool.args.model_dump(mode="json")`,
so an `update_schedule` the model wrote *without* `end_time` still arrived
at the browser as `end_time: null`. The drawer forwarded it with an
`"end_time" in update` test — present-and-null passes — so every partial
schedule update silently turned a bounded entry open-ended.

The executor was fixed for exactly this at #1764 (`None` means "unchanged";
`clear_end_time=True` is the explicit escape hatch). Nothing called it.
**The browser was wrong**; routing through the endpoint retires the defect.
Pinned by `test_update_schedule_null_end_time_divergence`, which asserts
both sides.

### 2. `update_plugin_config` replaced the stored config

`PUT /plugins/{id}/config` is the settings *form* endpoint — replace is
correct there, because the form posts every field. A chat op sends only
the keys it is changing. Worse than key loss: when a dropped key was
required, the second write was **rejected 400** and stored nothing —

```
{"detail":{"errors":["station_id is required"]}}
```

`configure_plugin` merges, the semantics #1764 decided on and
`test_mcp_state_effects.py` already pinned for MCP. **The browser was
wrong.**

### 3. `update_collection` destroyed variable-mode rules

`handleUpdateCollection` sent `selection_mode: "time"` alongside any
`interval_seconds`, so "make that collection rotate every 45 seconds"
silently flipped a variable-mode collection back to time mode. The
executor changes only the time config. **The browser was wrong.**

### 4. `replace_page` was mis-mapped in the registry (fixed here)

Not a browser/executor divergence — a registry bug the dead code hid.
#1764 aliased chat `replace_page` onto the `create_page` executor. But
`replace_page` is an **editor** op:

- the system prompt lists it under "PAGE EDITING (use when in the page
  editor context)" and calls it "destructive";
- the global-drawer bias says "do not write template content remotely
  from the global drawer" — navigate to the editor first;
- the failure hint is `emit navigate_to_page with page_id="new" first if
  no editor is mounted`;
- `apply_patch`, which the browser handles through the *identical* code
  path, was already `client_side=True`.

Executing it server-side would create a second page and leave the open
editor untouched. `replace_page` is now a client-side op; `create_page`
keeps its executor for the MCP tool of that name.
`test_parity_replace_page_vs_create_page` "passed" only because both paths
created a page in an empty store; it is replaced by
`test_chat_has_no_server_side_page_creation_spelling` and
`test_parity_create_page_is_mcp_only`.

### Minor narrowings (called out, not regressions)

- `update_setting(output)` with an invalid `target` and
  `update_setting(polling)` with a non-numeric interval used to be silent
  browser-side no-ops **reported to the model as success**. They now
  surface the server's error.
- `update_setting(active_page)` with `page_id: null` used to clear the
  active page. The grammar documents `page_id` as a string; the executor
  now rejects null.

## Proving divergence is now impossible

- `tests/test_op_parity.py` — the `chat()` driver now posts to
  `POST /ai/operations` instead of calling `execute()` in process, so the
  "chat path" it compares against MCP is the one the product ships.
  Unmounting the router fails all 10 parity tests.
- `tests/test_chat_op_http_parity.py` (26 tests) — every server-side op run
  twice against isolated stores, once as the browser's **old REST sequence**
  and once through the endpoint, comparing persisted bytes. The
  browser-sequence half is today's production behavior, so it passed before
  this change and still does; that is the zero-regression evidence.
- `tests/test_ops_wiring.py` (10 tests) — reads the real TSX and fails if a
  non-`client_side` op regains a browser-side executor branch, if
  `SERVER_EXECUTED_OPS` and the registry disagree, or if the endpoint stops
  being the single execution seam.

## Conventions ratchet

`ai` appended to `converted_domains`. Proven load-bearing — dropping
`responses=` and taking a `dict` body:

```
E   AssertionError: Converted domains must take Pydantic request models, not bare dicts
E       POST /ai/operations: body param `request` is annotated `dict` — use a Pydantic model
E   AssertionError: Converted domains must declare the errors they raise
E       POST /ai/operations: declares no 4xx in responses=
```

## Mutation proofs (non-vacuity)

| Mutation | Test that failed |
| --- | --- |
| Endpoint serves the executor's error envelope at 200 | `test_a_failing_executor_is_a_4xx_not_a_200_carrying_an_error` |
| `app.include_router(ai_router)` commented out | all 10 `test_op_parity.py` tests |
| Executors restored to pre-#1764 `end_time` / replace semantics | the 3 divergence tests + `test_update_schedule_applies_the_same_supplied_fields` |
| `api.enablePlugin(...)` re-added to the drawer | `test_no_server_executed_op_has_a_browser_side_rest_implementation` — `Offending calls: ['enablePlugin']` |
| `enable_plugin` dropped from `SERVER_EXECUTED_OPS` | `test_drawer_delegates_exactly_the_registrys_server_side_chat_ops` — `registry only: ['enable_plugin']` |
| `replace_page` alias restored in the registry | 5 tests across `test_ops_registry.py` + `test_op_parity.py` |

## Results

**Python full suite** (`fb-test:latest`, explicit `/app/data` mount):

- before: `1 failed, 5886 passed, 2 skipped`
- after: `1 failed, 5925 passed, 2 skipped` (+39)

The single failure is the known worktree-environmental
`test_check_image_formats.py::TestRepositoryIsClean`, identical before and
after.

**Data-dir leak count: 0** (`.pytest-data` empty after the full run).

**Lint:** `ruff==0.16.5` check + format clean.

**Web** (node:24, `npm ci --legacy-peer-deps`): eslint, prettier, `tsc
--noEmit`, and `146 test files / 1621 tests passed, 7 skipped`. No
Playwright spec touches the drawer or this endpoint, and no existing REST
envelope or status code changed.

## Not closed

- The hand-synced TS grammar mirror (`web/src/lib/ai-chat-types.ts`) is
  still hand-maintained. Task 11's plan line mentions retiring it; it is a
  separate, mechanical change (generate the union from the pydantic
  models) and folding it in here would have doubled the diff. The new
  `test_ops_wiring.py` already fails if the *op set* drifts, which is the
  part that mattered for divergence.
- `update_setting` and `trigger_system_update` are covered by delegation
  (both executors call the same REST handlers the browser called) rather
  than by a state-parity test — they need board/render wiring the parity
  harness does not stand up, the same reason `set_active_page` is
  UNCOVERED in `test_mcp_state_effects.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP
