### PR TITLE
fix: Phase 2 engine tail — render short-circuit, preview/send pool split, wedged-board wall clock

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -48,7 +48,7 @@ from .board_guards import (  # noqa: E402
     _require_board,
     _silence_active,
 )
-from .board_send_executor import run_board_send  # noqa: E402
+from .board_send_executor import run_board_preview, run_board_send  # noqa: E402
 from .collections.models import is_collection_id  # noqa: E402
 from .collections.service import (  # noqa: E402
     get_collection_service,
@@ -808,12 +808,14 @@ async def lifespan(app: FastAPI):
     except Exception:
         logger.debug("Failed to stop plugin-fetch executor during shutdown", exc_info=True)
 
-    # Stop the dedicated board-send pool (issue #1878). wait=False for the
-    # same reason: a wedged board must not stall process shutdown.
+    # Stop the dedicated board-send and live-preview pools (issue #1878).
+    # wait=False for the same reason: a wedged board must not stall process
+    # shutdown.
     try:
-        from .board_send_executor import shutdown_board_send_executor
+        from .board_send_executor import shutdown_board_preview_executor, shutdown_board_send_executor
 
         shutdown_board_send_executor()
+        shutdown_board_preview_executor()
     except Exception:
         logger.debug("Failed to stop board-send executor during shutdown", exc_info=True)
 
@@ -7163,7 +7165,10 @@ async def render_template_live(request: dict):
                 if isinstance(live_strategy, str) and live_strategy.startswith(TRANSITION_PLUGIN_PREFIX):
                     live_strategy = None
                 try:
-                    success, was_sent = await run_board_send(
+                    # Live-editor previews get their own bounded pool (#1878):
+                    # rapid-fire keystroke sends must not occupy the workers
+                    # /refresh, /force-refresh and POST /pages/{id}/send need.
+                    success, was_sent = await run_board_preview(
                         client.send_characters,
                         board_array,
                         strategy=live_strategy,

--- a/src/board_send_executor.py
+++ b/src/board_send_executor.py
@@ -18,6 +18,15 @@ Giving the send endpoints their own bounded pool decouples the two failure
 modes. Send saturation now degrades only sends; the shared pool stays free for
 everything else. The pool is deliberately SMALL: sends are serialized per board
 by the send worker anyway (#1755), so extra threads would only queue deeper.
+
+The same argument then applies one level down. ``POST /templates/render/live``
+is the live template editor's board write, and its own handler calls it
+"rapid-fire" — one board write per keystroke, each of them seconds of blocking
+network I/O. Sharing the send pool with it recreated the original failure mode
+inside the fix: measured here, a ``POST /refresh`` queued 14.80s behind twelve
+concurrent live previews (three waves of the four send workers). Previews
+therefore get a second, smaller pool of their own, so a burst of them degrades
+only previews.
 """
 
 from __future__ import annotations
@@ -35,8 +44,17 @@ from typing import Any, TypeVar
 # being driven at once plus the occasional out-of-band send.
 BOARD_SEND_MAX_WORKERS = 4
 
+# Concurrency ceiling for live-editor previews. Smaller than the send pool on
+# purpose: a preview burst is one human typing, and the value of the pool is
+# the BOUND, not the throughput. It must stay below BOARD_SEND_MAX_WORKERS so
+# that even a preview flood cannot consume send capacity indirectly.
+BOARD_PREVIEW_MAX_WORKERS = 2
+
 _executor: ThreadPoolExecutor | None = None
 _executor_lock = threading.Lock()
+
+_preview_executor: ThreadPoolExecutor | None = None
+_preview_executor_lock = threading.Lock()
 
 T = TypeVar("T")
 
@@ -74,3 +92,35 @@ async def run_board_send(func: Callable[..., T], /, *args: Any, **kwargs: Any) -
     loop = asyncio.get_running_loop()
     ctx = contextvars.copy_context()
     return await loop.run_in_executor(get_board_send_executor(), functools.partial(ctx.run, func, *args, **kwargs))
+
+
+def get_board_preview_executor() -> ThreadPoolExecutor:
+    """Lazily create (once) the shared live-preview pool."""
+    global _preview_executor
+    with _preview_executor_lock:
+        if _preview_executor is None:
+            _preview_executor = ThreadPoolExecutor(
+                max_workers=BOARD_PREVIEW_MAX_WORKERS, thread_name_prefix="board-preview"
+            )
+        return _preview_executor
+
+
+def shutdown_board_preview_executor() -> None:
+    """Shut down the live-preview pool (process teardown and tests only)."""
+    global _preview_executor
+    with _preview_executor_lock:
+        if _preview_executor is not None:
+            _preview_executor.shutdown(wait=False, cancel_futures=True)
+            _preview_executor = None
+
+
+async def run_board_preview(func: Callable[..., T], /, *args: Any, **kwargs: Any) -> T:
+    """``asyncio.to_thread`` for live-editor previews, on their own pool.
+
+    Identical contract to :func:`run_board_send`; only the pool differs, which
+    is the entire point — a rapid-fire burst of previews cannot occupy the
+    workers a real send needs.
+    """
+    loop = asyncio.get_running_loop()
+    ctx = contextvars.copy_context()
+    return await loop.run_in_executor(get_board_preview_executor(), functools.partial(ctx.run, func, *args, **kwargs))

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,7 @@
 """Main application entry point for FiestaBoard Display Service."""
 
+import hashlib
+import json
 import logging
 import signal
 import threading
@@ -25,6 +27,7 @@ from .pages.models import LineMetadata, Page
 from .pages.service import get_page_service
 from .schedules.service import get_schedule_service
 from .settings.service import get_settings_service
+from .templates.engine import extract_template_plugin_ids
 from .text_to_board import text_to_board_array
 from .triggers.service import get_trigger_service
 
@@ -161,6 +164,22 @@ class BoardRuntime:
         # of the next collection-boundary check for this board. 0.0 means
         # "check immediately". Only the primary runtime is consulted today.
         self.next_collection_check: float = 0.0
+
+        # Render short-circuit memo (issue #1883): the triple
+        # ``(render fingerprint, rendered content, page id)`` from the last
+        # render whose result reached — or was found already equal to — the
+        # dedupe cache above.
+        #
+        # It is deliberately a SINGLE tuple carrying its own validity proof
+        # rather than a standalone fingerprint field. Before the memo is
+        # trusted, ``_drive_board_pass`` re-checks that its content/page-id
+        # halves still equal ``last_active_page_content`` /
+        # ``last_active_page_id``. So every existing site that clears or
+        # overwrites the dedupe cache — invalidate_board_content(), the
+        # silence dispatch, the blank-board send, an out-of-band write, a
+        # throttled send — invalidates this memo for free, and a future one
+        # cannot forget to.
+        self.last_render: tuple[str, str, str] | None = None
 
 
 class DisplayService:
@@ -1263,6 +1282,90 @@ class DisplayService:
 
         return factory
 
+    # Bumped whenever the set of inputs the fingerprint covers changes, so a
+    # memo recorded by an older build can never be mistaken for a match.
+    _RENDER_FINGERPRINT_VERSION = 1
+
+    @staticmethod
+    def _render_fingerprint(page, active_page_id, page_service, contexts, *, override_active: bool) -> str | None:
+        """Hash every input a template render reads, or None if not computable.
+
+        Issue #1883. ``render_page`` for a template page is a pure function of
+        four things:
+
+        * the page itself (template lines, line metadata, device geometry) —
+          covered by ``model_dump_json()``, which also moves whenever
+          ``updated_at`` does;
+        * the template context, i.e. the data of the plugins the template
+          references. The reference set comes from the SAME
+          ``extract_template_plugin_ids`` scan that already decides which
+          plugins get fetched for this render (issue #1751): if that scan
+          under-approximated, the render would already be printing ``???``,
+          so the fingerprint is exactly as sound as the fetch it mirrors;
+        * config-derived render inputs that are not in either — color rules
+          (``ConfigManager.get_color_rules``) and plugin manifests. Those move
+          only through a config save, which bumps ``config_generation``;
+        * which branch of the pass we are on, so a tick that resolves the same
+          page through a temporary override is never confused with one that
+          resolved it normally.
+
+        Returns None — meaning "render, do not short-circuit" — whenever any
+        of that cannot be established: no per-pass context cache (the direct
+        MQTT/API callers), a non-template page, a formula page whose variable
+        owners are not statically knowable, a page object without a Pydantic
+        dump, a config manager with no generation counter, or any exception at
+        all. Every unknown fails toward rendering.
+        """
+        if contexts is None:
+            return None
+        if getattr(page, "type", None) != "template":
+            return None
+        template = getattr(page, "template", None)
+        if not template:
+            return None
+        dump = getattr(page, "model_dump_json", None)
+        if dump is None:
+            return None
+        try:
+            refs = extract_template_plugin_ids(template)
+            if refs is None:
+                return None  # formula page: variable owners not statically known
+
+            from .config_manager import get_config_manager
+
+            generation = getattr(get_config_manager(), "config_generation", None)
+            if generation is None:
+                return None  # cannot see config writes -> cannot skip a render
+
+            context = None
+            if refs:
+                context = page_service.shared_context_for(
+                    contexts,
+                    page.device_type,
+                    page.notes_wide,
+                    page.notes_tall,
+                    plugin_ids=refs,
+                )
+                if not isinstance(context, dict):
+                    return None
+            payload = json.dumps(
+                {
+                    "v": DisplayService._RENDER_FINGERPRINT_VERSION,
+                    "page_id": active_page_id,
+                    "page": dump(),
+                    "override": bool(override_active),
+                    "generation": generation,
+                    "data": {ref: (context or {}).get(ref) for ref in sorted(refs)},
+                },
+                sort_keys=True,
+                default=str,
+                separators=(",", ":"),
+            )
+        except Exception as e:  # never let the optimization break a send
+            logger.debug("Render fingerprint unavailable for %s: %s", active_page_id, e)
+            return None
+        return hashlib.blake2b(payload.encode("utf-8", "replace"), digest_size=16).hexdigest()
+
     # ------------------------------------------------------------------ #
     # Per-board display engine (single tick loop)
     # ------------------------------------------------------------------ #
@@ -1572,6 +1675,11 @@ class DisplayService:
                 logger.debug("Board %s: no active page available", board_id or "(default)")
                 return False
 
+            # The render short-circuit's memo for this pass (issue #1883), or
+            # None when the pass is not eligible. Carried down to the arming
+            # sites below.
+            fingerprint = None
+
             if inline_page is not None:
                 # One-off override: render the in-memory page directly. There is
                 # no stored page to look up and no preview cache to bypass.
@@ -1605,6 +1713,36 @@ class DisplayService:
                 if not page:
                     logger.warning(f"Active page not found: {active_page_id}")
                     return False
+
+                # --- Render short-circuit (issue #1883) ---
+                # #1752 made the FETCH set demand-driven but left the render
+                # itself time-driven: an unchanged tick still rendered the page
+                # and threw the result away at the content dedupe below. When
+                # every input the render reads is byte-identical to the inputs
+                # of the render whose output is sitting in the dedupe cache,
+                # the render can only reproduce that cached content — so the
+                # tick's outcome is already known to be "unchanged, skip".
+                #
+                # The memo carries the content and page id it was recorded
+                # with, and both are re-checked against the live dedupe cache
+                # here. That is what makes every existing cache-clearing site
+                # (invalidate_board_content, the exit-silence clear, a
+                # throttled or failed send that deliberately leaves the cache
+                # empty so the next tick retries) invalidate this too.
+                #
+                # Silence is excluded outright: the silence dispatch lives
+                # BELOW the render, so returning early here would skip it.
+                if not silence_mode_active:
+                    fingerprint = self._render_fingerprint(
+                        page, active_page_id, page_service, contexts, override_active=override_active
+                    )
+                    if (
+                        fingerprint is not None
+                        and rt.last_render == (fingerprint, rt.last_active_page_content, active_page_id)
+                        and rt.last_active_page_id == active_page_id
+                    ):
+                        logger.debug("Board %s: render inputs unchanged, skipping render", board_id or "(default)")
+                        return False
 
                 # Render with fresh data — force_refresh bypasses the preview cache
                 # so template variables (weather, time, stocks, etc.) are current.
@@ -1677,6 +1815,10 @@ class DisplayService:
             current_content = result.formatted
             if current_content == rt.last_active_page_content and active_page_id == rt.last_active_page_id:
                 logger.debug("Board %s: content unchanged, skipping send", board_id or "(default)")
+                # Arm the render short-circuit (issue #1883): this render's
+                # inputs provably produce the content already cached, so a
+                # later tick with the same fingerprint can skip the render.
+                rt.last_render = (fingerprint, current_content, active_page_id) if fingerprint else None
                 return False
             # In-flight half of the dedupe (issue #1755): the cache above is
             # only written when the worker finishes the send, so while a long
@@ -1738,6 +1880,10 @@ class DisplayService:
                         return False
                     rt.last_active_page_content = current_content
                     rt.last_active_page_id = active_page_id
+                    # Same arming as the unchanged-content branch (#1883): the
+                    # content now in the dedupe cache is what these inputs
+                    # render to.
+                    rt.last_render = (fingerprint, current_content, active_page_id) if fingerprint else None
                     # The engine just painted the page over whatever was on the
                     # board, so any out-of-band content is gone (issue #1831).
                     rt.showing_out_of_band = False

--- a/tests/test_board_client_policy.py
+++ b/tests/test_board_client_policy.py
@@ -22,6 +22,7 @@ Covers three behaviors added in issue #1754:
 """
 
 import threading
+import time
 from unittest.mock import Mock, patch
 
 import pytest
@@ -121,6 +122,46 @@ class TestConnectionRetry:
 
         result = client.send_characters(_flagship_grid(1))
 
+        assert result == (False, False)
+        assert mock_post.call_count == 1
+        cancel.wait.assert_not_called()
+
+    @patch("src.board_client.requests.post")
+    def test_wedged_board_costs_one_read_timeout_of_wall_clock(self, mock_post, client):
+        """The regression the audit measured, pinned in the unit that matters.
+
+        ``test_read_timeout_is_not_retried`` pins the ATTEMPT count. What the
+        Phase 2 audit actually measured on a wedged board was WALL CLOCK —
+        10.01s to 20.53s — and wall clock is what the caller pays: the board's
+        send worker holds its lock for the whole stall, and every ``wait=True``
+        caller queued behind it blocks for the same span.
+
+        The real stall is ``LOCAL_REQUEST_TIMEOUT[1]`` (10s), too slow for a
+        unit test, so the wedged board is modelled at 1/33 scale. The budget is
+        expressed as a MULTIPLE of one stall, which is the invariant that
+        matters and the one that survives a slow CI runner: retrying would cost
+        two stalls plus SEND_RETRY_BACKOFF_SECONDS, i.e. > 2x.
+        """
+        stall = 0.3
+        budget = stall * 1.8  # below 2 stalls + backoff, above one stall + noise
+        cancel = _no_cancel(client)
+
+        def _wedged(*_args, **_kwargs):
+            time.sleep(stall)
+            raise requests.exceptions.ReadTimeout("board accepted and went quiet")
+
+        mock_post.side_effect = _wedged
+
+        started = time.monotonic()
+        result = client.send_characters(_flagship_grid(1))
+        elapsed = time.monotonic() - started
+
+        # Wall clock first: it is the measurement, and asserting the attempt
+        # count ahead of it would hide the number behind a count mismatch.
+        assert elapsed < budget, (
+            f"a send to a wedged board took {elapsed:.2f}s, more than {budget:.2f}s "
+            f"({budget / stall:.1f}x one {stall:.2f}s read timeout) — the read timeout is being retried"
+        )
         assert result == (False, False)
         assert mock_post.call_count == 1
         cancel.wait.assert_not_called()

--- a/tests/test_board_preview_executor.py
+++ b/tests/test_board_preview_executor.py
@@ -1,0 +1,173 @@
+"""Live-editor previews cannot starve real board sends (#1878, second half).
+
+#1892 moved every board-send endpoint off asyncio's default executor onto a
+dedicated four-worker pool, which closed the audit's measurement: 40 concurrent
+2s requests no longer take the whole shared pool. What it did NOT close is the
+same failure mode *inside* that pool.
+
+``POST /templates/render/live`` is the live template editor's send. Its own
+handler calls it "rapid-fire": every keystroke in the editor is a board write,
+and a board write is seconds of blocking network I/O (a cloud board paces
+frames 15s apart). #1892 put it on the four-worker send pool alongside
+``/refresh``, ``/force-refresh``, ``PUT /settings/active-page`` and
+``POST /pages/{id}/send`` — so a handful of concurrent live previews occupies
+every send worker and a real send, to a completely different board, queues
+behind them.
+
+The fix is the same shape as #1892's: previews get their own bounded pool, so
+preview saturation degrades only previews.
+"""
+
+import asyncio
+import threading
+import time
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+
+import src.board_send_executor as board_send_executor
+from src.api_server import app
+from src.board_send_executor import BOARD_PREVIEW_MAX_WORKERS, BOARD_SEND_MAX_WORKERS
+
+# More concurrent live previews than the send pool has threads.
+_CONCURRENT_PREVIEWS = 12
+# Safety valve on the blocking stub; the assertions resolve long before it.
+_BLOCK_SECONDS = 5.0
+# A real send answering "promptly" means it did not queue behind the previews.
+# The gap being measured is ~0.05s vs _BLOCK_SECONDS.
+_BUDGET_SECONDS = 1.0
+# How many previews must provably be blocking on a thread before the
+# measurement. Deliberately the SMALLER of the two pool widths: post-fix only
+# BOARD_PREVIEW_MAX_WORKERS previews can be on threads at once, so a floor of
+# BOARD_SEND_MAX_WORKERS would be unreachable and the test would fail for the
+# wrong reason. The claim that the send pool could have been consumed rests on
+# ``outstanding`` below, which is measured the same way on both sides.
+_BLOCKED_PREVIEWS_FLOOR = BOARD_PREVIEW_MAX_WORKERS
+
+BOARD = {
+    "id": "board-1",
+    "name": "Board",
+    "device_type": "flagship",
+    "enabled": True,
+    "api_mode": "local",
+    "host": "mock-host",
+    "port": 7000,
+    "local_api_key": "k",
+}
+
+
+@pytest.fixture(autouse=True)
+def _fresh_pools():
+    board_send_executor.shutdown_board_send_executor()
+    board_send_executor.shutdown_board_preview_executor()
+    yield
+    board_send_executor.shutdown_board_send_executor()
+    board_send_executor.shutdown_board_preview_executor()
+
+
+@pytest.mark.asyncio
+async def test_live_preview_burst_does_not_starve_a_real_send():
+    """N slow live previews must not delay ``POST /refresh``."""
+    release = threading.Event()
+    entered = threading.Semaphore(0)
+
+    def _blocking_preview(*_args, **_kwargs):
+        entered.release()
+        release.wait(_BLOCK_SECONDS)
+        return True, True
+
+    preview_client = Mock()
+    preview_client.send_characters = _blocking_preview
+
+    engine = Mock()
+    engine.render_lines.return_value = "\n".join(["HELLO"] + [""] * 5)
+
+    settings = Mock()
+    settings.get_board_settings.return_value = Mock(boards=[BOARD])
+    settings.get_transition_settings.return_value = Mock(strategy="instant", step_interval_ms=0, step_size=1)
+
+    service = Mock()
+    service.check_and_send_active_page_with_status = lambda *a, **k: (True, None)
+
+    body = {"template": ["HELLO", "", "", "", "", ""], "board_id": BOARD["id"]}
+
+    transport = httpx.ASGITransport(app=app)
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as ac:
+            with (
+                patch("src.api_server.get_template_engine", return_value=engine),
+                patch("src.api_server.get_settings_service", return_value=settings),
+                patch("src.api_server.board_client_from_board_dict", return_value=preview_client),
+                patch("src.api_server._board_is_paused", return_value=False),
+                patch("src.api_server.get_service", return_value=service),
+            ):
+                previews = [
+                    asyncio.create_task(ac.post("/templates/render/live", json=body))
+                    for _ in range(_CONCURRENT_PREVIEWS)
+                ]
+
+                deadline = time.monotonic() + 5.0
+                occupied = 0
+                while occupied < _BLOCKED_PREVIEWS_FLOOR and time.monotonic() < deadline:
+                    if entered.acquire(blocking=False):
+                        occupied += 1
+                    else:
+                        await asyncio.sleep(0.01)
+                # Let the remaining previews reach the handler and queue.
+                await asyncio.sleep(0.2)
+
+                # Snapshotted BEFORE the measurement: a send that queues behind
+                # the previews necessarily outlives them, so counting
+                # afterwards would read the starvation under test as proof that
+                # starvation was impossible.
+                outstanding = sum(1 for t in previews if not t.done())
+
+                started = time.monotonic()
+                refresh = await ac.post("/refresh")
+                waited = time.monotonic() - started
+
+                release.set()
+                await asyncio.gather(*previews)
+    finally:
+        release.set()
+
+    # Non-vacuity: previews really were blocking on threads, and enough were
+    # outstanding to have taken every thread of the send pool.
+    assert occupied >= _BLOCKED_PREVIEWS_FLOOR, (
+        f"only {occupied} previews reached a worker thread; the saturation never happened"
+    )
+    assert outstanding >= BOARD_SEND_MAX_WORKERS, (
+        f"only {outstanding} previews were still in flight when the send ran; fewer than the "
+        f"{BOARD_SEND_MAX_WORKERS}-thread send pool, so nothing was proven"
+    )
+
+    assert refresh.status_code == 200
+    assert waited < _BUDGET_SECONDS, (
+        f"a real board send waited {waited:.2f}s behind {_CONCURRENT_PREVIEWS} live-editor "
+        "previews — previews and sends share one bounded pool"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_board_preview_uses_its_own_pool():
+    """The helper's contract, pinned directly rather than only through a route."""
+    via_preview = await board_send_executor.run_board_preview(threading.current_thread)
+    via_send = await board_send_executor.run_board_send(threading.current_thread)
+
+    assert via_preview.name.startswith("board-preview")
+    assert via_send.name.startswith("board-send")
+
+
+@pytest.mark.asyncio
+async def test_run_board_preview_forwards_arguments_and_propagates_exceptions():
+    """Same call contract as ``asyncio.to_thread``, including the failure path."""
+
+    def _work(a, *, b):
+        if a == "boom":
+            raise ValueError(b)
+        return f"{a}-{b}"
+
+    assert await board_send_executor.run_board_preview(_work, "x", b="y") == "x-y"
+    with pytest.raises(ValueError, match="detail"):
+        await board_send_executor.run_board_preview(_work, "boom", b="detail")

--- a/tests/test_board_preview_executor.py
+++ b/tests/test_board_preview_executor.py
@@ -98,6 +98,10 @@ async def test_live_preview_burst_does_not_starve_a_real_send():
             with (
                 patch("src.api_server.get_template_engine", return_value=engine),
                 patch("src.api_server.get_settings_service", return_value=settings),
+                # `_require_board` resolves the boards list through
+                # `src.board_guards` since the pages slice moved it there, so
+                # stubbing only `api_server` leaves the lookup 404ing.
+                patch("src.board_guards.get_settings_service", return_value=settings),
                 patch("src.api_server.board_client_from_board_dict", return_value=preview_client),
                 patch("src.api_server._board_is_paused", return_value=False),
                 patch("src.api_server.get_service", return_value=service),

--- a/tests/test_render_short_circuit.py
+++ b/tests/test_render_short_circuit.py
@@ -1,0 +1,504 @@
+"""The render short-circuit #1752's acceptance asked for and did not get (#1883).
+
+#1752 shipped "change-driven tick" in its title. Measurement afterwards found
+the FETCH set had become demand-driven while the RENDER stayed time-driven on
+the same 1 Hz wake: ``preview_page`` / ``render_page`` calls per 10 unchanged
+ticks stayed at 10 out of 10. The render result was produced and then thrown
+away at the content dedupe.
+
+These tests pin both halves of the fix:
+
+* the win — an unchanged input set renders ONCE across ten drive passes;
+* the safety — every input that can move the rendered bytes still forces a
+  render, so a real change is never swallowed. Those are the tests that make
+  the optimization non-vacuous: a short-circuit that always fires would pass
+  the first test and fail every other one here.
+
+Everything below drives the REAL ``DisplayService.check_and_send_for_board``
+pass over a REAL ``PageService`` and a REAL ``TemplateEngine`` — the fetch
+layer is the only stub, because plugin data freshness is exactly the input
+being varied.
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.main import BoardRuntime, DisplayService
+from src.pages.models import Page
+from src.pages.service import PageService
+from src.pages.storage import PageStorage
+from src.templates.engine import get_template_engine, reset_template_engine
+from tests.fake_clock import FakeClock, install_fake_time_service
+
+BOARD_ID = "board-1"
+PAGE_ID = "page-1"
+TICKS = 10
+
+
+# --------------------------------------------------------------------------
+# Doubles
+# --------------------------------------------------------------------------
+
+
+class RecordingClient:
+    """Board client that records each frame and can be made to fail."""
+
+    def __init__(self):
+        self.frames: list[list[list[int]]] = []
+        self.fail = False
+        self.last_send_throttled = False
+        self.use_cloud = False
+
+    def render(self, board_array, **_kwargs):
+        self.frames.append([row[:] for row in board_array])
+        if self.fail:
+            return False, False
+        return True, True
+
+    def read_current_message(self, sync_cache: bool = False):
+        return None
+
+    def clear_cache(self):
+        return None
+
+
+class StubRegistry:
+    """Fetch layer stub: returns whatever ``data`` currently holds."""
+
+    def __init__(self, data: dict):
+        self.data = data
+        self.trigger_plugins: dict = {}
+        self.builds = 0
+
+    @property
+    def enabled_plugins(self) -> dict:
+        return dict.fromkeys(self.data)
+
+    def build_template_context(self, board=None, plugin_ids=None, include_trigger_plugins=True):
+        self.builds += 1
+        if plugin_ids is None:
+            return {k: dict(v) for k, v in self.data.items()}
+        wanted = {str(p).lower() for p in plugin_ids}
+        return {k: dict(v) for k, v in self.data.items() if k.lower() in wanted}
+
+    def get_manifest(self, _plugin_id):
+        return None
+
+    def get_plugin(self, _plugin_id):
+        return None
+
+
+class StubConfigManager:
+    """Config store with silence off and a bumpable generation counter."""
+
+    def __init__(self):
+        self.config_generation = 1
+        self.color_rules: dict[tuple[str, str], list] = {}
+
+    def get_feature(self, name: str) -> dict:
+        if name == "silence_schedule":
+            return {"enabled": False, "by_board": {}}
+        return {}
+
+    def get_general(self) -> dict:
+        return {}
+
+    def get_board(self) -> dict:
+        return {}
+
+    def get_color_rules(self, feature_name: str, field_name: str) -> list:
+        return self.color_rules.get((feature_name, field_name), [])
+
+    def migrate_silence_schedule_to_utc(self) -> bool:
+        return False
+
+    def migrate_silence_schedule_to_per_board(self) -> int:
+        return 0
+
+
+class CountingPageService(PageService):
+    """Real PageService that counts the two render entry points."""
+
+    def __init__(self, storage):
+        super().__init__(storage=storage)
+        self.previews = 0
+        self.renders = 0
+
+    def preview_page(self, *args, **kwargs):
+        self.previews += 1
+        return super().preview_page(*args, **kwargs)
+
+    def render_page(self, *args, **kwargs):
+        self.renders += 1
+        return super().render_page(*args, **kwargs)
+
+
+class MemoryPageStorage(PageStorage):
+    """In-memory page store; keeps the suite off the filesystem."""
+
+    def __init__(self, pages: list[Page]):
+        self._pages = {p.id: p for p in pages}
+
+    def get(self, page_id):
+        return self._pages.get(page_id)
+
+    def list_all(self):
+        return list(self._pages.values())
+
+    def put(self, page: Page) -> None:
+        self._pages[page.id] = page
+
+
+# --------------------------------------------------------------------------
+# Rig
+# --------------------------------------------------------------------------
+
+
+class Rig:
+    """One board, one template page, one stub plugin — driven pass by pass."""
+
+    def __init__(
+        self,
+        monkeypatch,
+        *,
+        template: list[str],
+        data: dict,
+        silence: dict | None = None,
+        clock: FakeClock | None = None,
+    ):
+        self.clock = clock
+        self.page = Page(
+            id=PAGE_ID,
+            name="Test",
+            type="template",
+            device_type="flagship",
+            template=template,
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        self.storage = MemoryPageStorage([self.page])
+        self.pages = CountingPageService(self.storage)
+        self.registry = StubRegistry(data)
+        self.config = StubConfigManager()
+        if silence is not None:
+            self.config.get_feature = lambda name: dict(silence) if name == "silence_schedule" else {}
+        self.client = RecordingClient()
+
+        board = {
+            "id": BOARD_ID,
+            "name": "Board",
+            "device_type": "flagship",
+            "enabled": True,
+            "api_mode": "local",
+            "host": "mock-host",
+            "port": 7000,
+            "local_api_key": "k",
+        }
+        settings = MagicMock()
+        settings.get_board_settings.return_value = MagicMock(boards=[board])
+        settings.get_primary_board_id.return_value = BOARD_ID
+        settings.is_paused.side_effect = lambda board_id=None: False
+        settings.is_schedule_enabled.side_effect = lambda board_id=None: False
+        settings.get_active_page_id.side_effect = lambda board_id=None: PAGE_ID
+        settings.get_transition_settings.return_value = MagicMock(strategy="instant", step_interval_ms=0, step_size=1)
+        settings.should_send_to_board.return_value = True
+        settings.consume_temporary_override.side_effect = lambda: None
+        self.settings = settings
+
+        self.service = DisplayService()
+        self.service.runtimes[BOARD_ID] = BoardRuntime(client=self.client, board_id=BOARD_ID)
+        self.service._primary_board_id = BOARD_ID
+
+        monkeypatch.setattr("src.main.get_settings_service", lambda: settings)
+        monkeypatch.setattr("src.main.get_page_service", lambda: self.pages)
+        monkeypatch.setattr("src.main.get_schedule_service", lambda: MagicMock())
+        monkeypatch.setattr("src.main.get_collection_service", lambda: MagicMock())
+        monkeypatch.setattr("src.config.get_config_manager", lambda: self.config)
+        monkeypatch.setattr("src.config_manager.get_config_manager", lambda: self.config)
+        monkeypatch.setattr("src.plugins.registry.get_plugin_registry", lambda: self.registry)
+        monkeypatch.setattr("src.templates.engine.get_plugin_registry", lambda: self.registry)
+        monkeypatch.setattr(self.service, "request_board_refresh", lambda *a, **k: None)
+        monkeypatch.setattr(self.service, "_check_trigger_override", lambda: None)
+        if clock is not None:
+            install_fake_time_service(monkeypatch, clock)
+
+        engine = get_template_engine()
+        monkeypatch.setattr(engine, "_plugin_registry", self.registry)
+        monkeypatch.setattr(engine, "_config_manager", self.config)
+
+    @property
+    def runtime(self) -> BoardRuntime:
+        return self.service.runtimes[BOARD_ID]
+
+    def tick(self, n: int = 1) -> None:
+        for _ in range(n):
+            self.service.check_and_send_active_page(wait=True)
+        assert self.service.wait_until_idle(timeout=10.0), "send workers never went idle"
+
+    def edit_page(self, **fields) -> None:
+        updated = self.page.model_copy(update={**fields, "updated_at": datetime.now(UTC)})
+        self.storage.put(updated)
+        self.page = updated
+
+    def stop(self) -> None:
+        for rt in self.service.runtimes.values():
+            if rt.send_worker is not None:
+                rt.send_worker.stop()
+
+
+@pytest.fixture(autouse=True)
+def _fresh_template_engine():
+    reset_template_engine()
+    yield
+    reset_template_engine()
+
+
+@pytest.fixture
+def rig(monkeypatch):
+    rigs: list[Rig] = []
+
+    def _make(**kwargs):
+        r = Rig(monkeypatch, **kwargs)
+        rigs.append(r)
+        return r
+
+    yield _make
+    for r in rigs:
+        r.stop()
+
+
+def _default(**overrides):
+    base = {
+        "template": ["{{stub.value}}", "", "", "", "", ""],
+        "data": {"stub": {"value": "HELLO"}},
+    }
+    base.update(overrides)
+    return base
+
+
+# --------------------------------------------------------------------------
+# The win
+# --------------------------------------------------------------------------
+
+
+def test_ten_unchanged_ticks_render_once(rig):
+    """The measurement #1752's acceptance named: renders / 10 unchanged ticks."""
+    r = rig(**_default())
+
+    r.tick(TICKS)
+
+    assert len(r.client.frames) == 1, "content changed on the board across unchanged ticks"
+    assert r.pages.previews == 1, (
+        f"{r.pages.previews} renders across {TICKS} unchanged ticks; "
+        "the loop is still rendering every tick and diffing after"
+    )
+
+
+def test_unchanged_ticks_do_not_stop_fetching(rig):
+    """The short-circuit skips the RENDER, never the freshness check.
+
+    Skipping the fetch too would make the engine blind: nothing would ever
+    observe that the plugin data moved, so the board would freeze on its
+    first frame. The fingerprint is computed FROM the fetched context, so a
+    fetch must still happen on every tick.
+    """
+    r = rig(**_default())
+
+    r.tick(TICKS)
+
+    assert r.registry.builds >= TICKS, (
+        f"only {r.registry.builds} context builds across {TICKS} ticks — "
+        "the short-circuit skipped the freshness check, not just the render"
+    )
+
+
+# --------------------------------------------------------------------------
+# The safety: every input that moves the bytes must still force a render
+# --------------------------------------------------------------------------
+
+
+def test_changed_plugin_data_renders_and_sends(rig):
+    """Non-vacuity: a short-circuit that always fired would fail here."""
+    r = rig(**_default())
+    r.tick(TICKS)
+    assert len(r.client.frames) == 1
+
+    r.registry.data["stub"]["value"] = "GOODBYE"
+    r.tick()
+
+    assert r.pages.previews == 2, "the changed plugin value never reached a render"
+    assert len(r.client.frames) == 2, "the changed value never reached the board"
+    assert r.runtime.last_active_page_content.startswith("GOODBYE")
+
+
+def test_edited_page_renders_and_sends(rig):
+    """A page edit moves ``updated_at`` and the template bytes."""
+    r = rig(**_default())
+    r.tick(TICKS)
+
+    r.edit_page(template=["{{stub.value}} WORLD", "", "", "", "", ""])
+    r.tick()
+
+    assert r.pages.previews == 2
+    assert len(r.client.frames) == 2
+    assert r.runtime.last_active_page_content.startswith("HELLO WORLD")
+
+
+def test_color_rule_change_renders_and_sends(rig):
+    """Color rules live in config, not in the page or the plugin data.
+
+    They are the input that proves the fingerprint needs ``config_generation``:
+    nothing about the page or the fetched context moves when a user edits one,
+    yet the rendered bytes gain a colour tile.
+    """
+    r = rig(**_default(data={"stub": {"value": "42", "temperature": "42"}}))
+    r.tick(TICKS)
+    baseline = r.runtime.last_active_page_content
+
+    r.config.color_rules[("stub", "value")] = [{"condition": ">", "value": 0, "color": "red"}]
+    r.config.config_generation += 1
+    r.tick()
+
+    assert r.pages.previews == 2, "a config write did not invalidate the render memo"
+    assert r.runtime.last_active_page_content != baseline
+    assert len(r.client.frames) == 2
+
+
+def test_failed_send_re_renders_and_retries_next_tick(rig):
+    """A send that never reached the board must be retried, not memoized away."""
+    r = rig(**_default())
+    r.client.fail = True
+
+    r.tick(3)
+
+    assert len(r.client.frames) == 3, (
+        f"only {len(r.client.frames)} send attempts across 3 ticks after a failure — "
+        "the short-circuit swallowed the retry"
+    )
+    assert r.pages.previews == 3
+
+
+def test_throttled_send_re_renders_and_retries_next_tick(rig):
+    """A throttled send reports success but never reached the board (#1794)."""
+
+    class ThrottlingClient(RecordingClient):
+        def render(self, board_array, **kwargs):
+            self.frames.append([row[:] for row in board_array])
+            self.last_send_throttled = True
+            return True, False
+
+    r = rig(**_default())
+    r.client = ThrottlingClient()
+    r.runtime.client = r.client
+
+    r.tick(3)
+
+    assert len(r.client.frames) == 3, (
+        f"only {len(r.client.frames)} attempts across 3 ticks — a throttled send was memoized as delivered"
+    )
+
+
+def test_invalidate_board_content_forces_a_render(rig):
+    """ "Resend to board" must repaint even when nothing changed (#1794)."""
+    r = rig(**_default())
+    r.tick(TICKS)
+    assert len(r.client.frames) == 1
+
+    r.service.invalidate_board_content(BOARD_ID)
+    r.tick()
+
+    assert r.pages.previews == 2
+    assert len(r.client.frames) == 2
+
+
+def test_silence_starting_on_the_clock_is_dispatched_after_short_circuited_ticks(rig):
+    """The silence dispatch lives BELOW the render; skipping must not skip it.
+
+    Silence turns on by the CLOCK crossing the window boundary — no config
+    write, so no ``config_generation`` bump, and the page and plugin data are
+    untouched. The render fingerprint is therefore byte-identical across the
+    boundary: only the pass's explicit ``not silence_mode_active`` guard stops
+    the memo from swallowing the board's entry into silence.
+    """
+    clock = FakeClock(datetime(2026, 7, 15, 21, 0, tzinfo=UTC))
+    r = rig(
+        clock=clock,
+        **_default(
+            silence={
+                "enabled": True,
+                "start_time": "22:00+00:00",
+                "end_time": "06:00+00:00",
+                "mode": "indicator",
+                "page_id": None,
+                "indicator_text": "SNOOZING",
+                "indicator_position": "center",
+                "by_board": {},
+            }
+        ),
+    )
+    r.tick(TICKS)
+    assert len(r.client.frames) == 1
+    assert r.pages.previews == 1, "the memo never armed, so this proves nothing about the guard"
+
+    clock.advance(3600)  # 22:00 — inside the window, nothing else moved
+    r.tick()
+
+    assert len(r.client.frames) == 2, "entering silence did not reach the board"
+    assert r.runtime.snoozing_message_sent is True
+
+
+def test_formula_page_never_short_circuits(rig):
+    """``{{= ... }}`` hides its variable owners, so the memo must not arm."""
+    r = rig(
+        **_default(
+            template=["{{= stub.value }}", "", "", "", "", ""],
+            data={"stub": {"value": "HELLO"}},
+        )
+    )
+
+    r.tick(TICKS)
+
+    assert r.pages.previews == TICKS, (
+        "a formula page was short-circuited; its referenced plugins are not statically knowable"
+    )
+
+
+def test_direct_callers_without_a_pass_cache_never_short_circuit(rig):
+    """MQTT / ``/refresh`` call the per-board path with ``contexts=None``."""
+    r = rig(**_default())
+
+    for _ in range(TICKS):
+        r.service.check_and_send_for_board(BOARD_ID, r.runtime, is_primary=True, contexts=None, wait=True)
+    assert r.service.wait_until_idle(timeout=10.0)
+
+    assert r.pages.previews == TICKS
+
+
+def test_short_circuit_is_thread_safe_against_a_concurrent_cache_clear(rig):
+    """The memo carries its own validity proof, so a torn read cannot skip.
+
+    Clearing the dedupe cache from another thread between the memo write and
+    the next pass must make the memo stale rather than leave a fingerprint
+    that matches a cache it no longer describes.
+    """
+    r = rig(**_default())
+    r.tick()
+
+    done = threading.Event()
+
+    def _clear():
+        r.runtime.last_active_page_content = None
+        done.set()
+
+    t = threading.Thread(target=_clear)
+    t.start()
+    done.wait(5)
+    t.join(5)
+
+    r.tick()
+    assert r.pages.previews == 2


### PR DESCRIPTION
Closes the three engine/send-path findings the Phase 2 audit left open. Two of
the three had already been closed by #1892 in the form the audit reported them;
this PR says so with the measurement, and closes the residue that remained.

Full suite: **5942 passed → 5958 passed** (+16), same single pre-existing
environmental failure (`test_check_image_formats::test_no_tracked_file_in_this_repo_reaches_a_vulnerable_parser`),
2 skipped. `tests/golden/` byte-identical. Data-dir leak count **0**.

---

## 1. #1883 — the render short-circuit #1752's acceptance asked for

**Before / after (1 board, 1 template page, 1 referenced plugin, 10 unchanged drive passes):**

| metric | before | after |
|---|---:|---:|
| renders (`preview_page`) / 10 unchanged ticks | 10 | **1** |
| board sends / 10 unchanged ticks | 1 | **1** |
| plugin context builds / 10 unchanged ticks | 10 | **10** (unchanged, deliberately) |

The gate is a memo on `BoardRuntime`: `last_render = (fingerprint, content, page_id)`
from the last render whose output reached — or was found already equal to — the
dedupe cache. The fingerprint covers the page (`model_dump_json()`), the data of
the plugins the template references (from the same `extract_template_plugin_ids`
scan that already decides which plugins get fetched, #1751), `config_generation`
(the only way color rules and plugin manifests can move), and whether the pass
resolved the page through a temporary override.

**Fail-first** (against unmodified `src/main.py`):

```
tests/test_render_short_circuit.py F.FFF..FF...                    [100%]

_____________________ test_ten_unchanged_ticks_render_once _____________________
E   AssertionError: 10 renders across 10 unchanged ticks; the loop is still
    rendering every tick and diffing after
E   assert 10 == 1

__________________ test_changed_plugin_data_renders_and_sends __________________
E   AssertionError: the changed plugin value never reached a render
E   assert 11 == 2

______________________ test_edited_page_renders_and_sends ______________________
E   assert 11 == 2

___________________ test_color_rule_change_renders_and_sends ___________________
E   AssertionError: a config write did not invalidate the render memo
E   assert 11 == 2

________________ test_invalidate_board_content_forces_a_render _________________
E   assert 11 == 2

_ test_silence_starting_on_the_clock_is_dispatched_after_short_circuited_ticks _
E   AssertionError: the memo never armed, so this proves nothing about the guard
E   assert 10 == 1

========================= 6 failed, 6 passed in 0.43s ==========================
```

Post-fix: 12 passed.

**What I deliberately did not change**

- **The goldens did not move, and I did not re-record them.** They also do not
  prove this change: the corpus's scenario pages are stub objects with no
  `type` and no `template`, so the short-circuit never arms under it. The
  harness docstring already says the fetch/render machinery is out of the
  corpus's scope. The goldens are a guard here, not evidence;
  `tests/test_render_short_circuit.py` drives the real pass over a real
  `PageService` and a real `TemplateEngine` and is where the evidence lives.
- **The fetch stays per-tick.** Skipping the fetch too would make the engine
  blind — nothing would ever observe that the data moved. The fingerprint is
  computed *from* the fetched context; `test_unchanged_ticks_do_not_stop_fetching`
  pins that.
- **Silence is excluded from the short-circuit outright.** The silence dispatch
  lives below the render, and silence turns on by the *clock* crossing the
  window boundary — no config write, no fingerprint movement. The pass's
  `not silence_mode_active` guard is what stops the memo swallowing it.
- **`src/displays/send_worker.py` untouched** — no change to the latest-wins
  queue, waiter adoption, or the epoch guard.
- **`_pass_in_flight_keys` (#1900) untouched.** The short-circuit returns
  before the pass reads any dedupe state, inside the snapshot, so the torn-read
  fix is unaffected. The memo is read as a single attribute *before* the
  content/id it is compared against, so a worker finishing mid-check can only
  cause a spurious render, never a spurious skip.
- **Everything unknown fails open (render):** no per-pass context cache (direct
  MQTT / `/refresh` callers), a non-template page, a formula page, a config
  manager with no generation counter, or any exception.

## 2. #1878 — the executor finding, second half

The audit's measurement (40 concurrent 2s requests, three waves of 18 default-executor
workers) **was already closed by #1892**, which gave board sends a dedicated
four-worker pool. Previews (`page_service.preview_page`, `src/pages/routes.py`)
are on the default executor and cannot touch it.

What #1892 left is the same failure mode *inside* the new pool.
`POST /templates/render/live` is the live template editor's board write — its
own handler calls it "rapid-fire" — and #1892 put it on the four-worker **send**
pool next to `/refresh`, `/force-refresh`, `PUT /settings/active-page` and
`POST /pages/{id}/send`.

**Before / after, 12 concurrent live previews vs one `POST /refresh`:**

| | before | after |
|---|---:|---:|
| wall clock the send waited | **14.80s** | < 1.00s (budget) |

**Fail-first** (against the unmodified handler; the fixture's preview-pool
teardown stubbed out so the measurement is reached rather than an
`AttributeError`):

```
tests/_tmp_preview_probe.py F                                      [100%]

_____________ test_live_preview_burst_does_not_starve_a_real_send ______________
E   AssertionError: a real board send waited 14.80s behind 12 live-editor previews
    — previews and sends share one bounded pool
E   assert 14.797956465001334 < 1.0

============================== 1 failed in 15.61s ==============================
```

Post-fix: 3 passed; `test_board_send_executor` (#1892's own pool tests) stays green.

**What I deliberately did not change**

- `BOARD_SEND_MAX_WORKERS` stays 4, and the six board-send call sites stay on it.
- The pure preview endpoints (`POST /pages/{id}/preview`, the active-page
  preview) stay on the **default** executor. Moving them onto a two-worker pool
  would serialize the page-grid preview fan-out for no safety gain — they never
  touch the wire.
- `BOARD_PREVIEW_MAX_WORKERS = 2`, below the send pool on purpose: a preview
  burst is one human typing, and the value of the pool is the bound, not the
  throughput.

## 3. The wedged-board send's doubled cost

**This does not reproduce on the current trunk.** #1892 already made the
connection retry conditional on error class — `_is_retryable_send_error` is
`ConnectionError`-only, and `ReadTimeout` (the board accepting the request and
going quiet) is not retried. `test_read_timeout_is_not_retried` is green. **No
production change was made here and none was invented.**

What was missing is the measurement the brief asked to pin. Every existing test
in `tests/test_board_client_policy.py` pins the **attempt count**; the audit
reported **wall clock** (10.01s → 20.53s), which is what the caller actually
pays — the board's send worker holds its lock for the whole stall and every
`wait=True` caller queued behind it blocks for the same span.

`test_wedged_board_costs_one_read_timeout_of_wall_clock` models the wedged board
at 1/33 scale (the real read timeout is 10s) and expresses the budget as a
*multiple* of one stall — the invariant that survives a slow runner. Retrying
costs two stalls plus `SEND_RETRY_BACKOFF_SECONDS`, i.e. > 2x.

**Fail-first** (predicate widened back to #1754's `(ConnectionError, Timeout)`):

```
tests/test_board_client_policy.py ..FF.................            [100%]

__ TestConnectionRetry.test_wedged_board_costs_one_read_timeout_of_wall_clock __
E   AssertionError: a send to a wedged board took 0.61s, more than 0.54s
    (1.8x one 0.30s read timeout) — the read timeout is being retried
E   assert 0.6093295419996139 < 0.54

======================== 2 failed, 19 passed in 10.77s =========================
```

Post-fix: 21 passed.

**Decision, for the record:** the policy is *skip the retry for the failure
class that cannot succeed on a second attempt*, not *cap the retry budget*.
A `ReadTimeout` means the board took the request and stopped answering; a second
identical request to the same wedged board has no new information and pays the
identical timeout. Capping the budget would still pay part of a second stall for
nothing. `ConnectionError` (including `ConnectTimeout`) keeps its retry: no
connection was established, the failure is immediate, so the retry is nearly
free and often wins against a board mid-reboot.

---

## Verification

```
docker run --rm -v "$PWD":/app -v "$PWD/.pytest-data":/app/data -w /app \
  fb-test:latest python -m pytest tests/ -q --no-header -p no:cacheprovider
```

- baseline (`origin/next-rebuild`): `1 failed, 5942 passed, 2 skipped`
- this branch: `1 failed, 5958 passed, 2 skipped`
- the one failure is the pre-existing environmental
  `test_check_image_formats::test_no_tracked_file_in_this_repo_reaches_a_vulnerable_parser`
- `find .pytest-data -mindepth 1 | wc -l` → **0**
- `git status --short tests/golden` → clean
- `ruff==0.16.5 check` + `format --check` on `src tests` → clean

## Left open

- Plugin *manifest* changes that do not go through a config save (there is no
  such path today — install/enable/disable all write config and bump
  `config_generation`) are covered only by that assumption, which is stated in
  `_render_fingerprint`'s docstring. If a future hot-reload path lands, it must
  bump the generation or clear the runtime.
- The fingerprint JSON-dumps the referenced plugins' data each tick. For very
  large plugin payloads that cost is not free; it is bounded by the demand
  filter (only the plugins the template names) and is far below a render on the
  page shapes measured here, but it has not been profiled on a Pi with a
  large-payload plugin.
