### PR TITLE
fix(auth): gate provisioning while a stored MCP token exists (#1880)

### DIFF
--- a/src/auth/routes.py
+++ b/src/auth/routes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import secrets
 import time
 
 from fastapi import APIRouter, HTTPException, Request, Response, status
@@ -181,6 +182,51 @@ def _clear_failures(ip: str) -> None:
     _FAILED_ATTEMPTS.pop(ip, None)
 
 
+# --- Stored-MCP-token possession gate --------------------------------------
+
+
+def _bearer_token(request: Request) -> str | None:
+    """Return the token from an ``Authorization: Bearer <token>`` header, else None."""
+    header = request.headers.get("authorization", "")
+    scheme, _, value = header.partition(" ")
+    if scheme.lower() == "bearer" and value.strip():
+        return value.strip()
+    return None
+
+
+def _guard_stored_mcp_token(request: Request, svc) -> None:
+    """Refuse to adopt an unclaimed install while a stored MCP token exists.
+
+    On a login-disabled install, provisioning the first admin
+    (``POST /auth/setup``) or flipping the preference back on
+    (``POST /auth/preference {"enabled": true}``) both hand the caller a
+    session that can rotate or revoke the stored MCP token — hijacking a
+    credential the operator deliberately configured. Two unauthenticated
+    requests from anyone who can reach the port would otherwise be enough.
+
+    When a stored token is present, require the caller to prove possession of
+    it (``Authorization: Bearer <token>``) before either provisioning path
+    succeeds, so the stored token also guards the takeover path. Installs with
+    no stored token — the common first-run case — are unaffected.
+
+    An env-pinned token (``FIESTABOARD_MCP_TOKEN``) is *not* a stored token:
+    it cannot be rotated or revoked from the UI (those endpoints 409), so
+    there is nothing to hijack and it is not gated here.
+    """
+    stored = svc.get_stored_mcp_token()
+    if stored is None:
+        return
+    supplied = _bearer_token(request)
+    if not supplied or not secrets.compare_digest(stored, supplied):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "This install has a stored MCP token. Present it as a Bearer "
+                "token to enable login, or clear the token first."
+            ),
+        )
+
+
 # --- Endpoints -------------------------------------------------------------
 
 
@@ -207,7 +253,7 @@ async def auth_status(request: Request) -> StatusResponse:
 
 
 @router.post("/preference", response_model=SimpleResponse)
-async def auth_preference(payload: PreferenceRequest) -> SimpleResponse:
+async def auth_preference(payload: PreferenceRequest, request: Request) -> SimpleResponse:
     """Record the admin's first-run auth on/off choice.
 
     Only valid when:
@@ -216,6 +262,10 @@ async def auth_preference(payload: PreferenceRequest) -> SimpleResponse:
     * No user has been provisioned yet — once an account exists the
       decision is "enabled" and disabling must go through a future
       password-gated endpoint to avoid drive-by lockouts.
+
+    Enabling is additionally gated by possession of any stored MCP token —
+    see :func:`_guard_stored_mcp_token` — so a drive-by can't flip the
+    install on and then hijack that token.
     """
     env_raw = _auth_env_override()
     if env_raw is not None:
@@ -229,6 +279,10 @@ async def auth_preference(payload: PreferenceRequest) -> SimpleResponse:
             status_code=status.HTTP_409_CONFLICT,
             detail=("A user already exists. Sign in and use the account settings to change preferences."),
         )
+    # Only the enable direction opens the install up; disabling can't be a
+    # takeover, so it stays ungated.
+    if payload.enabled:
+        _guard_stored_mcp_token(request, svc)
     svc.set_auth_preference("enabled" if payload.enabled else "disabled")
     return SimpleResponse(status="ok")
 
@@ -242,6 +296,11 @@ async def auth_setup(payload: SetupRequest, request: Request, response: Response
             status_code=status.HTTP_409_CONFLICT,
             detail="A user has already been created. Use /auth/login.",
         )
+    # Creating the first admin flips a disabled install to "enabled" and hands
+    # back a session — the same takeover /auth/preference guards. Provisioning
+    # is an independent path to it, so gate it on the same stored-MCP-token
+    # possession check rather than leaving a bypass open.
+    _guard_stored_mcp_token(request, svc)
     try:
         svc.create_initial_user(payload.username, payload.password)
     except AlreadySetup:

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -348,6 +348,93 @@ def test_preference_rejected_after_setup(client, enabled):
     assert r.status_code == 409
 
 
+# --- Stored-MCP-token possession gate (#1880) ------------------------------
+#
+# On a preference-disabled install (no env pin, no user) that has a *stored*
+# MCP token, a drive-by must not be able to flip auth on / provision the first
+# admin and thereby hijack that token. Two unauthenticated requests
+# (``/auth/preference {enabled:true}`` -> ``/auth/setup``, or ``/auth/setup``
+# alone, which also flips the preference) would otherwise be enough. The stored
+# token must guard both provisioning paths.
+
+_STORED_TOKEN = "stored-mcp-token-abc123"
+
+
+def _disabled_with_stored_token():
+    """Persist a 'disabled' preference + a stored MCP token on the fresh service."""
+    svc = auth_service.get_auth_service()
+    svc.set_auth_preference("disabled")
+    svc.set_stored_mcp_token(_STORED_TOKEN)
+    return svc
+
+
+def test_preference_enable_blocked_when_stored_token_and_no_possession(client, undecided):
+    _disabled_with_stored_token()
+    r = client.post("/auth/preference", json={"enabled": True})
+    assert r.status_code == 403
+    # The install is not opened up.
+    assert client.get("/auth/status").json()["mode"] == "disabled"
+
+
+def test_preference_enable_allowed_when_stored_token_presented(client, undecided):
+    _disabled_with_stored_token()
+    r = client.post(
+        "/auth/preference",
+        json={"enabled": True},
+        headers={"Authorization": f"Bearer {_STORED_TOKEN}"},
+    )
+    assert r.status_code == 200
+    assert client.get("/auth/status").json()["mode"] == "enabled"
+
+
+def test_preference_enable_rejected_when_wrong_token_presented(client, undecided):
+    _disabled_with_stored_token()
+    r = client.post(
+        "/auth/preference",
+        json={"enabled": True},
+        headers={"Authorization": "Bearer not-the-token"},
+    )
+    assert r.status_code == 403
+    assert client.get("/auth/status").json()["mode"] == "disabled"
+
+
+def test_preference_disable_not_gated_by_stored_token(client, undecided):
+    _disabled_with_stored_token()
+    # Disabling is never a takeover, so no token is required.
+    r = client.post("/auth/preference", json={"enabled": False})
+    assert r.status_code == 200
+
+
+def test_setup_blocked_when_stored_token_and_no_possession(client, undecided):
+    """/auth/setup alone flips a disabled install on — gate it too."""
+    _disabled_with_stored_token()
+    r = client.post("/auth/setup", json={"username": "attacker", "password": "supersecret"})
+    assert r.status_code == 403
+    status_body = client.get("/auth/status").json()
+    # No admin was provisioned and the install stays disabled.
+    assert status_body["mode"] == "disabled"
+    assert status_body["setup_required"] is False
+
+
+def test_setup_allowed_when_stored_token_presented(client, undecided):
+    _disabled_with_stored_token()
+    r = client.post(
+        "/auth/setup",
+        json={"username": "owner", "password": "supersecret"},
+        headers={"Authorization": f"Bearer {_STORED_TOKEN}"},
+    )
+    assert r.status_code == 201
+    assert client.get("/auth/status").json()["mode"] == "enabled"
+
+
+def test_provisioning_unaffected_without_stored_token(client, undecided):
+    """Regression: the common first-run case (no stored token) still works."""
+    r = client.post("/auth/preference", json={"enabled": True})
+    assert r.status_code == 200
+    r2 = client.post("/auth/setup", json={"username": "owner", "password": "supersecret"})
+    assert r2.status_code == 201
+
+
 # --- /auth/change-username -------------------------------------------------
 
 


### PR DESCRIPTION
Closes the last unaddressed security item on the Phase 2 audit's "what's still owed" list.

Cherry-picked verbatim from #1882 (which targets `main` and is still a draft) onto the `next-rebuild` trunk, so the fix is present in the reworked backend rather than only in the branch it was written against. No code changed in the transfer; `src/auth/routes.py` auto-merged cleanly.

## The hole

On a preference-disabled install — no env pin, no admin user — that has a **stored** MCP token, anyone who can reach the port could:

1. `POST /auth/preference {"enabled": true}`
2. `POST /auth/setup`

…and walk away with a session that can rotate or revoke the stored MCP token. Two unauthenticated requests to hijack a credential the operator deliberately configured.

## The fix

While a stored token exists, both provisioning paths require possession of it (`Authorization: Bearer <token>`). `/auth/setup` is gated as well as the preference flip, because setup alone flips a disabled install on.

Deliberately **not** gated:
- installs with no stored token — the common first-run case, unaffected
- an env-pinned token (`FIESTABOARD_MCP_TOKEN`), which cannot be rotated or revoked from the UI (those endpoints 409), so there is nothing to hijack
- disabling auth, which grants nothing

## Verification on this trunk

- The 87 lines of tests that came with the fix pass here: `tests/test_auth_routes.py` + `tests/test_auth_service.py` → **75 passed**.
- Full suite: **6200 passed, 2 skipped**, **0 data-dir leaks** (explicit mount over `/app/data`).
- The single failure, `test_check_image_formats`, is the environmental `git ls-files` one that fails identically on the untouched trunk.
- `ruff==0.16.5` check + format clean.

#1882 can stay open against `main` or be closed in favour of this, depending on whether `main` gets the fix before `next` merges down.