### PR TITLE
fix(tests): stop the background threads that rewrite process globals mid-test

### DIFF
--- a/src/time_service.py
+++ b/src/time_service.py
@@ -12,6 +12,7 @@ datetime or zoneinfo to ensure consistency and testability.
 """
 
 import logging
+import threading
 from datetime import UTC, datetime
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -308,19 +309,65 @@ def _get_configured_timezone() -> str:
         return "UTC"
 
 
+#: True on a thread that is currently inside ``get_time_service()``'s
+#: construction step. See that function for why re-entry is reachable.
+_building = threading.local()
+
+#: A plain UTC service handed to callers that re-enter during construction.
+#: It reads no configuration, so it needs no per-test reset.
+_bootstrap: TimeService | None = None
+
+
+def _bootstrap_time_service() -> TimeService:
+    """A UTC ``TimeService`` for callers that re-enter during construction.
+
+    ``TimeService("UTC")`` always resolves, so building this one cannot log
+    and cannot re-enter.
+    """
+    global _bootstrap
+    if _bootstrap is None:
+        _bootstrap = TimeService(default_timezone="UTC")
+    return _bootstrap
+
+
 def get_time_service() -> TimeService:
     """Get or create the time service singleton.
 
     Uses the user-configured timezone from Config.GENERAL_TIMEZONE
     instead of hardcoding a default.
 
+    Construction is re-entrant, and until this guard it recursed until the
+    interpreter died. ``Config.GENERAL_TIMEZONE`` defaults to the empty string
+    when ``general.timezone`` is unset, ``TimeService.__init__`` logs a warning
+    for a timezone it cannot resolve, and the log handler in
+    :mod:`src.log_store` calls *this* function to timestamp every record. With
+    the global still unassigned that warning re-entered construction, warned
+    again, and so on:
+
+        src/log_store.py:82  in emit -> _create_log_entry
+        src/time_service.py       in get_time_service
+        src/time_service.py:50    in __init__ -> logger.warning(...)
+        RecursionError: maximum recursion depth exceeded
+
+    Under pytest that surfaces as an unraisable exception charged to whatever
+    test happened to be running when a background thread logged — observed on
+    CI as ``tests/test_tick_shared_context.py::TestSilenceWindowCache::
+    test_sixty_probes_at_idle_parse_the_window_once - RuntimeError: Failed to
+    process unraisable exception``.
+
     Returns:
         The global TimeService instance
     """
     global _time_service
     if _time_service is None:
-        tz = _get_configured_timezone()
-        _time_service = TimeService(default_timezone=tz)
+        if getattr(_building, "active", False):
+            return _bootstrap_time_service()
+        _building.active = True
+        try:
+            tz = _get_configured_timezone()
+            _time_service = TimeService(default_timezone=tz)
+        finally:
+            _building.active = False
     return _time_service
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,11 +66,32 @@ def _drop_all_singletons() -> None:
     build — and fully initialize — a brand-new plugin registry on every
     test): the next ``get_template_engine()`` call builds a fresh engine
     bound to a fresh registry, and only in tests that actually use it.
+
+    **Audited against every module global in ``src/``** (``grep -rn "    global
+    " src/``). The ones deliberately NOT reset here, and why:
+
+    * ``src.api_server._service_running`` / ``_service_thread`` /
+      ``_shutting_down`` — owned by ``tests/test_service_lifecycle.py``, which
+      drives them directly.
+    * ``src.display_runtime._running_probe`` / ``_loop_spawn`` / ``_loop_halt``
+      / ``_service_start_time`` — installed once by ``src.api_server`` at
+      import; not per-test state.
+    * ``src.board_send_executor._executor`` / ``_preview_executor`` and
+      ``src.plugins.registry._fetch_executor`` / ``_fetch_workers_lost`` —
+      idle thread pools that are already self-healing (shut down to ``None``,
+      rebuilt lazily). Their threads hold no config or data-dir state.
+    * ``src.network.wifi._service``, ``src.system.mdns._mdns_service``,
+      ``src.utils.transit_cache._cache_instance``, ``src.time_service._bootstrap``
+      and the ad-hoc response caches (``_ai_generate_last_call``,
+      ``_muni_stops_cache``, ``_station_info_cache``) — no test was observed
+      leaving any of them dirty. ``transit_cache`` does own a background
+      thread; add it here if one ever starts leaking.
     """
     import src.auth.service as auth_service_module
     import src.backup.service as backup_service_module
     import src.collections.service as collection_service_module
     import src.display_runtime as display_runtime
