### PR TITLE
docs(mcp): client migration note for the four wire-visible MCP changes + the supported plugin import surface

### DIFF
--- a/docs/internal/development/PLUGIN_DEVELOPMENT.md
+++ b/docs/internal/development/PLUGIN_DEVELOPMENT.md
@@ -770,6 +770,48 @@ Three rules follow:
   beyond the standard library plus the platform's own dependencies will be
   missing at runtime. Vendor it or do without.
 
+### What a plugin may import from the platform
+
+Self-containment applies to imports as well as to files. The supported
+plugin-facing surface is small and deliberately so — everything else in
+`src/` is platform internals that get renamed, moved, and deleted without
+notice, and without a deprecation window.
+
+| Module | What it gives you |
+|---|---|
+| `src.plugins.base` | `PluginBase`, `TransitionPluginBase`, `PluginResult`, `TriggerResult`, `PluginInfo`, `Option`, `OptionsRequest`, `OptionsResult`, `OptionsUnavailable`, `normalise` |
+| `src.plugins.testing` | `PluginTestCase`, `create_mock_response`, and the other test helpers — tests only |
+| `src.plugins.manifest` | Manifest validation helpers (`validate_manifest`, `validate_settings_schema_ui`, `collect_options_ids`) |
+| `src.board_chars` | `BoardChars` — the character-code table |
+| `src.triggers` | `TriggerPriority` |
+| `src.config` | `Config`, for the handful of global settings a plugin legitimately reads (e.g. `Config.GENERAL_TIMEZONE`) |
+| `src.devices` | `BoardContext` — the board shape passed to `self.board` |
+
+Anything not in that table — `src.utils.*`, `src.formatters.*`,
+`src.api_server`, `src.templates.*`, `src.pages.*`, the service singletons —
+is **not** a plugin API. Importing it works right up until it doesn't.
+
+**This includes your tests.** A plugin extracted out of the FiestaBoard repo
+usually leaves its data-source logic behind in `src/utils/`, and its tests
+keep importing the platform copy instead of the code the plugin actually
+ships. That is a suite testing a module its own users never load, and it
+breaks the day the platform deletes the leftover. The Phase 2 config cleanup
+removed `src/utils/{air_fog,muni,star_trek_quotes,surf,weather}.py`,
+`MessageFormatter.format_muni`, and the `get_*_source()` factories in
+`src/utils/{baywheels,traffic,stocks}.py`, and six plugin repos' suites went
+red on the import — every one of them in `tests/`, none in production code
+(see [#1879](https://github.com/Fiestaboard/FiestaBoard/issues/1879)).
+
+Two rules follow:
+
+- **Test the code you ship.** Import and patch `plugins.<your_id>`, not the
+  platform module your logic used to live in. `@patch('src.utils.surf.requests.get')`
+  should be `@patch('plugins.surf.requests.get')`.
+- **Pin the platform in CI.** A plugin repo's workflow checks out
+  `Fiestaboard/FiestaBoard` with no `ref:`, so it floats on the platform's
+  default branch and breaks the moment a platform PR merges, with no signal
+  beforehand. Pin a `ref:` to a released tag and bump it on purpose.
+
 ### How this is enforced
 
 | when | what happens |

--- a/docs/internal/setup/MCP_CLIENTS.md
+++ b/docs/internal/setup/MCP_CLIENTS.md
@@ -194,6 +194,117 @@ HTTPS reverse proxy *and* implementing an OAuth authorization server.
 That's well out of scope for a home LED display. **Use Claude Desktop
 or Claude Code instead.**
 
+## Upgrading an existing MCP client
+
+The MCP server's wire contract changed in this release. Client *config* is
+unaffected — same transport, same URL, same bearer token — so Claude Desktop
+and Claude Code keep working with no edit. If you wrote your own client, or
+you script against `/api/mcp/` directly, four behaviors are different.
+
+### 1. Tool failures now set the protocol `isError` flag
+
+Every failure used to be a *successful* `CallToolResult` whose payload
+happened to say `{"status": "error", ...}`. A client that treated any
+non-exception result as success never noticed a failure at all.
+
+Now every tool registers through one wrapper, so any executor error envelope
+or unexpected exception comes back as `isError: true`. Check that flag first.
+
+Two things deliberately stay ordinary results:
+
+- **Success** still carries `structuredContent` and `isError: false`.
+- **Policy blocks** — a send suppressed by silence mode or pause — are
+  `isError: false` with `structuredContent.status == "blocked"`. They are
+  policy for the model to relay, not failures. Do not treat them as errors.
+
+### 2. `structuredContent` is absent on the failure path
+
+The old error result carried the machine-readable envelope:
+
+```json
+{
+  "content": [
+    {"type": "text", "text": "{\n  \"status\": \"error\",\n  \"error\": \"Page 'missing' not found.\"\n}"}
+  ],
+  "isError": false,
+  "structuredContent": {"status": "error", "error": "Page 'missing' not found."}
+}
+```
+
+The new one carries text only:
+
+```json
+{
+  "content": [
+    {"type": "text", "text": "Error executing tool get_page: Page 'missing' not found."}
+  ],
+  "isError": true
+}
+```
+
+Anything reading `structuredContent` on the error path now gets nothing.
+
+**No information was lost, only relocated.** The text after the
+`Error executing tool <name>:` prefix (and the space after it) is the same
+string the old `structuredContent.error` field held — the executors' error envelopes are
+still the source, they are just raised as a protocol error at the MCP
+boundary rather than returned as a payload. Read `isError`, then
+`content[0].text`, and strip the prefix if you were parsing the old field.
+
+Unexpected exceptions are no longer stringified onto the wire. They are
+logged server-side with their traceback and reduced to:
+
+```text
+<tool> failed unexpectedly (<ExceptionClass>); details are in the server log.
+```
+
+That is intentional — raw exception text routinely carried filesystem paths
+and config values. Look in the container log for the detail.
+
+### 3. `list_registry_plugins` is paginated
+
+It used to return a top-level JSON array of every registry entry. It now
+returns an object:
+
+```json
+{"plugins": [], "total": 54, "page": 1, "page_size": 20, "total_pages": 3}
+```
+
+(`plugins` elided — it holds the 20 entries of this page.)
+
+A client iterating the old array breaks outright; one that ignores pagination
+silently sees a fraction of the marketplace. Pass `page` (1-based) and
+`page_size` (1-100, default 20) and walk to `total_pages`. Out-of-range
+values are errors, not clamps.
+
+### 4. `teaser` and `previews` are omitted by default
+
+Every registry entry carries `teaser` and `previews` — literal split-flap
+board rows used to show what a plugin looks like on a board. They dominate
+the payload, so the default projection drops them. Measured against the
+54-entry registry: the old full-list response serializes to ~38 KB, the new
+default page to ~7.7 KB, a ~80% cut.
+
+A client that rendered board previews straight from this response goes blank
+until it opts back in, by naming the fields it wants:
+
+```json
+{
+  "name": "list_registry_plugins",
+  "arguments": {"page": 1, "fields": ["name", "teaser", "previews"]}
+}
+```
+
+`fields` is an **exact projection, not an additive opt-in**: each entry then
+carries only the fields you name, plus `id`, which is always included. Naming
+a field no entry has is an error that lists the valid ones.
+
+### Also new: five tools
+
+`get_active_page`, `get_board_content`, `preview_saved_page`,
+`send_message`, and `validate_template` were added in the same release.
+Nothing was removed or renamed.
+
 ## Troubleshooting
 
 **"Some MCP servers could not be loaded… skipped: fiestaboard"** — your

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1384,6 +1384,34 @@ class TestProtocolIsError:
         assert "Page 'missing' not found." in text
         assert "Traceback" not in text
 
+    def test_error_result_is_text_only_behind_the_documented_prefix(self, rpc):
+        """Pin the failure-path wire shape documented for MCP clients.
+
+        The pre-#1765 error was ``isError: false`` plus
+        ``structuredContent {"status": "error", "error": ...}``. The new one
+        drops the structured field and carries the executor's own message in
+        ``content[0].text`` behind a fixed prefix, which is what
+        ``docs/internal/setup/MCP_CLIENTS.md`` tells a migrating client to
+        read. Both halves are pinned here so a change in the shape — ours or
+        an mcp SDK upgrade's — fails a test instead of quietly making the
+        migration note wrong.
+        """
+        mock_svc = MagicMock()
+        mock_svc.get_page.return_value = None
+        with patch("src.pages.service.get_page_service", return_value=mock_svc):
+            result = rpc("get_page", {"page_id": "missing"})
+
+        assert result.get("isError") is True, f"error flag not set: {result}"
+        assert "structuredContent" not in result, (
+            f"the error path is documented as text-only; a structured payload reappeared: {result}"
+        )
+        assert [c.get("type") for c in result["content"]] == ["text"], (
+            f"error content is documented as a single text block: {result}"
+        )
+        assert result["content"][0]["text"] == "Error executing tool get_page: Page 'missing' not found.", (
+            f"the documented prefix or the domain message changed: {result}"
+        )
+
     def test_executor_failure_sets_is_error(self, rpc):
         mock_svc = MagicMock()
         mock_svc.update_schedule.return_value = None


### PR DESCRIPTION
Closes #1885. Addresses the platform half of #1879 (per-repo issues filed separately, listed below).

Two documentation findings from the Phase 2 audit, plus one small test.

## Finding 1 — #1885: MCP client migration note

`docs/internal/setup/MCP_CLIENTS.md` gains an **"Upgrading an existing MCP client"** section. Every claim in it was checked against the running server through the real JSON-RPC endpoint (`TestClient` on `/api/mcp/`) before it was written down, not taken from the issue.

### Verified vs. corrected

| Issue claim | Verdict |
|---|---|
| Errors set `isError` | **Confirmed, and stronger.** The issue says "15 of 18 sampled tools". All **33** tools register through the single `_tool` wrapper — none bypasses it — so the flag is uniform, not sampled. |
| `structuredContent` gone on failure; text prefixed `Error executing tool <name>: ` | **Confirmed verbatim.** Observed error result is exactly `{"content": [{"type": "text", "text": "Error executing tool get_page: Page 'missing' not found."}], "isError": true}` — no `structuredContent` key at all. |
| `list_registry_plugins` → `{plugins, total, page, page_size, total_pages}`, 20 of 54 | **Confirmed.** Observed `{"total": 54, "page": 1, "page_size": 20, "total_pages": 3}` with 20 entries. `origin/main` returns a bare `list[...]`. |
| `teaser`/`previews` opt-in via `fields`, −80.6% payload | **Confirmed, with a correction the issue omits.** `fields` is an **exact projection**, not an additive opt-in: an entry then carries *only* the named fields plus `id`. A client that passes `fields=["previews"]` expecting the defaults back loses `name`, `description`, `category`, everything. The note says so. Measured on the 54-entry registry: full list 38,309 B → default page `structuredContent` 7,678 B = **−80.0%**, matching the issue's −80.6% (different serialization). |
| Numeric color range 63–70 vs 63–71 | **Not touched** — already fixed on `phase2/test-quality` (#1901). Nothing here contradicts it. |

Also documented, found while verifying: five tools were **added** in the same release (`get_active_page`, `get_board_content`, `preview_saved_page`, `send_message`, `validate_template`); none removed or renamed. And two things deliberately stay ordinary non-error results: successes (which keep `structuredContent`) and **policy blocks** — a send suppressed by silence mode or pause comes back `isError: false` with `structuredContent.status == "blocked"`, because a block is policy for the model to relay, not a failure. A migrating client that starts treating every non-success as an error would get that wrong.

### On the issue's suggestion to restore a structured error payload

**Not doing it**, deliberately.

1. **Nothing machine-readable was lost.** The pre-#1765 envelope was `{"status": "error", "error": "<string>"}` and nothing else — `src/ops/results.py::err()` has no codes, no field paths, no retryability hints. The new `content[0].text` is that same string behind a constant prefix. Restoring the field would re-add a duplicate of text already on the wire.
2. **The SDK has no structured-error channel.** `mcp.server.mcpserver.exceptions.ToolError` carries a message and nothing else; `Tool.run` converts it to `CallToolResult(isError=True)`. Emitting `isError: true` *with* `structuredContent` means bypassing the raise path in all 33 tools and hand-building results — reimplementing per-tool exactly what #1765 centralised, and reopening the bug class it closed (a second return path that can silently forget the flag).
3. **`isError` + text is the spec's tool-failure convention.** `structuredContent` is defined as the tool's structured *output*; overloading it as an error channel is what the old code did, and it is why failures were invisible.

Revisit if the executors ever grow real error *codes* — then there is something to carry that text cannot.

Instead, the shape is **pinned by a test** (commit 1) so the note cannot go stale silently. The error text is produced by the mcp SDK's framework layer, not our code, so an SDK upgrade could rewrite the prefix; the test fails first.

**Fail-first evidence** — restoring the pre-#1765 behaviour (`get_page` returning the envelope, `_raise_error_envelope` passing it through instead of raising):

```
FAILED tests/test_mcp_server.py::TestProtocolIsError::test_error_result_is_text_only_behind_the_documented_prefix
E   AssertionError: error flag not set: {'content': [{'text': '{\n  "status": "error",\n  "error": "Page \'missing\' not found."\n}', 'type': 'text'}], 'isError': False, 'structuredContent': {'status': 'error', 'error': "Page 'missing' not found."}}
E   assert False is True
```

That failure output is also the *old* wire shape verbatim, so it doubles as the evidence for the "before" example in the note. (Two weaker sabotages passed and are worth recording: breaking only `_raise_error_envelope`, or only `get_page`'s `raise ToolError`, both still produce `isError: true` — the wrapper and the tool body converge on the same result. Only reverting both reproduces the old behaviour.)

**No production code changed in this PR.**

## Finding 2 — #1879: sibling plugin repos

Swept **all 52** `fiestaboard-plugin--*` repos, production code and tests.

- **Six suites break, not four.** #1879 lists muni, star-trek-quotes, surf, air-fog. Also broken: **`lyft-bike-share`** (`get_baywheels_source` and the `src.utils.baywheels.Config` patch target both removed, though the module survives) and **`traffic`** (`get_traffic_source` and `src.utils.traffic.Config`, same shape).
- **`stocks` is fine** despite looking at-risk — `StocksSource`, `TIME_WINDOW_MAP`, `POPULAR_STOCKS`, and the `yf` import all survive. **`weather`** is fine too: it never imported `src.utils.weather`.
- **100% of the breakage is in `tests/`.** Every plugin's production code imports only `src.plugins.base`, `src.plugins.testing`, `src.plugins.manifest`, `src.board_chars`, `src.config`, `src.triggers`, `src.devices`, and `src.utils.transit_cache` — all of which survive.
- **No `ref:` pin anywhere.** 51/52 workflows check out `Fiestaboard/FiestaBoard` with no `ref:`, so they float on the platform's default branch (`generative-ai-art` has no CI at all). All six go red simultaneously the moment this stack merges to `main`, with no signal beforehand. The failure is a collection-time `ImportError`, so the whole file dies and `--cov-fail-under=70` fails too.

**Which way the fix goes:** these repos were reaching into platform internals. `src/utils/*` and `src/formatters/*` appear in no documentation and were never a plugin API — they are pre-extraction leftovers. When each plugin moved out of this repo, its tests moved with it but kept importing the platform copy of logic the plugin itself now ships. Those suites test a module their own users never load. The deletions are legitimate cleanup of dead platform code, so **no shim is owed** — but the missing written contract is on the platform, and that is fixed here.

`docs/internal/development/PLUGIN_DEVELOPMENT.md` gains **"What a plugin may import from the platform"** under the self-containment section: a table of the supported modules, the rule to patch `plugins.<id>` rather than `src.utils.<id>`, and the recommendation to pin a `ref:` in plugin CI.

**Nothing was pushed to any sibling repo.** Tracking issues filed (see below).

## Verification

- `tests/test_mcp_server.py` + `test_mcp_state_effects.py` + `test_mcp_plugin_tools_decoupled.py` + `test_mcp_prompts_and_resources.py`: **212 passed**, data-dir leak count **0**.
- `ruff==0.16.5 check` + `format --check` over `src tests`: clean (310 files).
- `docs:lint:frontmatter` / `:contract` / `:markdown` / `:spell`: 63 pages, 100 markdown files, **0 issues** (two fixed en route: an MD038 code-span space and two British spellings).
- lychee over `docs/internal/**/*.md` with `lychee.toml`: **48 OK, 0 errors**.

<!-- claude-changelog -->
⚙️ MCP clients get a migration note for this release's wire changes — failures now set `isError`, the plugin registry is paginated, and board previews are opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP
