### PR TITLE
perf(logs): make GET /logs cost O(offset+limit), not O(bytes on disk)

### DIFF
--- a/src/debug/routes.py
+++ b/src/debug/routes.py
@@ -34,6 +34,7 @@ module attributes, and one patch target is the whole truth.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 
@@ -496,7 +497,14 @@ async def get_logs(
             detail=f"Invalid log level: {level}. Valid levels: {list(VALID_LOG_LEVELS)}",
         )
 
-    logs, total, has_more = log_store._read_logs_from_files(limit=limit, offset=offset, level=level, search=search)
+    # Reading a log page touches the filesystem. Even bounded to one page it
+    # is blocking I/O, and on a Pi the syscall latency is an order of
+    # magnitude worse than here — so it goes to a thread rather than stalling
+    # the event loop for every other request, the same way the page and
+    # settings routes hand their blocking work off.
+    logs, total, has_more = await asyncio.to_thread(
+        log_store._read_logs_from_files, limit=limit, offset=offset, level=level, search=search
+    )
 
     return LogsResponse(
         logs=logs,

--- a/src/log_store.py
+++ b/src/log_store.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import logging
 import logging.handlers
+import os
 import threading
 from collections import deque
 from pathlib import Path
@@ -135,6 +136,87 @@ def _setup_file_logging():
         logger.warning(f"Failed to set up file logging: {e}")
 
 
+# Reverse-read chunk size. One 64 KB read holds ~250 JSON log lines, so a
+# default 50-row page is usually satisfied by a single read() near the end of
+# ``app.log``.
+_REVERSE_CHUNK_BYTES = 64 * 1024
+
+# How many recently-seen ``(timestamp, message)`` keys the deduplicator
+# remembers. The old reader kept one per entry in the whole corpus — 177k
+# tuples for a full 33.5 MB log set, and the single largest term in the
+# 191.6 MB an unfiltered ``GET /logs?limit=100`` used to allocate.
+#
+# A window is sufficient because duplicates cannot be far apart in the
+# newest-first stream: rotation writes every line to exactly one file, so the
+# only pairs that ever collide are an entry in the 500-slot in-memory ring and
+# its copy among the newest lines of ``app.log``. Those are at most ~1000
+# positions apart; 4096 is an 8x margin over that, and costs well under a
+# megabyte.
+_DEDUPE_WINDOW = 4096
+
+
+def _iter_lines_reversed(path: Path, chunk_size: int = _REVERSE_CHUNK_BYTES):
+    """Yield a file's lines newest-last-first, reading backwards in chunks.
+
+    The equivalent of ``reversed(f.readlines())`` without the ``readlines()``:
+    the caller can stop after a handful of lines and the rest of the file is
+    never read. Lines come back as ``bytes``; decoding is the caller's job so
+    that one undecodable line does not sink the file.
+    """
+    with open(path, "rb") as f:
+        f.seek(0, os.SEEK_END)
+        remaining = f.tell()
+        # Bytes belonging to a line that started before the current chunk.
+        partial = b""
+        while remaining > 0:
+            read_size = min(chunk_size, remaining)
+            remaining -= read_size
+            f.seek(remaining)
+            parts = (f.read(read_size) + partial).split(b"\n")
+            # parts[0] is only a line's tail unless we just read byte 0.
+            partial = parts.pop(0)
+            yield from reversed(parts)
+        if partial:
+            yield partial
+
+
+def _iter_entries_newest_first():
+    """Yield log entries newest first, opening as little as possible.
+
+    Order matches what the eager reader produced: the in-memory ring
+    (newest first), then ``app.log``, then ``app.log.1`` .. ``app.log.N``,
+    each read back to front. Files are opened lazily, so a consumer that
+    stops after one page never touches the backups.
+    """
+    with _log_lock:
+        memory_logs = list(_log_buffer)
+    yield from reversed(memory_logs)
+
+    current_log = _log_file()
+    candidates = [current_log] + [Path(f"{current_log}.{i}") for i in range(1, LOG_BACKUP_COUNT + 1)]
+
+    for log_file in candidates:
+        if not log_file.exists():
+            continue
+        try:
+            for raw in _iter_lines_reversed(log_file):
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except (UnicodeDecodeError, ValueError):
+                    # Not JSON, or not even UTF-8. Skip the line. The old
+                    # reader let a decode error escape ``readlines()`` and
+                    # dropped the whole file; reverse reading has already
+                    # emitted the newer entries by then, so per-line is both
+                    # the only available granularity and the better one.
+                    continue
+        except Exception:
+            # A file that cannot be read never breaks the endpoint, as before.
+            continue
+
+
 def _read_logs_from_files(
     limit: int = 100, offset: int = 0, level: str | None = None, search: str | None = None
 ) -> tuple[list[dict[str, Any]], int, bool]:
@@ -142,78 +224,52 @@ def _read_logs_from_files(
     Read logs from log files with filtering and pagination.
 
     Returns: (logs, total_matching, has_more)
+
+    Cost is O(offset + limit), not O(bytes on disk): the stream is consumed
+    newest first and abandoned one entry past the requested page.
+    Consequently ``total_matching`` is a **lower bound** whenever the scan
+    stopped early — the reader cannot count a corpus it deliberately did not
+    read. It is exact whenever the stream was exhausted, which covers every
+    small deployment and every filter that matches less than a full page.
+    ``has_more`` is exact in all cases and is the authoritative "is there
+    another page" signal.
     """
-    all_logs = []
+    need = offset + limit
+    level_upper = level.upper() if level else None
+    search_lower = search.lower() if search else None
 
-    # Read from current log file and backups
-    current_log = _log_file()
-    log_files = [current_log]
-    for i in range(1, LOG_BACKUP_COUNT + 1):
-        backup_file = Path(f"{current_log}.{i}")
-        if backup_file.exists():
-            log_files.append(backup_file)
+    # Bounded dedupe window: a set for lookups, a deque to evict the oldest
+    # key once it can no longer collide with anything still to come.
+    seen: set[tuple[Any, Any]] = set()
+    seen_order: deque[tuple[Any, Any]] = deque()
 
-    # Read all log entries from files (newest first)
-    for log_file in log_files:
-        if not log_file.exists():
+    page: list[dict[str, Any]] = []
+    matched = 0
+
+    for entry in _iter_entries_newest_first():
+        # Deduplicate before filtering, as before: two entries can share a
+        # ``(timestamp, message)`` while differing in level, and the first one
+        # seen is the one that counts.
+        key = (entry.get("timestamp"), entry.get("message"))
+        if key in seen:
             continue
-        try:
-            with open(log_file, encoding="utf-8") as f:
-                lines = f.readlines()
-                for line in reversed(lines):
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        entry = json.loads(line)
-                        all_logs.append(entry)
-                    except json.JSONDecodeError:
-                        continue
-        except Exception:
+        seen.add(key)
+        seen_order.append(key)
+        if len(seen_order) > _DEDUPE_WINDOW:
+            seen.discard(seen_order.popleft())
+
+        if level_upper is not None and entry.get("level") != level_upper:
+            continue
+        if search_lower is not None and not (
+            search_lower in entry.get("message", "").lower() or search_lower in entry.get("logger", "").lower()
+        ):
             continue
 
-    # Also include in-memory buffer (most recent)
-    with _log_lock:
-        memory_logs = list(_log_buffer)
+        matched += 1
+        if matched > offset and len(page) < limit:
+            page.append(entry)
+        if matched > need:
+            # One past the page: enough to answer ``has_more`` exactly.
+            break
 
-    # Merge: memory logs are most recent, then file logs
-    # Deduplicate by timestamp + message
-    seen = set()
-    merged_logs = []
-
-    for log in reversed(memory_logs):
-        key = (log.get("timestamp"), log.get("message"))
-        if key not in seen:
-            seen.add(key)
-            merged_logs.append(log)
-
-    for log in all_logs:
-        key = (log.get("timestamp"), log.get("message"))
-        if key not in seen:
-            seen.add(key)
-            merged_logs.append(log)
-
-    # Apply filters
-    filtered_logs = merged_logs
-
-    if level:
-        level_upper = level.upper()
-        filtered_logs = [log for log in filtered_logs if log.get("level") == level_upper]
-
-    if search:
-        search_lower = search.lower()
-        filtered_logs = [
-            log
-            for log in filtered_logs
-            if search_lower in log.get("message", "").lower() or search_lower in log.get("logger", "").lower()
-        ]
-
-    total_matching = len(filtered_logs)
-
-    # Apply pagination
-    start = offset
-    end = offset + limit
-    paginated = filtered_logs[start:end]
-    has_more = end < total_matching
-
-    return paginated, total_matching, has_more
+    return page, matched, matched > need

--- a/tests/test_log_store_pagination.py
+++ b/tests/test_log_store_pagination.py
@@ -1,0 +1,416 @@
+"""``GET /logs`` must cost O(offset + limit), not O(bytes on disk).
+
+Two halves, and the order matters.
+
+**The goldens** (``TestReadContract``) are value-level pins on
+:func:`src.log_store._read_logs_from_files` written against the *unmodified*
+tree: ordering, dedupe, filter semantics, offsets past the end, blank and
+unparseable lines. They are the zero-regression evidence — every one of them
+passed before ``_read_logs_from_files`` was rewritten and passes after.
+
+**The bound** (``TestReadIsBounded``) is the reproduction. The old reader
+globbed ``app.log`` plus five 5 MB backups, ``readlines()``-ed each in full,
+``json.loads``-ed every line into one list *plus* a ``seen`` set holding a
+``(timestamp, message)`` tuple for the entire corpus, and only then sliced
+``[offset:offset + limit]``. Returning 100 rows out of a full 33.5 MB log set
+(177,720 entries) peaked at 191.6 MB — enough to OOM-kill a Pi 3B+, whose
+1 GB is shared with the GPU. Against the smaller corpus these tests build,
+the pre-fix numbers were::
+
+    entries parsed        30000  (bound: 2000)
+    files opened              6  (bound: 1)
+    tracemalloc peak     23.5 MB (bound: 4 MB)
+
+Counts, not wall-clock: they transfer off this machine.
+
+Deliberate contract changes, each pinned below by a test that names it:
+
+1. ``total`` is a **lower bound** once the scan stops early — the reader can
+   no longer know the size of a corpus it deliberately did not read. It stays
+   exact whenever the scan reaches the end (every filtered read that matches
+   less than a page, and every small corpus). ``has_more`` is exact in all
+   cases and remains the authoritative "is there another page" signal.
+2. The ``seen`` set is bounded to a sliding window instead of the corpus.
+   Duplicates only ever arise between the 500-entry in-memory ring and the
+   newest lines of ``app.log`` — rotation writes each line to exactly one
+   file — so a window covers every duplicate that can actually occur. Two
+   entries sharing a ``(timestamp, message)`` from opposite ends of a 33 MB
+   corpus are now both returned; that pairing needs identical timestamps
+   hours apart.
+3. A line that is not valid UTF-8 now skips that line. It used to raise out
+   of ``readlines()`` and silently discard the whole file. Reverse-reading
+   cannot un-yield the newer entries it already produced, so per-line is the
+   only available granularity — and it is the better one.
+"""
+
+from __future__ import annotations
+
+import json
+import tracemalloc
+from unittest.mock import patch
+
+import pytest
+
+from src import log_store
+
+
+def _entry(ts: str, level: str = "INFO", logger: str = "src.main", message: str = "m") -> dict:
+    return {"timestamp": ts, "level": level, "logger": logger, "message": message}
+
+
+def _write(path, entries) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+
+
+@pytest.fixture
+def log_dir(tmp_path, monkeypatch):
+    """Point the reader at a scratch log dir with an empty in-memory ring."""
+    directory = tmp_path / "logs"
+    directory.mkdir()
+    monkeypatch.setattr(log_store, "LOG_DIR", directory)
+    with log_store._log_lock:
+        saved = list(log_store._log_buffer)
+        log_store._log_buffer.clear()
+    yield directory
+    with log_store._log_lock:
+        log_store._log_buffer.clear()
+        log_store._log_buffer.extend(saved)
+
+
+class TestReadContract:
+    """Value-level goldens. All of these passed before the rewrite."""
+
+    def test_returns_entries_newest_first_within_a_file(self, log_dir):
+        _write(log_dir / "app.log", [_entry("t1"), _entry("t2"), _entry("t3")])
+
+        logs, total, has_more = log_store._read_logs_from_files(limit=10)
+
+        assert [entry["timestamp"] for entry in logs] == ["t3", "t2", "t1"]
+        assert (total, has_more) == (3, False)
+
+    def test_reads_the_current_file_before_its_backups(self, log_dir):
+        _write(log_dir / "app.log", [_entry("current")])
+        _write(log_dir / "app.log.1", [_entry("backup1")])
+        _write(log_dir / "app.log.2", [_entry("backup2")])
+
+        logs, _, _ = log_store._read_logs_from_files(limit=10)
+
+        assert [entry["timestamp"] for entry in logs] == ["current", "backup1", "backup2"]
+
+    def test_reads_a_backup_index_even_when_an_earlier_one_is_missing(self, log_dir):
+        """``app.log.3`` is still read with no ``app.log.1`` present."""
+        _write(log_dir / "app.log", [_entry("current")])
+        _write(log_dir / "app.log.3", [_entry("orphan")])
+
+        logs, total, _ = log_store._read_logs_from_files(limit=10)
+
+        assert [entry["timestamp"] for entry in logs] == ["current", "orphan"]
+        assert total == 2
+
+    def test_puts_the_in_memory_ring_ahead_of_every_file_entry(self, log_dir):
+        _write(log_dir / "app.log", [_entry("file")])
+        with log_store._log_lock:
+            log_store._log_buffer.append(_entry("mem-old"))
+            log_store._log_buffer.append(_entry("mem-new"))
+
+        logs, total, _ = log_store._read_logs_from_files(limit=10)
+
+        assert [entry["timestamp"] for entry in logs] == ["mem-new", "mem-old", "file"]
+        assert total == 3
+
+    def test_the_ring_copy_wins_when_a_timestamp_and_message_repeat(self, log_dir):
+        """Dedupe key is ``(timestamp, message)``; the earlier one survives."""
+        _write(log_dir / "app.log", [_entry("t1", level="ERROR", logger="from.file")])
+        with log_store._log_lock:
+            log_store._log_buffer.append(_entry("t1", level="INFO", logger="from.ring"))
+
+        logs, total, _ = log_store._read_logs_from_files(limit=10)
+
+        assert len(logs) == 1
+        assert logs[0]["logger"] == "from.ring"
+        assert total == 1
+
+    def test_dedupe_runs_before_filtering_so_a_shadowed_entry_stays_hidden(self, log_dir):
+        """The ring's DEBUG copy suppresses the file's ERROR copy entirely."""
+        _write(log_dir / "app.log", [_entry("t1", level="ERROR")])
+        with log_store._log_lock:
+            log_store._log_buffer.append(_entry("t1", level="DEBUG"))
+
+        logs, total, has_more = log_store._read_logs_from_files(limit=10, level="ERROR")
+
+        assert (logs, total, has_more) == ([], 0, False)
+
+    def test_skips_blank_and_unparseable_lines(self, log_dir):
+        with open(log_dir / "app.log", "w", encoding="utf-8") as f:
+            f.write(json.dumps(_entry("t1")) + "\n")
+            f.write("\n")
+            f.write("   \n")
+            f.write("not json at all\n")
+            f.write('{"truncated": \n')
+            f.write(json.dumps(_entry("t2")) + "\n")
+
+        logs, total, _ = log_store._read_logs_from_files(limit=10)
+
+        assert [entry["timestamp"] for entry in logs] == ["t2", "t1"]
+        assert total == 2
+
+    def test_tolerates_a_final_line_with_no_trailing_newline(self, log_dir):
+        with open(log_dir / "app.log", "w", encoding="utf-8") as f:
+            f.write(json.dumps(_entry("t1")) + "\n")
+            f.write(json.dumps(_entry("t2")))
+
+        logs, total, _ = log_store._read_logs_from_files(limit=10)
+
+        assert [entry["timestamp"] for entry in logs] == ["t2", "t1"]
+        assert total == 2
+
+    def test_missing_log_directory_reads_as_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(log_store, "LOG_DIR", tmp_path / "nope")
+        with log_store._log_lock:
+            log_store._log_buffer.clear()
+
+        assert log_store._read_logs_from_files(limit=10) == ([], 0, False)
+
+    def test_level_filter_is_case_insensitive_and_exact(self, log_dir):
+        _write(log_dir / "app.log", [_entry("t1", level="INFO"), _entry("t2", level="ERROR")])
+
+        logs, total, has_more = log_store._read_logs_from_files(limit=10, level="error")
+
+        assert [entry["timestamp"] for entry in logs] == ["t2"]
+        assert (total, has_more) == (1, False)
+
+    def test_search_matches_message_or_logger_case_insensitively(self, log_dir):
+        _write(
+            log_dir / "app.log",
+            [
+                _entry("t1", message="Board REFUSED the key"),
+                _entry("t2", logger="src.utils.WEATHER", message="ok"),
+                _entry("t3", message="unrelated"),
+            ],
+        )
+
+        by_message, _, _ = log_store._read_logs_from_files(limit=10, search="refused")
+        by_logger, _, _ = log_store._read_logs_from_files(limit=10, search="weather")
+
+        assert [entry["timestamp"] for entry in by_message] == ["t1"]
+        assert [entry["timestamp"] for entry in by_logger] == ["t2"]
+
+    def test_search_and_level_compose(self, log_dir):
+        _write(
+            log_dir / "app.log",
+            [
+                _entry("t1", level="ERROR", message="board refused"),
+                _entry("t2", level="INFO", message="board refused"),
+                _entry("t3", level="ERROR", message="all good"),
+            ],
+        )
+
+        logs, total, _ = log_store._read_logs_from_files(limit=10, level="ERROR", search="refused")
+
+        assert [entry["timestamp"] for entry in logs] == ["t1"]
+        assert total == 1
+
+    def test_paginates_with_offset_and_reports_has_more(self, log_dir):
+        _write(log_dir / "app.log", [_entry(f"t{i}") for i in range(10)])
+
+        page, _total, has_more = log_store._read_logs_from_files(limit=3, offset=3)
+
+        assert [entry["timestamp"] for entry in page] == ["t6", "t5", "t4"]
+        assert has_more is True
+
+    def test_the_final_page_reports_no_more(self, log_dir):
+        _write(log_dir / "app.log", [_entry(f"t{i}") for i in range(10)])
+
+        page, total, has_more = log_store._read_logs_from_files(limit=4, offset=6)
+
+        assert [entry["timestamp"] for entry in page] == ["t3", "t2", "t1", "t0"]
+        assert (total, has_more) == (10, False)
+
+    def test_an_offset_past_the_end_is_an_empty_page_with_the_true_total(self, log_dir):
+        _write(log_dir / "app.log", [_entry(f"t{i}") for i in range(5)])
+
+        page, total, has_more = log_store._read_logs_from_files(limit=10, offset=500)
+
+        assert (page, total, has_more) == ([], 5, False)
+
+    def test_entries_are_returned_verbatim(self, log_dir):
+        """No reshaping: whatever the JSON line held is what comes back."""
+        weird = {"timestamp": "t1", "message": "m", "extra": {"nested": [1, 2]}}
+        _write(log_dir / "app.log", [weird])
+
+        logs, _, _ = log_store._read_logs_from_files(limit=10)
+
+        assert logs == [weird]
+
+
+class _CountingJson:
+    """A ``json`` stand-in that counts ``loads`` calls."""
+
+    def __init__(self, real):
+        self._real = real
+        self.loads_calls = 0
+
+    def loads(self, *args, **kwargs):
+        self.loads_calls += 1
+        return self._real.loads(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+CORPUS_FILES = 6
+ENTRIES_PER_FILE = 5000
+TOTAL_ENTRIES = CORPUS_FILES * ENTRIES_PER_FILE
+
+
+@pytest.fixture
+def big_corpus(log_dir):
+    """Six rotated files of realistic JSON log lines, newest in ``app.log``."""
+    levels = ("DEBUG", "INFO", "WARNING", "ERROR")
+    for file_index in range(CORPUS_FILES):
+        name = "app.log" if file_index == 0 else f"app.log.{file_index}"
+        # file 0 is newest, so its sequence numbers are the highest.
+        base = (CORPUS_FILES - 1 - file_index) * ENTRIES_PER_FILE
+        with open(log_dir / name, "w", encoding="utf-8") as f:
+            for i in range(ENTRIES_PER_FILE):
+                seq = base + i
+                f.write(
+                    json.dumps(
+                        {
+                            "timestamp": f"2026-09-06T00:00:{seq:06d}Z",
+                            "level": levels[seq % len(levels)],
+                            "logger": "src.displays.service",
+                            "message": f"rendered page {seq} in {seq % 97} ms and sent it to the board",
+                        }
+                    )
+                    + "\n"
+                )
+    return log_dir
+
+
+class TestReadIsBounded:
+    """The reproduction: cost must track the page, not the corpus."""
+
+    def test_a_hundred_row_page_does_not_parse_the_whole_corpus(self, big_corpus, monkeypatch):
+        counter = _CountingJson(json)
+        monkeypatch.setattr(log_store, "json", counter)
+
+        logs, _, has_more = log_store._read_logs_from_files(limit=100, offset=0)
+
+        assert len(logs) == 100
+        assert has_more is True
+        # Old reader: 30000. A page of 100 needs 101 entries plus slack for
+        # blank lines and read-ahead within one chunk.
+        assert counter.loads_calls < 2000, f"parsed {counter.loads_calls} entries for a 100-row page"
+
+    def test_a_hundred_row_page_does_not_open_every_backup(self, big_corpus):
+        opened = []
+        real_open = open
+
+        def tracking_open(file, *args, **kwargs):
+            opened.append(str(file))
+            return real_open(file, *args, **kwargs)
+
+        import builtins
+
+        builtins.open = tracking_open
+        try:
+            log_store._read_logs_from_files(limit=100, offset=0)
+        finally:
+            builtins.open = real_open
+
+        # Old reader opened all six. The newest alone covers a 100-row page.
+        assert len(opened) == 1, opened
+        assert opened[0].endswith("app.log")
+
+    def test_a_hundred_row_page_stays_under_a_few_megabytes(self, big_corpus):
+        tracemalloc.start()
+        try:
+            tracemalloc.reset_peak()
+            logs, _, _ = log_store._read_logs_from_files(limit=100, offset=0)
+            _, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+
+        assert len(logs) == 100
+        # Old reader peaked at 23.5 MB on this corpus (191.6 MB on a full
+        # 33.5 MB one). 4 MB leaves room for one reverse-read chunk.
+        assert peak < 4 * 1024 * 1024, f"peak {peak / 1024 / 1024:.1f} MB for a 100-row page"
+
+    def test_a_deep_offset_still_only_reads_what_it_must(self, big_corpus, monkeypatch):
+        counter = _CountingJson(json)
+        monkeypatch.setattr(log_store, "json", counter)
+
+        logs, _, has_more = log_store._read_logs_from_files(limit=50, offset=1000)
+
+        assert len(logs) == 50
+        assert has_more is True
+        # offset + limit + 1 == 1051 entries are genuinely needed.
+        assert counter.loads_calls < 3000, f"parsed {counter.loads_calls} entries for offset=1000"
+
+    def test_a_filter_that_matches_nothing_still_reports_an_empty_page(self, big_corpus):
+        """Correctness is not traded away: an exhaustive scan still happens
+        when the filter forces one, and it still returns the true total."""
+        logs, total, has_more = log_store._read_logs_from_files(limit=100, search="no such text anywhere")
+
+        assert (logs, total, has_more) == ([], 0, False)
+
+    def test_a_filter_that_matches_a_quarter_of_the_corpus_paginates_correctly(self, big_corpus):
+        logs, _, has_more = log_store._read_logs_from_files(limit=10, level="ERROR")
+
+        assert len(logs) == 10
+        assert has_more is True
+        assert {entry["level"] for entry in logs} == {"ERROR"}
+        # Newest ERROR first, descending.
+        seqs = [int(entry["timestamp"][-7:-1]) for entry in logs]
+        assert seqs == sorted(seqs, reverse=True)
+
+
+class TestTotalIsALowerBoundOnceTheScanStopsEarly:
+    """Deliberate change #1, pinned so it cannot drift back silently."""
+
+    def test_total_is_exact_when_the_scan_reaches_the_end(self, log_dir):
+        _write(log_dir / "app.log", [_entry(f"t{i}") for i in range(40)])
+
+        _, total, has_more = log_store._read_logs_from_files(limit=100)
+
+        assert (total, has_more) == (40, False)
+
+    def test_total_is_a_lower_bound_when_the_page_is_full(self, big_corpus):
+        logs, total, has_more = log_store._read_logs_from_files(limit=100, offset=0)
+
+        assert len(logs) == 100
+        assert has_more is True
+        # Not TOTAL_ENTRIES: the reader stopped one entry past the page.
+        assert total == 101
+        assert total < TOTAL_ENTRIES
+
+
+class TestTheHandlerDoesNotStallTheEventLoop:
+    """``GET /logs`` was a synchronous file read inside an ``async def``.
+
+    1.53 s of blocking on a laptop; roughly 20 s of a wedged event loop at Pi
+    speeds, during which nothing else — no schedule tick, no board send, no
+    other request — makes progress. The read now goes to a worker thread.
+    """
+
+    def test_the_reader_runs_off_the_main_thread(self):
+        import asyncio
+        import threading
+
+        from src.debug import routes
+
+        threads: list[str] = []
+
+        def spy(**kwargs):
+            threads.append(threading.current_thread().name)
+            return ([], 0, False)
+
+        with patch("src.log_store._read_logs_from_files", side_effect=spy):
+            response = asyncio.run(routes.get_logs(limit=10, offset=0, level=None, search=None))
+
+        assert response.total == 0
+        assert threads, "the handler never called the reader"
+        assert threads[0] != threading.main_thread().name, "the reader ran on the event loop thread"


### PR DESCRIPTION
## The bug

`src/log_store.py:_read_logs_from_files` globbed `app.log` plus five 5 MB backups
(`LOG_MAX_BYTES` 5 MB × `LOG_BACKUP_COUNT` 5), `readlines()`-ed each in full,
`json.loads`-ed every line into one merged list **plus** a `seen` set holding a
`(timestamp, message)` tuple for the entire corpus, and only *then* sliced
`[offset:offset + limit]`. Complexity was O(total bytes on disk) for a request
that returns one page.

Second defect, same endpoint: `src/debug/routes.py:499` called that synchronous
read inline inside an `async def`, so the whole read blocked the single event
loop — no schedule tick, no board send, no other request made progress meanwhile.

A Pi 3B+ has 1 GB shared with the GPU, minus OS and nginx. One `GET /logs` was
enough to OOM-kill the container.

## Measured, 100 rows out of a full rotated log set

30.0 MB across 6 files, 191,156 entries (`GET /logs?limit=100&offset=0`):

| | before | after |
| --- | ---: | ---: |
| wall clock | 3.25 s | 0.00 s |
| entries parsed (`json.loads` calls) | 191,156 | **101** |
| log files opened | 6 | **1** |
| `tracemalloc` peak allocated | 148.2 MB | **0.3 MB** |
| process RSS delta | +406.5 MB | **+0.7 MB** |

Same harness, same corpus, `src/log_store.py` swapped between `origin/next` and
this branch. (The brief's 33.5 MB / 177,720-entry / 191.6 MB figures come from a
corpus with slightly longer lines; same shape, same conclusion.)

## What changed

**`src/log_store.py`**

- `_iter_lines_reversed(path)` — reverse-reads a file in 64 KB chunks and yields
  lines newest-first, as `bytes`. The equivalent of `reversed(f.readlines())`
  without the `readlines()`: a caller that stops after a page never reads the
  rest of the file.
- `_iter_entries_newest_first()` — one generator over the in-memory ring
  (newest first), then `app.log`, then `app.log.1 .. app.log.5`. Files are
  opened **lazily**, so a page that fits in `app.log` never touches a backup.
- `_read_logs_from_files` consumes that stream, dedupes, filters, keeps at most
  `limit` entries, and **breaks one entry past `offset + limit`**. Memory is
  O(limit); work is O(offset + limit).
- The `seen` set is bounded to a 4096-key sliding window (a `set` for lookups
  plus a `deque` for eviction) instead of growing to the corpus.

**`src/debug/routes.py`**

- `GET /logs` now `await asyncio.to_thread(log_store._read_logs_from_files, ...)`,
  matching the pattern at `src/pages/routes.py:636` and `src/settings/routes.py:669`.
  Kwargs are passed through unchanged, so `patch("src.log_store._read_logs_from_files")`
  and its `call_args.kwargs` assertions in `tests/test_debug_contract.py` still hold.

## What provably did not change

`tests/test_log_store_pagination.py::TestReadContract` is 19 value-level goldens
written and run against the **unmodified** tree first — ordering (ring before
files; `app.log` before its backups; newest-first within each file), the
dedupe key and which copy survives, dedupe-runs-before-filtering, blank and
unparseable lines, a final line with no trailing newline, a missing log
directory, case-insensitive level and search, search over message *or* logger,
composed filters, `offset` past the end, and entries returned verbatim.

Baseline run on `origin/next` (before any source edit):

```
tests/test_log_store_pagination.py ................FFFF...F              [100%]
========================= 5 failed, 19 passed in 1.44s =========================
```

All 19 pass unchanged after the rewrite. That is the zero-regression evidence.

## What deliberately changed

Each is pinned by a test that names it, and called out in the test module's
docstring.

1. **`total` is a lower bound once the scan stops early.** The reader can no
   longer count a corpus it deliberately did not read. It stays *exact* whenever
   the stream is exhausted — every small deployment, and every filter that
   matches less than a full page. `has_more` is exact in **all** cases (the scan
   always goes one entry past the page) and remains the authoritative
   "is there another page" signal.
   Pinned by `TestTotalIsALowerBoundOnceTheScanStopsEarly`.
2. **The `seen` set is a window, not the corpus.** Duplicates cannot be far
   apart in the newest-first stream: rotation writes each line to exactly one
   file, so the only colliding pairs are an entry in the 500-slot in-memory
   ring and its copy among the newest lines of `app.log` — at most ~1000
   positions apart. The window is 4096, an 8x margin. Two entries sharing a
   `(timestamp, message)` from opposite ends of a 30 MB corpus are now both
   returned; that pairing requires identical timestamps hours apart.
3. **A line that is not valid UTF-8 now skips that line**, where it used to
   raise out of `readlines()` and silently discard the whole file. Reverse
   reading has already yielded the newer entries by the time it reaches the bad
   byte, so per-line is the only available granularity — and it is the better one.

## The bound tests fail without the fix

Against `origin/next`'s reader, on the corpus the tests build
(6 files × 5,000 entries):

```
E   AssertionError: parsed 30000 entries for a 100-row page
E   assert 30000 < 2000
E   AssertionError: ['.../logs/app.log', ..., '.../logs/app.log.5']
E   assert 6 == 1
E   AssertionError: peak 23.5 MB for a 100-row page
E   assert 24653548 < ((4 * 1024) * 1024)
E   AssertionError: parsed 30000 entries for offset=1000
E   assert 30000 < 3000
E   assert 30000 == 101
```

Non-vacuity re-checked against the **new** code by sabotage:

- Removing the `break` (early exit) → 4 of those 5 fail again (`30000 < 2000`,
  `6 == 1`, `30000 < 3000`, `30000 == 101`). The `tracemalloc` bound still
  passes without it, honestly: streaming alone fixes the memory half.
- Reverting `asyncio.to_thread` to the inline call →
  `TestTheHandlerDoesNotStallTheEventLoop::test_the_reader_runs_off_the_main_thread`
  fails with `AssertionError: the reader ran on the event loop thread /
  assert 'MainThread' != 'MainThread'`.

## Suite

Full suite, `docker run --rm -m 3g ... fb-test:latest python -m pytest tests/ -q`,
with `.pytest-data` mounted over the image's `VOLUME /app/data`:

| | result |
| --- | --- |
| `origin/next` (this branch's src reverted, new test file removed) | **1 failed, 6610 passed, 2 skipped** in 151.66s |
| this branch | **1 failed, 6635 passed, 2 skipped** in 154.99s |

A strict superset: +25 passing (the new file), and `comm -13` over the sorted
`FAILED` lines of both runs is empty — no new failure.

The one failure is identical in both runs and environmental, not a regression:
`tests/test_check_image_formats.py::TestRepositoryIsClean::test_no_tracked_file_in_this_repo_reaches_a_vulnerable_parser`
shells out to `git ls-files`, which exits 128 inside the container because this
is a **git worktree** whose `.git` file points outside the mount.

**Data-dir leak count: 0** (`find .pytest-data -mindepth 1 | wc -l` → `0`) after
both runs.

## Lint

`ruff==0.16.5`, `ruff check` + `ruff format --check` over `src plugins tests scripts`:
`All checks passed!` / `453 files already formatted`.