+    import src.mqtt.client as mqtt_client_module
     import src.pages.service as page_service_module
     import src.panels.service as panel_service_module
     import src.schedules.service as schedule_service_module
@@ -111,7 +132,85 @@ def _drop_all_singletons() -> None:
     # singleton; test_service_lifecycle.py drives the background *thread*
     # (`_service_running`, `_service_thread`), which is api_server state and is
     # still left alone.
+    #
+    # Dropping the reference is not enough: `DisplayService.initialize()` starts
+    # a `board-state-poll` thread, and that thread outlives the reference. See
+    # `_stop_display_service` for what it does to the *next* test in the worker.
+    _stop_display_service(display_runtime._service)
     display_runtime._service = None
+
+    # The MQTT client singleton, which owns a `_sync_loop` thread of its own.
+    # Same argument as the display service: `tests/test_mqtt_client.py` leaves
+    # five of them running, and `get_mqtt_client()` answers with a client built
+    # against a previous test's mock broker until something replaces it.
+    _stop_mqtt_client(mqtt_client_module._mqtt_client_instance)
+    mqtt_client_module._mqtt_client_instance = None
+
+
+def _stop_display_service(service) -> None:
+    """Stop the background threads of the ``DisplayService`` being dropped.
+
+    ``DisplayService.initialize()`` starts a daemon ``board-state-poll`` thread
+    whose loop is::
+
+        while self.running:
+            interval = self._get_board_read_interval()   # get_settings_service()
+            ...
+            time.sleep(interval)
+
+    Nulling ``display_runtime._service`` drops the *reference*; the thread keeps
+    running. Every 30s it re-enters ``get_settings_service()``, which — because
+    this fixture has since set ``_settings_service = None`` — CONSTRUCTS A NEW
+    SettingsService and stores it in the process global, and then, through
+    ``SettingsService.__init__`` -> ``_load_transition_settings`` ->
+    ``Config._get_board()``, constructs a new ``ConfigManager`` singleton
+    against the default config path. Both writes land in whatever test happens
+    to be running at that moment, in that worker.
+
+    That is the xdist flake this closes. Two observed shapes:
+
+    * ``tests/test_transitions_contract.py`` — the ``beta_on`` fixture enables
+      ``transition_plugins_enabled`` on the settings singleton, the poll thread
+      replaces the singleton mid-test, and the route's beta gate reads the
+      replacement's default ``False``::
+
+          assert 'Transition plugins are an experimental beta. ...'
+                 == "Transition plugin 'ghost' not loaded or not enabled"
+
+    * ``tests/test_silence_per_board_composition.py`` — ``ConfigManager`` is a
+      ``__new__``-singleton that ignores ``config_path`` once an instance
+      exists, so ``ConfigManager(config_path=tmp/config.json)`` silently binds
+      to the poll thread's default-path instance and the migration finds
+      nothing to seed (``assert 0 == 1``).
+
+    ``running = False`` is the existing stop seam — it is exactly what
+    ``src/main.py``'s SIGTERM handler does — so no production code changes.
+    The thread re-checks it at the top of every iteration and exits without
+    touching another global. Send workers and the adaptive post-send refresh
+    thread get their own cancels; neither is joined, because a per-test join
+    would cost more than the leak.
+    """
+    if service is None:
+        return
+    service.running = False
+    try:
+        runtimes = list(getattr(service, "runtimes", {}).values())
+    except RuntimeError:  # pragma: no cover - dict replaced concurrently
+        return
+    for runtime in runtimes:
+        cancel = getattr(runtime, "refresh_cancel", None)
+        if cancel is not None:
+            cancel.set()
+        worker = getattr(runtime, "send_worker", None)
+        if worker is not None:
+            worker.stop(timeout=0.0)
+
+
+def _stop_mqtt_client(client) -> None:
+    """Stop the ``_sync_loop`` thread of the MQTT client being dropped."""
+    if client is None:
+        return
+    client._running = False
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_singleton_isolation.py
+++ b/tests/test_singleton_isolation.py
@@ -1,0 +1,146 @@
+"""The per-test singleton reset must also stop the threads that rewrite them.
+
+``tests/conftest.py``'s autouse ``_isolated_data_dir`` drops every cached
+service between tests. Dropping the *reference* is not the whole job: a
+``DisplayService`` that reached ``initialize()`` owns a daemon
+``board-state-poll`` thread, and that thread keeps re-entering
+``get_settings_service()`` — which, with the singleton just nulled, builds a
+fresh ``SettingsService`` and stores it in the process global, then builds a
+fresh default-path ``ConfigManager`` through
+``SettingsService.__init__`` -> ``_load_transition_settings`` ->
+``Config._get_board()``.
+
+Under ``pytest -n auto`` that lands in whichever test the worker is running 30
+seconds later, which is how ``test_transitions_contract``,
+``test_silence_per_board_composition`` and ``test_tick_shared_context``
+failed on CI at SHAs containing none of their changes.
+
+These tests pin the reset, not the symptom: after ``_drop_all_singletons()``
+the poll thread is gone and the globals it used to rewrite stay dropped.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import MagicMock
+
+import src.display_runtime as display_runtime
+import src.settings.service as settings_service_module
+from src.main import DisplayService
+from tests.conftest import _drop_all_singletons
+
+
+def _service_with_a_hot_poll_thread(monkeypatch) -> tuple[DisplayService, threading.Event]:
+    """A real ``DisplayService`` running the real ``_board_poll_loop``.
+
+    Only the poll *interval* is shortened — from the 30s production default to
+    1ms — so the loop's re-entry into ``get_settings_service()`` (which is what
+    leaks) happens on a test's timescale instead of a CI worker's. The loop
+    body, the accessor it calls and the global it writes are all the real ones.
+    """
+    entered = threading.Event()
+    service = DisplayService()
+
+    real_interval = DisplayService._get_board_read_interval
+
+    def fast_interval(self):
+        entered.set()
+        real_interval(self)  # the real accessor: get_settings_service()
+        return 0.001
+
+    monkeypatch.setattr(DisplayService, "_get_board_read_interval", fast_interval)
+    service._poll_thread = threading.Thread(target=service._board_poll_loop, daemon=True, name="board-state-poll")
+    service._poll_thread.start()
+    assert entered.wait(5), "the poll loop never ran; the fixture is not exercising it"
+    return service, entered
+
+
+def test_dropping_the_display_service_singleton_stops_its_board_poll_thread(monkeypatch):
+    service, _ = _service_with_a_hot_poll_thread(monkeypatch)
+    display_runtime._service = service
+
+    _drop_all_singletons()
+
+    service._poll_thread.join(timeout=5)
+    assert not service._poll_thread.is_alive(), (
+        "board-state-poll outlived the singleton reset; it will rebuild "
+        "get_settings_service()/ConfigManager inside a later test"
+    )
+
+
+def test_a_dropped_services_poll_thread_stops_rebuilding_the_settings_singleton(monkeypatch):
+    """The observable dirt: the settings global does not come back by itself."""
+    service, _ = _service_with_a_hot_poll_thread(monkeypatch)
+    display_runtime._service = service
+
+    _drop_all_singletons()
+
+    # A construction already in flight when the reset landed may still assign;
+    # let it, then re-drop. What must not happen is a *new* one after this.
+    time.sleep(0.05)
+    settings_service_module._settings_service = None
+
+    # Long enough for a 1ms-interval loop to have rebuilt it a hundred times.
+    time.sleep(0.25)
+
+    assert settings_service_module._settings_service is None, (
+        "a dropped service's poll thread reconstructed the settings singleton "
+        "after the reset; whatever test is running now sees a service it never "
+        "configured"
+    )
+
+
+def test_a_log_record_during_time_service_construction_does_not_recurse(monkeypatch):
+    """The third CI shape: an unraisable RecursionError charged to a bystander.
+
+    ``Config.GENERAL_TIMEZONE`` is ``""`` whenever ``general.timezone`` is
+    unset — which every stub config manager in the suite leaves it — and
+    ``TimeService.__init__`` logs a warning for a timezone it cannot resolve.
+    ``src.log_store``'s handler timestamps that warning by calling
+    ``get_time_service()``, which, with the singleton still unassigned, started
+    construction over, warned again, and recursed to the interpreter's limit.
+
+    ``LogBufferHandler.emit`` swallows the ``RecursionError``, so the count of
+    constructions — not an exception — is what makes this test fail without the
+    guard. On CI the same recursion escaped on a background thread and failed
+    ``tests/test_tick_shared_context.py::TestSilenceWindowCache::
+    test_sixty_probes_at_idle_parse_the_window_once`` with ``RuntimeError:
+    Failed to process unraisable exception``, a test that never touches the
+    time service.
+    """
+    import logging
+
+    import src.time_service as time_service_module
+    from src.log_store import LogBufferHandler
+
+    config_manager = MagicMock()
+    config_manager.get_general.return_value = {}  # no "timezone" key -> ""
+    monkeypatch.setattr("src.config.get_config_manager", lambda: config_manager)
+    monkeypatch.setattr("src.config_manager.get_config_manager", lambda: config_manager)
+    time_service_module.reset_time_service()
+
+    constructions: list[str] = []
+    real_init = time_service_module.TimeService.__init__
+
+    def counting_init(self, default_timezone="America/Los_Angeles"):
+        constructions.append(default_timezone)
+        real_init(self, default_timezone=default_timezone)
+
+    monkeypatch.setattr(time_service_module.TimeService, "__init__", counting_init)
+
+    handler = LogBufferHandler()
+    root = logging.getLogger()
+    root.addHandler(handler)
+    try:
+        # Non-vacuity: the timezone really is unresolvable, so __init__ really
+        # does log while the singleton is still unassigned.
+        assert time_service_module._get_configured_timezone() == ""
+        service = time_service_module.get_time_service()
+    finally:
+        root.removeHandler(handler)
+
+    assert service is time_service_module._time_service
+    # The configured (empty) timezone, plus at most the one-off UTC bootstrap
+    # handed to the re-entrant log record.
+    assert len(constructions) <= 2, f"get_time_service() re-entered its own construction {len(constructions)} times"


### PR DESCRIPTION
Three test modules — `test_transitions_contract`, `test_silence_per_board_composition`
and `test_tick_shared_context` — have been failing intermittently under CI's
`pytest -n auto` at SHAs containing none of their changes. They are not three
flakes. They are one leak with three faces, plus one latent production bug that
turns a stray log line into a failed bystander.

## What was actually leaking

`tests/conftest.py`'s autouse `_isolated_data_dir` drops every cached singleton
between tests. Dropping `src.display_runtime._service` drops the **reference**.
It does not stop the thread.

A `DisplayService` that reached `initialize()` owns a daemon `board-state-poll`
thread whose loop is:

```python
while self.running:
    interval = self._get_board_read_interval()   # -> get_settings_service()
    ...
    time.sleep(interval)
```

Every 30 seconds, forever, it re-enters `get_settings_service()`. The fixture has
since set `_settings_service = None`, so that call **constructs a new
SettingsService and stores it in the process global** — and then, through
`SettingsService.__init__` → `_load_transition_settings` → `Config._get_board()`,
constructs a new default-path `ConfigManager` singleton as well. Both writes land
in whatever test the worker happens to be running at that moment.

A thread-leak probe over the full suite found the leakers — 24 threads per worker
from four modules:

```
LEAKTHREAD tests/test_config_contract.py::...                    -> ['board-state-poll']   (7)
LEAKTHREAD tests/test_panels_contract.py::...                    -> ['board-state-poll']   (9)
LEAKTHREAD tests/test_board_credentials_unification.py::...      -> ['board-state-poll']   (6)
LEAKTHREAD tests/test_persistence_round_trip.py::...             -> ['board-state-poll']   (2)
```

That explains two of the three modules directly:

* **transitions** — the `beta_on` fixture enables `transition_plugins_enabled` on
  the settings singleton; the poll thread replaces the singleton mid-test; the
  route's beta gate reads the replacement's default `False` and 404s.
* **silence** — `ConfigManager` is a `__new__`-singleton that ignores
  `config_path` once an instance exists, so `ConfigManager(config_path=tmp/config.json)`
  silently binds to the poll thread's default-path instance and the migration
  finds nothing to seed.

## The third face: a re-entrant singleton in `src/`

`test_tick_shared_context` failed differently on CI —
`RuntimeError: Failed to process unraisable exception`. The traceback from
[run 34098792788](https://github.com/Fiestaboard/FiestaBoard/actions/runs/34098792788):

```
src/log_store.py:82: in emit
    log_entry = _create_log_entry(record, self.format(record))
src/log_store.py:67: in _create_log_entry
    time_service = get_time_service()
src/time_service.py:323: in get_time_service
    _time_service = TimeService(default_timezone=tz)
src/time_service.py:50: in __init__
    logger.warning(f"Unknown default timezone: {default_timezone}, using UTC")
...
E   RecursionError: maximum recursion depth exceeded while calling a Python object
```

`Config.GENERAL_TIMEZONE` returns `cls._get_general().get("timezone", "")` — the
default is the **empty string**, which no `ZoneInfo` resolves. `TimeService.__init__`
warns about it. `src/log_store.py`'s handler timestamps every record by calling
`get_time_service()`. With the global still unassigned, that warning re-entered
construction, warned again, and recursed until the interpreter died. Under pytest
the unraisable `RecursionError` is charged to whichever test was running — here a
silence-cache test that never touches the time service.

This one is a genuine production landmine, not a test artifact, so it is fixed in
`src/time_service.py`: a thread-local guard makes `get_time_service()` re-entrant,
handing the nested call a plain UTC service instead of starting a second
construction.

## The fix

* **`tests/conftest.py`** — `_drop_all_singletons()` now *stops* the DisplayService
  it drops: `running = False` (the existing stop seam — literally what `src/main.py`'s
  SIGTERM handler does), plus `refresh_cancel.set()` and `send_worker.stop(timeout=0.0)`
  per runtime. No production behaviour changes for this half; nothing is joined,
  because a per-test join would cost more than the leak. The MQTT client singleton
  (`src.mqtt.client._mqtt_client_instance`), which owns a `_sync_loop` thread and was
  absent from the reset list entirely, is stopped and dropped the same way.
* **`src/time_service.py`** — re-entrancy guard on `get_time_service()`.
* **`tests/test_singleton_isolation.py`** — three regression tests, all
  mutation-proven below.

No `xdist_group` marker, no `-p no:xdist`, no serialisation. The globals stop
being rewritten.

## Before / after on a scheduling that reliably failed

A throwaway module (not committed) leaks a `board-state-poll` thread exactly the
way the four real leakers do — a real `DisplayService`, the real `_board_poll_loop`,
registered at `src.display_runtime._service` — with the interval shortened from 30s
to 0 so the race is reliable rather than ~1-in-30. Then the three suspect modules
run behind it in the same process.

**Before** (fix reverted, same tree):

```
FAILED tests/test_transitions_contract.py::test_preview_without_a_plugin_id_is_rejected
FAILED tests/test_transitions_contract.py::test_preview_rejects_an_unknown_device_type
FAILED tests/test_transitions_contract.py::test_preview_returns_the_frames_and_the_delay_they_add_up_to
FAILED tests/test_transitions_contract.py::test_live_test_of_an_unloaded_plugin_is_a_404_naming_it
FAILED tests/test_transitions_contract.py::test_restore_accepts_an_omitted_body
FAILED tests/test_silence_per_board_composition.py::TestMigrationLockSafety::test_seeding_migration_does_not_hold_the_config_lock_across_the_board_lookup
=================== 6 failed, 32 passed, 3 warnings in 0.77s ===================
```

with, verbatim, the same assertion CI produced on `next-rebuild`
([run 34098092285](https://github.com/Fiestaboard/FiestaBoard/actions/runs/34098092285)):

```
E   AssertionError: assert 'Transition p...his endpoint.' == 'Transition p...r not enabled'
E     - Transition plugin 'ghost' not loaded or not enabled
E     + Transition plugins are an experimental beta. Enable them in Settings → Beta to use this endpoint.
```

and the same `assert 0 == 1` CI produced for the silence migration.

**After** (this branch):

```
======================== 38 passed, 3 warnings in 0.72s ========================
```

## The globals, observably dirty

`tests/test_singleton_isolation.py` pins the reset rather than the symptom. With
`service.running = False` sabotaged back to `True` in the conftest fix:

```
FAILED tests/test_singleton_isolation.py::test_dropping_the_display_service_singleton_stops_its_board_poll_thread
E   AssertionError: board-state-poll outlived the singleton reset; it will rebuild get_settings_service()/ConfigManager inside a later test
E   assert not True
E    +  where True = is_alive()
E    +    where is_alive = <Thread(board-state-poll, started daemon 281473139077472)>.is_alive

FAILED tests/test_singleton_isolation.py::test_a_dropped_services_poll_thread_stops_rebuilding_the_settings_singleton
E   AssertionError: a dropped service's poll thread reconstructed the settings singleton after the reset; whatever test is running now sees a service it never configured
E   assert <src.settings.service.SettingsService object at 0xffff9285c2b0> is None
E    +  where <src.settings.service.SettingsService object at 0xffff9285c2b0> = settings_service_module._settings_service
```

And with `src/time_service.py` reverted:

```
FAILED tests/test_singleton_isolation.py::test_a_log_record_during_time_service_construction_does_not_recurse
E   AssertionError: get_time_service() re-entered its own construction 99 times
```

(99, not 1000 — `LogBufferHandler.emit` swallows the `RecursionError`, which is
why the test counts constructions instead of expecting an exception.)

All three pass on this branch.

## The conftest reset list had drifted

Audited against `grep -rn "    global " src/` — every module global in `src/`.
The one real gap was `src.mqtt.client._mqtt_client_instance`, which owns a
`_sync_loop` thread and which `tests/test_mqtt_client.py` leaves running five
times; it is now reset. The stale `src.api_server._service` entry the earlier
review found was already corrected on trunk.

Everything else is deliberately left alone, and `_drop_all_singletons`'s docstring
now says so per entry: the `api_server` service-loop flags (owned by
`test_service_lifecycle`), the `display_runtime` import-time callbacks, the
self-healing thread pools (`board_send_executor`, `plugins.registry._fetch_executor`),
and the config-independent caches. `src.utils.transit_cache._cache_instance` does own
a background thread but no test was observed leaving it dirty; it is named in the
docstring as the next candidate if one ever does.

## Verification

| Check | Result |
|---|---|
| Full suite, `-n 4 -m "not integration"`, explicit `/app/data` mount, **before** | 6467 passed, 1 skipped, 1 failed |
| Full suite, same command, **after** | **6470 passed, 1 skipped, 1 failed** |
| Delta | +3, exactly the three new regression tests |
| Data-dir leak count (`find .pytest-data -type f \| wc -l`) | **0** |
| `ruff==0.16.5` check + format over `src/ plugins/ tests/ scripts/` | clean, 447 files |

The single failure in both columns is
`tests/test_check_image_formats.py::TestRepositoryIsClean::test_no_tracked_file_in_this_repo_reaches_a_vulnerable_parser`
— the documented worktree-environment failure (`git ls-files` exits non-zero inside
the mounted container). Identical on the untouched baseline; the failure set is a
strict subset.

## What this does not close

* `get_settings_service()` and its nine siblings (`get_page_service`,
  `get_collection_service`, …) are unlocked `if _x is None: _x = X()` accessors. Two
  threads that both observe `None` each build an instance and the loser's assignment
  clobbers the winner's, discarding anything written to it. `get_service()` in
  `display_runtime` and `get_mdns_service()` already use double-checked locking; the
  rest do not. Stopping the leaked threads removes the trigger the suite had, but the
  race is still reachable at process start, when the display loop thread and the first
  request both touch a cold singleton. Worth a follow-up.
* `Config.GENERAL_TIMEZONE` still returns `""` by default, so a fresh install still
  logs `Unknown default timezone: , using UTC` once. The guard makes that harmless
  instead of fatal; the empty default itself is untouched here.
* The `plugin-fetch_*`, `board-send_*` and `_do_refresh` threads still outlive their
  tests. They are pool workers or bounded one-shots that touch no process global, so
  they are inert — but the probe that found this is worth re-running if a new flake
  of this shape appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP
