### PR TITLE
feat(api): the consumer-facing /v1 surface — 31 operations, one front door

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -447,6 +447,9 @@ Off by default: a fresh install answers every request. With
 # first-appearance-in-the-paths-object order, which opened on MQTT and put
 # `pages` fourteenth, below `debug`.
 OPENAPI_TAGS = [
+    # `/v1` is deliberately absent: it is prepended by src/v1/openapi.py, which
+    # owns its own description and has to run after this module is importable.
+    # Swagger renders tags in schema order, so the consumer surface still leads.
     {"name": "service", "description": "The display loop itself: health, status, start/stop/refresh."},
     {"name": "board", "description": "Write to a board out of band, and read back what is physically on it."},
     {"name": "pages", "description": "Pages — the unit of content. CRUD, preview, send, import/export."},

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -2115,6 +2115,14 @@ from .backup.routes import router as backup_router  # noqa: E402
 
 app.include_router(backup_router)
 
+# The consumer-facing API. Mounted last, and imported here rather than at the
+# top of the module, because src/v1 imports the domain routers it adapts —
+# every one of which this module has already imported by now. src/v1 owns its
+# own routes, its tag metadata and the securitySchemes declaration.
+from .v1 import mount_v1  # noqa: E402
+
+mount_v1(app)
+
 
 if __name__ == "__main__":
     import uvicorn

--- a/src/auth/middleware.py
+++ b/src/auth/middleware.py
@@ -9,14 +9,17 @@ Public paths (no auth required):
     * ``/openapi.json``, ``/docs``, ``/redoc`` — API docs (still useful)
     * CORS preflight (``OPTIONS``) requests
 
-MCP endpoint (``/mcp/*``):
-    If an MCP token is configured (``FIESTABOARD_MCP_TOKEN`` or the value
+Bearer-token paths (``/mcp/*`` and ``/v1/*``):
+    If an API token is configured (``FIESTABOARD_MCP_TOKEN`` or the value
     stored via Settings), the MCP endpoint requires an
     ``Authorization: Bearer <token>`` header instead of the session
     cookie. This lets external MCP clients (Claude Desktop, Claude Code)
-    connect without needing to drive a browser login flow. A 401 from
-    this endpoint includes ``WWW-Authenticate: Bearer`` so the client
-    knows to send a pre-shared token rather than attempting OAuth.
+    connect — and lets any script drive ``/v1`` — without needing to
+    drive a browser login flow. A 401 from the MCP endpoint includes
+    ``WWW-Authenticate: Bearer`` so the client knows to send a pre-shared
+    token rather than attempting OAuth. On ``/v1`` a request with no
+    Authorization header falls through to the ordinary session-cookie
+    check instead, so a token does not lock the browser out.
 
     That check runs in **every** auth mode, ``disabled`` included — a
     configured token is a credential the operator asked for, not a
@@ -80,6 +83,27 @@ def _is_mcp_path(path: str) -> bool:
     return path == "/mcp" or path.startswith(("/mcp/", "/api/mcp/")) or path == "/api/mcp"
 
 
+def _is_v1_path(path: str) -> bool:
+    """True for the consumer-facing ``/v1`` surface.
+
+    The same nginx double-regime as MCP: usually the ``/api`` prefix is
+    stripped before we see it, but a path arriving with the prefix intact
+    must resolve identically.
+    """
+    return path == "/v1" or path.startswith(("/v1/", "/api/v1/")) or path == "/api/v1"
+
+
+def _accepts_bearer(path: str) -> bool:
+    """Paths on which an ``Authorization: Bearer`` token is a valid credential.
+
+    Bearer acceptance used to stop at ``/mcp*``, which is the mechanical
+    reason a script could not authenticate against the REST API at all: the
+    token existed, ``verify_mcp_bearer`` existed, and no HTTP path would take
+    it. ``/v1`` is the surface a script is meant to use, so it takes it too.
+    """
+    return _is_mcp_path(path) or _is_v1_path(path)
+
+
 def _bearer_from(request: Request) -> str | None:
     """Pull the token from an ``Authorization: Bearer <token>`` header."""
     header = request.headers.get("authorization", "")
@@ -133,16 +157,22 @@ class AuthMiddleware(BaseHTTPMiddleware):
         # When no token is configured there is nothing to enforce, so we
         # fall through: auth-disabled installs stay open and cookie-auth
         # installs keep using the session cookie.
-        if _is_mcp_path(path) and mcp_token() is not None:
+        if _accepts_bearer(path) and mcp_token() is not None:
             supplied = _bearer_from(request)
-            # No Authorization header, or a bad one -> challenge. We skip
-            # the session-cookie fallback because Claude/etc. will never
-            # have a cookie, and a 401 with WWW-Authenticate is exactly
-            # the signal such a client needs.
-            if supplied is None or not verify_mcp_bearer(supplied):
+            if supplied is not None:
+                if not verify_mcp_bearer(supplied):
+                    return _mcp_unauthorized()
+                request.scope["auth_user"] = "mcp-client" if _is_mcp_path(path) else "api-token"
+                return await call_next(request)
+            # A bearer path with no Authorization header. On /mcp that is a
+            # challenge — Claude/etc. will never have a cookie, and a 401
+            # with WWW-Authenticate is exactly the signal such a client
+            # needs. On /v1 it falls through to the ordinary cookie check
+            # instead, because the browser is a legitimate v1 caller once
+            # the web UI migrates onto it (Wave 2), and refusing a valid
+            # session there would be a regression the token merely enables.
+            if _is_mcp_path(path):
                 return _mcp_unauthorized()
-            request.scope["auth_user"] = "mcp-client"
-            return await call_next(request)
 
         if mode == "disabled":
             return await call_next(request)

--- a/src/displays/messages.py
+++ b/src/displays/messages.py
@@ -29,10 +29,16 @@ def render_message(
     strategy: str,
     step_interval_ms: int,
     step_size: int,
+    force: bool = False,
 ) -> tuple[bool, bool]:
     """Wrap ``text`` to a ``rows``×``cols`` grid and render it through ``client``.
 
     Returns the client's ``(success, was_sent)`` pair unchanged.
+
+    ``force`` bypasses the client's unchanged-content dedupe, so an identical
+    message is re-flapped rather than skipped. It defaults to False — the
+    behavior every caller had before ``POST /v1/boards/{board}/message``
+    needed to expose it.
     """
     wrapped = wrap_message_text(text, rows=rows, cols=cols)
     board_array = text_to_board_array(wrapped, rows=rows, cols=cols)
@@ -41,4 +47,5 @@ def render_message(
         strategy=strategy,
         step_interval_ms=step_interval_ms,
         step_size=step_size,
+        force=force,
     )

--- a/src/ops/executors.py
+++ b/src/ops/executors.py
@@ -322,7 +322,153 @@ async def set_active_page(page_id: str, board_id: str | None = None) -> dict[str
     )
 
 
-def send_message(text: str, board_id: str | None = None) -> dict[str, Any]:
+class _SendTarget:
+    """The collaborators one board write needs, resolved once.
+
+    Built by :func:`_resolve_send_target`, which is the gate sequence
+    ``POST /send-message`` performs before it touches a board. Factored out
+    of :func:`send_message` so :func:`send_characters` cannot drift from it:
+    the two operations differ only in what grid they hand the client.
+    """
+
+    __slots__ = ("board", "board_id", "client", "primary_id", "service", "settings_service")
+
+    def __init__(self, service, client, board, board_id, primary_id, settings_service) -> None:
+        self.service = service
+        self.client = client
+        self.board = board
+        self.board_id = board_id
+        self.primary_id = primary_id
+        self.settings_service = settings_service
+
+
+def _resolve_send_target(board_id: str | None) -> tuple[_SendTarget | None, dict[str, Any] | None]:
+    """``(target, refusal)`` — exactly one of the two is not ``None``.
+
+    The refusal is already an executor envelope: an ``err`` for a missing
+    collaborator, or a ``status: "blocked"`` result for the silence window
+    (#1788) and a paused board (#970). Blocked is deliberately not an error —
+    it is policy, and a model relaying it should not retry.
+    """
+    # get_service is the DisplayService singleton accessor — api_server
+    # owns it, but this is the same seam get_system_status and
+    # set_active_page already use; no REST handler is called.
+    from src.api_server import get_service
+    from src.config import Config
+    from src.settings.service import get_settings_service
+
+    service = get_service()
+    if not service:
+        return None, err("Display service not initialized.")
+
+    settings_service = get_settings_service()
+    primary_id = settings_service.get_primary_board_id()
+    board: dict[str, Any] | None = None
+    if board_id is not None:
+        boards = settings_service.get_board_settings().boards or []
+        board = next((b for b in boards if isinstance(b, dict) and b.get("id") == board_id), None)
+        if board is None:
+            return None, err(f"Board not found: {board_id}")
+
+    # Silence gate (#1788): resolve the *target* board's window; omitted
+    # board_id resolves the primary, exactly like the REST handler.
+    if Config.is_silence_mode_active(board_id if board_id is not None else primary_id):
+        return None, {
+            "status": "blocked",
+            "message": "Manual sends blocked during silence mode to prevent wake-ups",
+            "silence_mode": True,
+            "board_id": board_id,
+        }
+
+    # Pause gate (#970): a paused board is left untouched.
+    if settings_service.is_paused(board_id=board_id) is True:
+        return None, {
+            "status": "blocked",
+            "message": "Board is paused — sends are blocked until it is resumed.",
+            "paused": True,
+            "board_id": board_id,
+        }
+
+    client = service.get_board_client(board_id) if board_id is not None else service.vb_client
+    if not client:
+        return None, err(
+            f"Board client not initialized: {board_id}" if board_id is not None else "Board client not initialized."
+        )
+
+    # Size the grid to the target board (the REST handler's active-first-
+    # board sizing when board_id is omitted).
+    if board is None:
+        board_settings = settings_service.get_board_settings()
+        board = board_settings.boards[0] if board_settings.boards else {}
+
+    return _SendTarget(service, client, board, board_id, primary_id, settings_service), None
+
+
+def _target_dimensions(target: _SendTarget):
+    """Rows/cols of the board this send targets."""
+    from src.devices import resolve_dimensions
+
+    return resolve_dimensions(
+        target.board.get("device_type") or "flagship",
+        target.board.get("notes_wide") or 1,
+        target.board.get("notes_tall") or 1,
+    )
+
+
+def _transition_for(target: _SendTarget, strategy, step_interval_ms, step_size):
+    """Per-call transition overrides, falling back to the stored settings.
+
+    ``None`` means "use what the install is configured for" — the behavior
+    every caller had before the overrides existed.
+    """
+    stored = target.settings_service.get_transition_settings()
+    return (
+        stored.strategy if strategy is None else strategy,
+        stored.step_interval_ms if step_interval_ms is None else step_interval_ms,
+        stored.step_size if step_size is None else step_size,
+    )
+
+
+def _after_send(target: _SendTarget) -> None:
+    """Out-of-band bookkeeping every manual write owes the rest of the app.
+
+    The board now shows content the display loop didn't put there
+    (#1794/#1831): mark it, push fresh MQTT state so Home Assistant agrees,
+    and ask for an adaptive refresh. The dedupe cache is deliberately left
+    alone so the message survives the next engine tick.
+    """
+    try:
+        target.service.mark_showing_out_of_band(target.board_id)
+    except Exception as exc:
+        logger.debug("Out-of-band mark after send failed: %s", exc)
+    try:
+        from src.mqtt import get_mqtt_client
+
+        mqtt_client = get_mqtt_client()
+        publisher = getattr(mqtt_client, "_state_publisher", None) if mqtt_client else None
+        if publisher is not None:
+            publisher.mark_display_updated()
+            publisher.gather_and_publish()
+    except Exception as exc:
+        logger.debug("MQTT state publish after send failed: %s", exc)
+    # Adaptive post-send refresh is primary-only (board-state polling
+    # tracks only the primary board — issue #1243).
+    if target.board_id is None or target.board_id == target.primary_id:
+        try:
+            target.service.request_board_refresh()
+        except Exception as exc:
+            logger.debug("Board refresh after send failed: %s", exc)
+
+
+def send_message(
+    text: str,
+    board_id: str | None = None,
+    *,
+    strategy: str | None = None,
+    step_interval_ms: int | None = None,
+    step_size: int | None = None,
+    force: bool = False,
+) -> dict[str, Any]:
     """Send an ad-hoc text message straight to a board (issue #1765).
 
     Mirrors ``POST /send-message`` gate for gate — silence (#1788), pause
@@ -335,109 +481,93 @@ def send_message(text: str, board_id: str | None = None) -> dict[str, Any]:
     Silence and pause come back as ``status: "blocked"`` results, not
     errors — they are deliberate policy, and the model should relay them
     rather than retry.
+
+    The keyword-only arguments are pass-throughs for the ``/v1`` front door
+    (``POST /v1/boards/{board}/message``): a per-request transition, and
+    ``force`` to bypass the client's unchanged-content dedupe. Every one of
+    them defaults to the behavior this executor had before they existed —
+    the stored transition settings, and no forcing.
     """
     try:
-        # get_service is the DisplayService singleton accessor — api_server
-        # owns it, but this is the same seam get_system_status and
-        # set_active_page already use; no REST handler is called.
-        from src.api_server import get_service
-        from src.config import Config
-        from src.devices import resolve_dimensions
         from src.displays.messages import render_message
-        from src.settings.service import get_settings_service
 
-        service = get_service()
-        if not service:
-            return err("Display service not initialized.")
+        target, refusal = _resolve_send_target(board_id)
+        if refusal is not None:
+            return refusal
+        assert target is not None
 
-        settings_service = get_settings_service()
-        primary_id = settings_service.get_primary_board_id()
-        board: dict[str, Any] | None = None
-        if board_id is not None:
-            boards = settings_service.get_board_settings().boards or []
-            board = next((b for b in boards if isinstance(b, dict) and b.get("id") == board_id), None)
-            if board is None:
-                return err(f"Board not found: {board_id}")
-
-        # Silence gate (#1788): resolve the *target* board's window; omitted
-        # board_id resolves the primary, exactly like the REST handler.
-        if Config.is_silence_mode_active(board_id if board_id is not None else primary_id):
-            return {
-                "status": "blocked",
-                "message": "Manual sends blocked during silence mode to prevent wake-ups",
-                "silence_mode": True,
-                "board_id": board_id,
-            }
-
-        # Pause gate (#970): a paused board is left untouched.
-        if settings_service.is_paused(board_id=board_id) is True:
-            return {
-                "status": "blocked",
-                "message": "Board is paused — sends are blocked until it is resumed.",
-                "paused": True,
-                "board_id": board_id,
-            }
-
-        client = service.get_board_client(board_id) if board_id is not None else service.vb_client
-        if not client:
-            return err(
-                f"Board client not initialized: {board_id}" if board_id is not None else "Board client not initialized."
-            )
-
-        # Size the grid to the target board (the REST handler's active-first-
-        # board sizing when board_id is omitted).
-        if board is None:
-            board_settings = settings_service.get_board_settings()
-            board = board_settings.boards[0] if board_settings.boards else {}
-        dims = resolve_dimensions(
-            board.get("device_type") or "flagship",
-            board.get("notes_wide") or 1,
-            board.get("notes_tall") or 1,
+        dims = _target_dimensions(target)
+        resolved_strategy, resolved_interval, resolved_step = _transition_for(
+            target, strategy, step_interval_ms, step_size
         )
-
-        transition = settings_service.get_transition_settings()
         success, was_sent = render_message(
-            client,
+            target.client,
             text,
             rows=dims.rows,
             cols=dims.cols,
-            strategy=transition.strategy,
-            step_interval_ms=transition.step_interval_ms,
-            step_size=transition.step_size,
+            strategy=resolved_strategy,
+            step_interval_ms=resolved_interval,
+            step_size=resolved_step,
+            force=force,
         )
         if not success:
             return err("Failed to send message to the board.")
         if not was_sent:
             return ok("Message unchanged, no update needed.", skipped=True, board_id=board_id)
 
-        # Out-of-band bookkeeping (#1794/#1831): the board now shows content
-        # the display loop didn't put there. The dedupe cache is deliberately
-        # left alone so the message survives the next engine tick.
-        try:
-            service.mark_showing_out_of_band(board_id)
-        except Exception as exc:
-            logger.debug("Out-of-band mark after MCP send failed: %s", exc)
-        try:
-            from src.mqtt import get_mqtt_client
-
-            mqtt_client = get_mqtt_client()
-            publisher = getattr(mqtt_client, "_state_publisher", None) if mqtt_client else None
-            if publisher is not None:
-                publisher.mark_display_updated()
-                publisher.gather_and_publish()
-        except Exception as exc:
-            logger.debug("MQTT state publish after MCP send failed: %s", exc)
-        # Adaptive post-send refresh is primary-only (board-state polling
-        # tracks only the primary board — issue #1243).
-        if board_id is None or board_id == primary_id:
-            try:
-                service.request_board_refresh()
-            except Exception as exc:
-                logger.debug("Board refresh after MCP send failed: %s", exc)
-
+        _after_send(target)
         return ok("Message sent successfully.", board_id=board_id)
     except Exception as exc:
         return err(f"Error sending message: {exc}")
+
+
+def send_characters(
+    characters: list[list[int]],
+    board_id: str | None = None,
+    *,
+    strategy: str | None = None,
+    step_interval_ms: int | None = None,
+    step_size: int | None = None,
+    force: bool = False,
+) -> dict[str, Any]:
+    """Send an already-built flap grid to a board.
+
+    The raw-grid sibling of :func:`send_message`: same gate sequence, same
+    bookkeeping, no text layout. It backs the ``characters``, ``fill`` and
+    ``page_id`` forms of ``POST /v1/boards/{board}/message``, which arrive as
+    a grid rather than as a string, so those forms cannot acquire a different
+    silence/pause/refresh story from the text form.
+
+    ``characters`` is trusted to be the right shape for the target board —
+    validating it is the caller's job, because the caller knows whether a
+    mismatch is a client error (a supplied grid) or a server one (a page that
+    rendered wrong).
+    """
+    try:
+        target, refusal = _resolve_send_target(board_id)
+        if refusal is not None:
+            return refusal
+        assert target is not None
+
+        resolved_strategy, resolved_interval, resolved_step = _transition_for(
+            target, strategy, step_interval_ms, step_size
+        )
+        success, was_sent = target.client.render(
+            characters,
+            strategy=resolved_strategy,
+            step_interval_ms=resolved_interval,
+            step_size=resolved_step,
+            force=force,
+        )
+        if not success:
+            return err("Failed to send characters to the board.")
+        if not was_sent:
+            return ok("Board content unchanged, no update needed.", skipped=True, board_id=board_id)
+
+        _after_send(target)
+        return ok("Characters sent successfully.", board_id=board_id)
+    except Exception as exc:
+        return err(f"Error sending characters: {exc}")
 
 
 # ---------------------------------------------------------------------------

--- a/src/v1/__init__.py
+++ b/src/v1/__init__.py
@@ -1,0 +1,38 @@
+"""The consumer-facing FiestaBoard API.
+
+`/v1` is the surface a script, an integration or a person with `curl` is
+meant to use. The rest of the HTTP surface is the web UI's private RPC
+channel — 179 of the 199 published operations have no caller outside
+`web/src`, and the two the published docs recommend have no caller at all.
+This package is the answer to "how do I put text on my board" being a
+sixteen-way choice with no ranking.
+
+Thirty-one operations over four nouns — board, page, schedule, plugin — every
+one of them an adapter over a handler, service or executor that already
+exists. It adds exactly one concept: `{board}` accepts the literal `primary`,
+so a single-board owner never learns that boards have ids, and a multi-board
+owner can finally address board 2 over HTTP at all.
+
+Mounting
+--------
+`src.api_server` calls :func:`mount_v1`, which includes the router *and*
+declares the API's security scheme. The declaration has to happen here rather
+than on the routes because authentication is enforced in ASGI middleware
+(:mod:`src.auth.middleware`), which FastAPI cannot see — without this the
+published schema tells every consumer the API is unauthenticated.
+"""
+
+from __future__ import annotations
+
+from . import routes_boards, routes_content, routes_meta, routes_plugins
+from .openapi import install_security_scheme
+from .router import router
+
+
+def mount_v1(app) -> None:
+    """Attach the v1 surface to *app*: its routes and its security scheme."""
+    app.include_router(router)
+    install_security_scheme(app)
+
+
+__all__ = ["install_security_scheme", "mount_v1", "router"]

--- a/src/v1/boards.py
+++ b/src/v1/boards.py
@@ -1,0 +1,51 @@
+"""Board addressing for the ``/v1`` surface.
+
+The one concept v1 adds over the internal API: ``{board}`` accepts either a
+board id **or** the literal ``primary``. A single-board owner never has to
+learn that boards have ids, and a multi-board owner never has to guess which
+one an id-less endpoint meant — the internal surface's oldest ergonomic
+defect (``POST /send-message`` has no ``board_id`` at all, so board 2 is
+unreachable over HTTP today).
+
+Nothing here is new domain logic: ``primary`` resolves through
+``SettingsService.get_primary_board_id()`` and every id resolves through
+``src.board_guards._require_board``, which is the single place in the
+codebase that makes the "unknown board" verdict.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException
+
+from src.board_guards import _board_dims, _require_board, get_settings_service
+
+#: The alias every v1 board path accepts in place of a real board id.
+PRIMARY_ALIAS = "primary"
+
+
+def resolve_board_id(board: str) -> str:
+    """Turn a ``{board}`` path segment into a concrete board id.
+
+    ``primary`` resolves to the install's primary board; anything else is
+    taken as a board id and validated. Raises 404 for an unknown id and 404
+    for ``primary`` on an install with no board configured yet — a caller
+    that cannot address any board gets the same verdict either way.
+    """
+    if board == PRIMARY_ALIAS:
+        primary_id = get_settings_service().get_primary_board_id()
+        if not primary_id:
+            raise HTTPException(status_code=404, detail="No board is configured on this install.")
+        return primary_id
+    _require_board(board)
+    return board
+
+
+def resolve_board(board: str) -> tuple[str, dict]:
+    """``(board_id, board_entry)`` for a ``{board}`` path segment."""
+    board_id = resolve_board_id(board)
+    return board_id, _require_board(board_id)
+
+
+def board_dimensions(board_entry: dict):
+    """Resolved ``rows``/``cols`` for a board entry (never raises)."""
+    return _board_dims(board_entry)

--- a/src/v1/models.py
+++ b/src/v1/models.py
@@ -1,0 +1,333 @@
+"""Wire models unique to the ``/v1`` surface.
+
+v1 is an adapter, so most of it reuses the models the domains already
+publish — ``Page``, ``ScheduleEntry``/``ScheduleResponse``, ``Collection``,
+``PluginDetail``, ``TemplateRenderResponse``, ``HealthResponse``,
+``StatusResponse``. What lives here is only the genuinely new shapes: the
+merged board view, the one message body that replaced five write endpoints,
+and the two merged catalogues.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field, StrictBool, StrictInt, model_validator
+
+#: Highest valid flap code. 0-71 covers blank, the alphabet, digits,
+#: punctuation and the eight colour tiles.
+MAX_CHARACTER_CODE = 71
+
+#: One flap. ``StrictInt`` because ``isinstance(True, int)`` is true, and a
+#: JSON ``true`` silently filling a board with code 1 is exactly the hole the
+#: debug endpoint's hand-rolled check left open (#1887 review).
+FlapCode = Annotated[StrictInt, Field(ge=0, le=MAX_CHARACTER_CODE)]
+
+#: Revert behaviour when a timed message expires, mirroring
+#: ``VALID_REVERT_MODES`` in :mod:`src.settings.service`.
+RevertMode = Literal["schedule", "page", "blank"]
+
+
+class BoardSummary(BaseModel):
+    """One board, as a consumer needs to see it.
+
+    A deliberate projection, not the stored entry: ``GET /settings/board``
+    serves connection credentials (masked) and per-tile wiring, none of which
+    a consumer writing to a board has any use for.
+    """
+
+    id: str = Field(description="The board's stable id. Usable anywhere {board} appears in a v1 path.")
+    name: str = Field(description="Human-readable board name, as set in Settings.")
+    device_type: str = Field(description='Board hardware: "flagship", "note", or "note_array".')
+    rows: int = Field(description="Grid height in flaps.")
+    cols: int = Field(description="Grid width in flaps.")
+    is_primary: bool = Field(description='True for the board that the alias "primary" resolves to.')
+    paused: bool = Field(description="While true, FiestaBoard writes nothing to this board from any code path.")
+    schedule_enabled: bool = Field(description="Whether this board follows its schedule rather than a fixed page.")
+
+
+class BoardListResponse(BaseModel):
+    """``GET /v1/boards``."""
+
+    boards: list[BoardSummary]
+    total: int
+
+
+class BoardDetail(BoardSummary):
+    """One board plus what is on it right now.
+
+    The merge named in the design: ``GET /board/current-message`` (what the
+    flaps show), ``GET /settings/active-page`` (the sticky manual selection)
+    and ``GET /schedules/active/page`` (what the schedule says) answered as
+    one document, because "what is this board doing" is one question.
+    """
+
+    characters: list[list[int]] | None = Field(
+        default=None,
+        description="The flap codes currently on the board, or null if nothing has been sent to it yet.",
+    )
+    text: str | None = Field(
+        default=None,
+        description="``characters`` decoded back to text, for reading. Null when ``characters`` is null.",
+    )
+    read_at: str | None = Field(
+        default=None,
+        description="When ``characters`` was read from the board (ISO 8601). Null for a live read.",
+    )
+    active_page_id: str | None = Field(
+        default=None,
+        description="The page or collection pinned to this board by hand, if any.",
+    )
+    scheduled_page_id: str | None = Field(
+        default=None,
+        description="The page the schedule selects for right now. Null when scheduling is off or nothing matches.",
+    )
+    resolved_page_id: str | None = Field(
+        default=None,
+        description="The page actually being displayed, with any collection resolved to a member page.",
+    )
+    source: Literal["manual", "schedule", "none"] = Field(
+        description="Where ``resolved_page_id`` came from.",
+    )
+    default_page_id: str | None = Field(
+        default=None,
+        description="The page shown when the schedule has a gap.",
+    )
+    override_expires_at: str | None = Field(
+        default=None,
+        description="When the active timed message expires (ISO 8601), or null if none is running.",
+    )
+
+
+class BoardUpdate(BaseModel):
+    """``PATCH /v1/boards/{board}`` — every field optional, only what you send is applied."""
+
+    name: str | None = Field(default=None, min_length=1, max_length=100, description="Rename the board.")
+    paused: StrictBool | None = Field(
+        default=None,
+        description="Pause or resume the board. While paused nothing is written to it from any code path.",
+    )
+    schedule_enabled: StrictBool | None = Field(
+        default=None,
+        description="Turn this board's schedule on or off.",
+    )
+    default_page_id: str | None = Field(
+        default=None,
+        description="Page shown when the schedule has a gap. Send null to clear it.",
+    )
+
+
+class TransitionOverride(BaseModel):
+    """Per-send transition animation, overriding the install's settings."""
+
+    strategy: str | None = Field(default=None, description='Transition strategy name, e.g. "instant" or "wipe".')
+    interval_ms: int | None = Field(default=None, ge=0, le=5000, description="Milliseconds between animation steps.")
+    step_size: int | None = Field(default=None, ge=1, description="Flaps advanced per animation step.")
+
+
+class MessageRequest(BaseModel):
+    """``POST /v1/boards/{board}/message`` — the front door.
+
+    Exactly one of ``text``, ``lines``, ``characters``, ``page_id`` or
+    ``fill`` says *what* to show. Everything else says how long and how.
+    """
+
+    text: str | None = Field(
+        default=None,
+        description="Plain text, word-wrapped to the board. Colour and character markers ({red}, {63}) work here.",
+    )
+    lines: list[str] | None = Field(
+        default=None,
+        description="One string per board row, laid out without re-wrapping across rows.",
+    )
+    characters: list[list[FlapCode]] | None = Field(
+        default=None,
+        description="A raw flap grid, sized exactly to the board. Codes are 0-71.",
+    )
+    page_id: str | None = Field(
+        default=None,
+        description="Render a saved page (or collection) and send the result.",
+    )
+    fill: FlapCode | None = Field(
+        default=None,
+        description="Fill the whole board with one flap code (0-71). 0 blanks it.",
+    )
+
+    duration_minutes: int | None = Field(
+        default=None,
+        ge=1,
+        le=480,
+        description=(
+            "Show this for N minutes, then revert. Omit for a message that stays until something else replaces it."
+        ),
+    )
+    revert_mode: RevertMode | None = Field(
+        default=None,
+        description='What to show when a timed message expires. Requires duration_minutes. Defaults to "schedule".',
+    )
+    revert_page_id: str | None = Field(
+        default=None,
+        description='The page to revert to. Required when revert_mode is "page".',
+    )
+    transition: TransitionOverride | None = Field(
+        default=None,
+        description="Override the install's transition animation for this one send.",
+    )
+    force: StrictBool = Field(
+        default=False,
+        description="Send even when the board already shows this exact content, which is normally skipped.",
+    )
+
+    @model_validator(mode="after")
+    def _exactly_one_content_field(self) -> MessageRequest:
+        supplied = [
+            name
+            for name, value in (
+                ("text", self.text),
+                ("lines", self.lines),
+                ("characters", self.characters),
+                ("page_id", self.page_id),
+                ("fill", self.fill),
+            )
+            if value is not None
+        ]
+        if len(supplied) != 1:
+            raise ValueError(
+                "Supply exactly one of text, lines, characters, page_id or fill "
+                f"(got {', '.join(supplied) if supplied else 'none'})"
+            )
+        return self
+
+
+class MessageResponse(BaseModel):
+    """What a v1 board write actually did.
+
+    ``sent`` is the honest answer, not an acknowledgement: it is false when
+    the install's output target is UI-only, when the board already showed
+    this exact content, and when a timed message was queued for the display
+    loop rather than written on the spot. ``reason`` names which.
+    """
+
+    sent: bool = Field(description="True only when flaps were written to the physical board by this request.")
+    board_id: str = Field(description="The board this went to, with the 'primary' alias already resolved.")
+    characters: list[list[int]] = Field(description="The flap grid this request produced, sent or not.")
+    text: str = Field(description="``characters`` decoded back to text, for logs and confirmations.")
+    expires_at: str | None = Field(
+        default=None,
+        description="When a timed message reverts (ISO 8601). Null for a message with no duration.",
+    )
+    reason: str | None = Field(
+        default=None,
+        description="Why nothing was written, when sent is false. Null when sent is true.",
+    )
+
+
+class ActivePageRequest(BaseModel):
+    """``PUT /v1/boards/{board}/active-page``."""
+
+    page_id: str | None = Field(
+        description="Page or collection to pin to this board. Send null to unpin and fall back to the schedule.",
+    )
+
+
+class ActivePageResponse(BaseModel):
+    """The result of pinning a page to a board."""
+
+    board_id: str
+    page_id: str | None = Field(description="What is now pinned. Null means nothing is.")
+    sent: bool = Field(description="Whether the new page reached the board immediately.")
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Non-fatal problems, e.g. collection members that do not fit this board.",
+    )
+
+
+class PluginEntry(BaseModel):
+    """One plugin in the merged catalogue.
+
+    ``GET /plugins`` and ``GET /displays`` are the same registry listing seen
+    twice — ``/displays`` is a four-field projection of it. v1 publishes one
+    catalogue, with the display projection's ``available`` folded in.
+    """
+
+    id: str = Field(description="Plugin id. Usable anywhere {plugin} appears in a v1 path.")
+    name: str
+    version: str
+    description: str = ""
+    author: str = ""
+    category: str | None = None
+    plugin_type: str = Field(default="data", description='"data" for a content source, "transition" for an animation.')
+    icon: str | None = None
+    enabled: bool = Field(description="Whether this plugin runs and contributes template variables.")
+    configured: bool = Field(description="Whether its required settings have been filled in.")
+
+
+class PluginListResponse(BaseModel):
+    """``GET /v1/plugins``."""
+
+    plugins: list[PluginEntry]
+    total: int
+    enabled_count: int
+
+
+class PluginUpdate(BaseModel):
+    """``PATCH /v1/plugins/{plugin}``.
+
+    Collapses ``POST /enable``, ``POST /disable`` and ``PUT /config`` into
+    one call. ``config`` stays a free-form map on purpose: a typed body would
+    reject the ``"***"`` sentinel the API serves in place of a stored secret,
+    which is what a client round-trips when it edits one field of a form.
+    """
+
+    enabled: StrictBool | None = Field(default=None, description="Enable or disable the plugin.")
+    config: dict[str, Any] | None = Field(
+        default=None,
+        description='Replace the plugin\'s settings. Send "***" for a secret you do not want to change.',
+    )
+
+
+class PluginData(BaseModel):
+    """``GET /v1/plugins/{plugin}/data`` — the merge of the raw and formatted reads."""
+
+    plugin_id: str
+    available: bool = Field(description="False when the plugin is disabled, unconfigured, or its fetch failed.")
+    data: dict[str, Any] | None = Field(default=None, description="The plugin's own variable payload.")
+    lines: list[str] = Field(
+        default_factory=list,
+        description="The plugin's board-ready lines, as GET /displays/{type} served them.",
+    )
+    text: str = Field(default="", description="``lines`` joined with newlines.")
+    error: str | None = Field(default=None, description="Why the data is unavailable, when it is.")
+
+
+class VariableCatalog(BaseModel):
+    """``GET /v1/variables`` — every name a template may use, from both sources.
+
+    Merges ``GET /templates/variables`` (the engine's vocabulary plus the
+    static colour, symbol and filter tables) with ``GET
+    /plugins/variables/all`` (what installed plugins contribute). They were
+    two endpoints answering one question.
+    """
+
+    variables: dict[str, list[str]] = Field(description="Variable names grouped by their source namespace.")
+    max_lengths: dict[str, int] = Field(description="Longest value each variable can render to, for layout.")
+    variable_metadata: dict[str, Any] = Field(default_factory=dict, description="Per-variable descriptions and types.")
+    variable_groups: dict[str, Any] = Field(default_factory=dict, description="Display grouping for editors.")
+    colors: dict[str, int] = Field(description='Colour names to flap codes, e.g. {"red": 63}.')
+    symbols: list[str] = Field(description="Symbol names usable as {sun}, {star} and so on.")
+    filters: list[str] = Field(description="Filters usable after a variable, e.g. {{x|pad:5}}.")
+    formatting: dict[str, Any] = Field(description="Layout helpers such as fill_space.")
+    syntax_examples: dict[str, str] = Field(description="Worked examples of the template syntax.")
+    plugin_system_enabled: bool = Field(description="False when the plugin subsystem is unavailable on this install.")
+
+
+class RenderRequest(BaseModel):
+    """``POST /v1/render`` — render a template without saving or sending it."""
+
+    template: str | list[str] = Field(
+        description="A template string, or one string per board row. A list is padded to the board's height.",
+    )
+    line_metadata: list[dict[str, Any]] | None = Field(
+        default=None,
+        description="Per-line alignment and wrap options, one entry per line.",
+    )

--- a/src/v1/openapi.py
+++ b/src/v1/openapi.py
@@ -82,7 +82,9 @@ def build_openapi(app) -> dict[str, Any]:
         version=app.version,
         description=app.description,
         routes=app.routes,
-        tags=(app.openapi_tags or []) + [V1_TAG_METADATA],
+        # Prepended, not appended: Swagger renders tags in this order and the
+        # consumer surface has to be the first thing a newcomer sees.
+        tags=[V1_TAG_METADATA, *(app.openapi_tags or [])],
     )
     schema.setdefault("components", {})["securitySchemes"] = SECURITY_SCHEMES
     schema["security"] = SECURITY_REQUIREMENT

--- a/src/v1/openapi.py
+++ b/src/v1/openapi.py
@@ -1,0 +1,107 @@
+"""Declare in the schema that this API is authenticated.
+
+Measured on ``next``: the published OpenAPI document has **no**
+``securitySchemes`` and no top-level ``security``, so a consumer reading it
+cannot discover that authentication exists at all — let alone which kind.
+That is not an oversight in any one route; it is structural. Authentication
+is enforced in ASGI middleware (:mod:`src.auth.middleware`), not in FastAPI
+dependencies, and FastAPI can only infer security from dependencies. So it
+has to be stated.
+
+Two schemes, because the app really does accept two credentials:
+
+``apiToken``
+    ``Authorization: Bearer <token>``. Created at ``POST /auth/mcp-token``
+    and accepted on ``/v1/*`` and ``/mcp*``. This is the one a script uses;
+    it is what makes FiestaBoard scriptable at all.
+``session``
+    The browser session cookie from ``POST /auth/login``, which is what the
+    web UI holds.
+
+Declared as alternatives at the document root — a request satisfies the
+scheme by presenting either — so the document says what the middleware
+does rather than an idealised version of it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi.openapi.utils import get_openapi
+
+from src.auth.service import SESSION_COOKIE_NAME
+
+#: OpenAPI ``securitySchemes`` for the two credentials the app accepts.
+SECURITY_SCHEMES: dict[str, dict[str, Any]] = {
+    "apiToken": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": (
+            "A FiestaBoard API token, sent as `Authorization: Bearer <token>`. Create one with "
+            "`POST /auth/mcp-token` or pin one out of band with the `FIESTABOARD_MCP_TOKEN` environment "
+            "variable. Accepted on every `/v1` route and on the MCP endpoint. This is the credential to use "
+            "from a script: unlike the session cookie it needs no browser login flow.\n\n"
+            "When no token is configured and authentication is disabled, the API is open and no credential "
+            "is required — the default for a local-only install."
+        ),
+    },
+    "session": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": SESSION_COOKIE_NAME,
+        "description": (
+            "The browser session cookie issued by `POST /auth/login`. What the web UI holds. A script should "
+            "use `apiToken` instead."
+        ),
+    },
+}
+
+#: Either credential satisfies a request; an empty requirement is not offered,
+#: because "no credential" is an install-level setting, not a per-route one.
+SECURITY_REQUIREMENT: list[dict[str, list[str]]] = [{"apiToken": []}, {"session": []}]
+
+#: Tag metadata for the consumer surface. The internal domains publish 22
+#: bare tag names with no descriptions; this one says what it is.
+V1_TAG_METADATA: dict[str, Any] = {
+    "name": "v1",
+    "description": (
+        "The FiestaBoard API. Four nouns — board, page, schedule, plugin — and one way to do each thing.\n\n"
+        'Start here: `POST /v1/boards/primary/message` with `{"text": "HELLO"}` puts text on your board. '
+        "`primary` works as a board id on every `/v1/boards/...` path, so a single-board install never needs to "
+        "look one up.\n\n"
+        "Every write reports what actually happened rather than merely acknowledging the request: `sent` is true "
+        "only when flaps moved, and a `reason` says why when they did not."
+    ),
+}
+
+
+def build_openapi(app) -> dict[str, Any]:
+    """The app's schema, with the security it actually enforces declared."""
+    schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        description=app.description,
+        routes=app.routes,
+        tags=(app.openapi_tags or []) + [V1_TAG_METADATA],
+    )
+    schema.setdefault("components", {})["securitySchemes"] = SECURITY_SCHEMES
+    schema["security"] = SECURITY_REQUIREMENT
+    return schema
+
+
+def install_security_scheme(app) -> None:
+    """Replace ``app.openapi`` with one that declares the security schemes.
+
+    Idempotent: mounting twice (a test app factory, a reload) leaves one
+    wrapper, not a stack of them.
+    """
+    if getattr(app, "_fiestaboard_v1_openapi_installed", False):
+        return
+
+    def _openapi() -> dict[str, Any]:
+        if app.openapi_schema is None:
+            app.openapi_schema = build_openapi(app)
+        return app.openapi_schema
+
+    app.openapi = _openapi
+    app._fiestaboard_v1_openapi_installed = True

--- a/src/v1/router.py
+++ b/src/v1/router.py
@@ -1,0 +1,13 @@
+"""The single ``/v1`` router every v1 module attaches its routes to.
+
+One tag, ``v1``, for the whole surface: the point of this API is that a
+consumer sees one small coherent thing rather than twenty-two internal
+domains. The tag is also what opts the surface into the conventions ratchet
+(``tests/conventions_manifest.json``).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/v1", tags=["v1"])

--- a/src/v1/routes_boards.py
+++ b/src/v1/routes_boards.py
@@ -1,0 +1,503 @@
+"""``/v1/boards`` — the front door.
+
+Six operations replace sixteen ways to write to a board and ten ways to read
+one. Every one of them is an adapter: the write goes through
+:mod:`src.ops.executors`, which already mirrors ``POST /send-message`` gate
+for gate and is already board-aware; the read composes three existing reads;
+the patch calls three existing setters.
+
+The one rule this surface states that the internal API never did: **a v1
+write honours the install's output target.** ``should_send_to_board()`` is
+checked before anything is written, and ``sent`` in the response says what
+actually happened. Today ``POST /pages/{id}/send``, ``POST /debug/fill`` and
+``POST /debug/blank`` honour it while ``POST /send-message`` ignores it — the
+same action behaving two ways. v1 picks one and tells the caller.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from fastapi import HTTPException
+
+from src import display_runtime as runtime
+from src.api_errors import errors
+from src.board_chars import characters_to_message
+from src.ops import executors
+from src.text_to_board import text_to_board_array, wrap_message_text
+
+from .boards import board_dimensions, resolve_board, resolve_board_id
+from .models import (
+    ActivePageRequest,
+    ActivePageResponse,
+    BoardDetail,
+    BoardListResponse,
+    BoardSummary,
+    BoardUpdate,
+    MessageRequest,
+    MessageResponse,
+)
+from .router import router
+
+logger = logging.getLogger(__name__)
+
+UI_ONLY_REASON = "The install's output target is UI only, so nothing was written to the board."
+UNCHANGED_REASON = "The board already shows this exact content. Send force=true to write it anyway."
+
+
+def _settings_service():
+    from src.settings.service import get_settings_service
+
+    return get_settings_service()
+
+
+def _schedule_service():
+    from src.schedules.service import get_schedule_service
+
+    return get_schedule_service()
+
+
+def _summary(board: dict[str, Any], primary_id: str | None) -> BoardSummary:
+    """Project one stored board entry into the consumer view."""
+    settings_service = _settings_service()
+    board_id = board.get("id") or ""
+    dims = board_dimensions(board)
+    return BoardSummary(
+        id=board_id,
+        name=board.get("name") or board_id,
+        device_type=board.get("device_type") or "flagship",
+        rows=dims.rows,
+        cols=dims.cols,
+        is_primary=board_id == primary_id,
+        paused=settings_service.is_paused(board_id=board_id) is True,
+        schedule_enabled=bool(settings_service.is_schedule_enabled(board_id=board_id)),
+    )
+
+
+@router.get(
+    "/boards",
+    response_model=BoardListResponse,
+    responses=errors(503),
+    summary="List the boards this install drives",
+    description=(
+        "Every configured board, with the id you use in the rest of this API, its grid size, and whether it is "
+        "currently paused or following its schedule. The board marked `is_primary` is the one the literal path "
+        "segment `primary` resolves to, so a single-board install never has to look an id up at all."
+    ),
+)
+async def list_boards() -> BoardListResponse:
+    try:
+        settings_service = _settings_service()
+        boards = settings_service.get_board_settings().boards or []
+        primary_id = settings_service.get_primary_board_id()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Could not read the boards store: %s", exc)
+        raise HTTPException(status_code=503, detail="Board settings are unavailable.") from exc
+
+    entries = [_summary(b, primary_id) for b in boards if isinstance(b, dict) and b.get("id")]
+    return BoardListResponse(boards=entries, total=len(entries))
+
+
+@router.get(
+    "/boards/{board}",
+    response_model=BoardDetail,
+    responses=errors(404, 503),
+    summary="Read a board and everything it is doing",
+    description=(
+        "One answer to 'what is this board showing, and why'. It merges what the internal API splits across three "
+        "endpoints: the flaps currently on the board, the page pinned to it by hand, and the page its schedule "
+        "selects for right now. `source` says which of the two won. `board` may be a board id or the literal "
+        "`primary`."
+    ),
+)
+async def get_board(board: str) -> BoardDetail:
+    from src.collections.service import get_collection_service, resolve_active_page_id
+    from src.time_service import get_time_service
+
+    board_id, entry = resolve_board(board)
+    settings_service = _settings_service()
+    schedule_service = _schedule_service()
+    primary_id = settings_service.get_primary_board_id()
+    base = _summary(entry, primary_id)
+
+    service = runtime.get_service()
+    characters: list[list[int]] | None = None
+    read_at: str | None = None
+    if service is not None:
+        rt = service.get_runtime(board_id)
+        if rt is not None:
+            characters = rt.polled_characters
+            if characters is not None and rt.polled_at is not None:
+                read_at = datetime.fromtimestamp(rt.polled_at, tz=UTC).isoformat()
+            if characters is None:
+                characters = getattr(rt.client, "_last_characters", None) if rt.client is not None else None
+
+    active_page_id = settings_service.get_active_page_id(board_id=board_id)
+    scheduled_page_id = None
+    if settings_service.is_schedule_enabled(board_id=board_id):
+        now = get_time_service().get_current_time()
+        scheduled_page_id = schedule_service.get_active_page_id(
+            now.time(), now.strftime("%A").lower(), board_id=board_id
+        )
+
+    if active_page_id:
+        source = "manual"
+        chosen = active_page_id
+    elif scheduled_page_id:
+        source = "schedule"
+        chosen = scheduled_page_id
+    else:
+        source = "none"
+        chosen = None
+
+    override = settings_service.get_temporary_override()
+    return BoardDetail(
+        **base.model_dump(),
+        characters=characters,
+        text=characters_to_message(characters) if characters else None,
+        read_at=read_at,
+        active_page_id=active_page_id,
+        scheduled_page_id=scheduled_page_id,
+        resolved_page_id=resolve_active_page_id(chosen, get_collection_service),
+        source=source,
+        default_page_id=schedule_service.get_default_page(board_id=board_id),
+        override_expires_at=(override.expires_at if override is not None and board_id == primary_id else None),
+    )
+
+
+@router.patch(
+    "/boards/{board}",
+    response_model=BoardDetail,
+    responses=errors(400, 404, 503),
+    summary="Change how a board behaves",
+    description=(
+        "Rename a board, pause or resume it, turn its schedule on or off, or set the page it falls back to when the "
+        "schedule has a gap. Only the fields you send are applied; omit the rest. Pausing stops every write to the "
+        "board from every code path — the display loop, schedules, plugin triggers, MQTT and this API alike."
+    ),
+)
+async def update_board(board: str, request: BoardUpdate) -> BoardDetail:
+    board_id = resolve_board_id(board)
+    settings_service = _settings_service()
+    provided = request.model_dump(exclude_unset=True)
+
+    if "paused" in provided and provided["paused"] is not None:
+        settings_service.set_paused(provided["paused"], board_id=board_id)
+
+    if "schedule_enabled" in provided and provided["schedule_enabled"] is not None:
+        settings_service.set_schedule_enabled(provided["schedule_enabled"], board_id=board_id)
+
+    if "default_page_id" in provided:
+        page_id = provided["default_page_id"]
+        if page_id is not None:
+            _require_page_ref(page_id)
+        _schedule_service().set_default_page(page_id, board_id=board_id)
+
+    if "name" in provided and provided["name"] is not None:
+        boards = [dict(b) for b in (settings_service.get_board_settings().boards or []) if isinstance(b, dict)]
+        for candidate in boards:
+            if candidate.get("id") == board_id:
+                candidate["name"] = provided["name"]
+        try:
+            settings_service.set_boards(boards)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return await get_board(board)
+
+
+def _require_page_ref(page_id: str) -> None:
+    """404 unless *page_id* names a page or a collection that exists."""
+    from src.collections.models import is_collection_id
+    from src.collections.service import get_collection_service
+    from src.pages.service import get_page_service
+
+    if is_collection_id(page_id):
+        if not get_collection_service().get_collection(page_id):
+            raise HTTPException(status_code=404, detail=f"Collection not found: {page_id}")
+        return
+    if not get_page_service().get_page(page_id):
+        raise HTTPException(status_code=404, detail=f"Page not found: {page_id}")
+
+
+def _validate_grid(characters: list[list[int]], rows: int, cols: int) -> None:
+    """Reject a supplied grid the board cannot display.
+
+    A 400, not a 422: the body already passed schema validation (flap codes
+    are range-checked by the request model), and whether the grid *fits* is a
+    fact about the board, not about the JSON. 422 belongs to FastAPI —
+    API_CONVENTIONS.md, "Error contract".
+    """
+    if len(characters) != rows or any(len(row) != cols for row in characters):
+        got = f"{len(characters)}x{len(characters[0]) if characters else 0}"
+        raise HTTPException(
+            status_code=400,
+            detail=f"characters must be a {rows}x{cols} grid for this board, got {got}",
+        )
+
+
+def _grid_for(request: MessageRequest, rows: int, cols: int) -> tuple[list[list[int]], str, list[str] | None]:
+    """``(characters, text, template_lines)`` for whichever content field was sent.
+
+    ``template_lines`` is the form a timed message can be stored as; it is
+    ``None`` for the two raw-grid forms, which the temporary-override store
+    has no representation for.
+    """
+    if request.text is not None:
+        wrapped = wrap_message_text(request.text, rows=rows, cols=cols)
+        return text_to_board_array(wrapped, rows=rows, cols=cols), wrapped, wrapped.split("\n")
+
+    if request.lines is not None:
+        joined = "\n".join(request.lines)
+        return text_to_board_array(joined, rows=rows, cols=cols), joined, list(request.lines)
+
+    if request.fill is not None:
+        grid = [[request.fill] * cols for _ in range(rows)]
+        return grid, characters_to_message(grid), None
+
+    if request.characters is not None:
+        _validate_grid(request.characters, rows, cols)
+        return request.characters, characters_to_message(request.characters), None
+
+    # page_id — the remaining form, guaranteed by the request model.
+    from src.pages.service import get_page_service
+
+    page_service = get_page_service()
+    result = page_service.preview_page(request.page_id, force_refresh=True)
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"Page not found: {request.page_id}")
+    if not result.available:
+        raise HTTPException(status_code=503, detail=result.error or "Page rendering failed")
+    return (
+        text_to_board_array(result.formatted, rows=rows, cols=cols),
+        result.formatted,
+        result.formatted.split("\n"),
+    )
+
+
+def _raise_for_executor(result: dict[str, Any]) -> None:
+    """Turn an executor refusal into the status code it deserves.
+
+    Blocked is policy, not breakage: silence and pause are both 409, the same
+    verdict ``POST /send-message`` and ``POST /debug/fill`` give. Anything
+    else the executor calls an error is a 500 — the 503 cases (no service, no
+    client) are checked before it is ever called, so they cannot arrive here.
+    """
+    if result.get("status") == "blocked":
+        raise HTTPException(status_code=409, detail=str(result.get("message")))
+    if result.get("status") == "error":
+        raise HTTPException(status_code=500, detail=str(result.get("error") or "Failed to send to the board."))
+
+
+def _raise_if_throttled(client) -> None:
+    """A write the client-side send floor dropped is a 429 (#1868, #1754).
+
+    Reuses the debug router's helper rather than restating its Retry-After
+    arithmetic, so all three manual senders answer the same way.
+    """
+    from src.debug.routes import _raise_if_throttled as _debug_raise_if_throttled
+
+    _debug_raise_if_throttled(client)
+
+
+@router.post(
+    "/boards/{board}/message",
+    response_model=MessageResponse,
+    responses=errors(400, 404, 409, 429, 500, 503),
+    summary="Put something on a board",
+    description=(
+        "The one way to write to a board. Send exactly one of `text` (word-wrapped for you), `lines` (one string "
+        "per row), `characters` (a raw flap grid), `page_id` (render a saved page) or `fill` (one flap code "
+        "everywhere; 0 blanks the board).\n\n"
+        "Add `duration_minutes` to make it temporary — it reverts to your schedule, a chosen page, or a blank board "
+        "when the time is up. `board` may be a board id or the literal `primary`.\n\n"
+        "`sent` in the response tells you whether flaps actually moved. It is false, with a `reason`, when the "
+        "install's output target is UI-only and when the board already showed this exact content. A board that is "
+        "paused or inside its silence window refuses the write with 409 rather than lying about it."
+    ),
+)
+async def send_to_board(board: str, request: MessageRequest) -> MessageResponse:
+    board_id, entry = resolve_board(board)
+    settings_service = _settings_service()
+
+    if request.revert_mode is not None and request.duration_minutes is None:
+        raise HTTPException(status_code=400, detail="revert_mode requires duration_minutes")
+    if request.revert_page_id is not None and request.revert_mode != "page":
+        raise HTTPException(status_code=400, detail='revert_page_id requires revert_mode "page"')
+
+    service = runtime.get_service()
+    if not service:
+        raise HTTPException(status_code=503, detail="Service not initialized")
+    if service.get_board_client(board_id) is None:
+        raise HTTPException(status_code=503, detail=f"Board client not initialized: {board_id}")
+
+    dims = board_dimensions(entry)
+    characters, text, template_lines = _grid_for(request, dims.rows, dims.cols)
+
+    expires_at = None
+    if request.duration_minutes is not None:
+        expires_at = await _arm_temporary_override(board_id, request, template_lines)
+
+    if not settings_service.should_send_to_board():
+        return MessageResponse(
+            sent=False,
+            board_id=board_id,
+            characters=characters,
+            text=text,
+            expires_at=expires_at,
+            reason=UI_ONLY_REASON,
+        )
+
+    transition = request.transition
+    send_kwargs = {
+        "strategy": transition.strategy if transition else None,
+        "step_interval_ms": transition.interval_ms if transition else None,
+        "step_size": transition.step_size if transition else None,
+        "force": request.force,
+    }
+
+    from src.board_send_executor import run_board_send
+
+    if request.text is not None:
+        result = await run_board_send(executors.send_message, request.text, board_id, **send_kwargs)
+    else:
+        result = await run_board_send(executors.send_characters, characters, board_id, **send_kwargs)
+
+    _raise_for_executor(result)
+
+    if result.get("skipped"):
+        _raise_if_throttled(service.get_board_client(board_id))
+        return MessageResponse(
+            sent=False,
+            board_id=board_id,
+            characters=characters,
+            text=text,
+            expires_at=expires_at,
+            reason=UNCHANGED_REASON,
+        )
+
+    return MessageResponse(
+        sent=True,
+        board_id=board_id,
+        characters=characters,
+        text=text,
+        expires_at=expires_at,
+        reason=None,
+    )
+
+
+async def _arm_temporary_override(board_id: str, request: MessageRequest, template_lines: list[str] | None) -> str:
+    """Store the timed-message state, and return when it expires.
+
+    Delegates to ``POST /settings/temporary-override`` — the existing home of
+    duration, revert mode and the inline one-off content of #1787 — rather
+    than restating its validation. Two limits come from that mechanism and
+    are reported rather than papered over: it is stored globally and applied
+    by the display loop for the **primary** board only, and it can only hold
+    text, so the raw-grid forms cannot be timed.
+    """
+    from src.settings.models import TemporaryOverrideRequest
+    from src.settings.routes import set_temporary_override
+
+    settings_service = _settings_service()
+    if board_id != settings_service.get_primary_board_id():
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "duration_minutes is only supported on the primary board — "
+                "timed messages are applied by the display loop for the primary board only."
+            ),
+        )
+    if template_lines is None:
+        raise HTTPException(
+            status_code=400,
+            detail="duration_minutes cannot be combined with characters or fill; use text, lines or page_id",
+        )
+
+    body: dict[str, Any] = {
+        "duration_minutes": request.duration_minutes,
+        "revert_mode": request.revert_mode or "schedule",
+    }
+    if request.revert_page_id is not None:
+        body["revert_page_id"] = request.revert_page_id
+    if request.page_id is not None:
+        body["page_id"] = request.page_id
+    else:
+        body["template"] = template_lines
+        board = resolve_board(board_id)[1]
+        body["device_type"] = board.get("device_type") or "flagship"
+        body["notes_wide"] = board.get("notes_wide") or 1
+        body["notes_tall"] = board.get("notes_tall") or 1
+
+    await set_temporary_override(TemporaryOverrideRequest(**body))
+    return (datetime.now(UTC) + timedelta(minutes=int(request.duration_minutes))).isoformat()
+
+
+@router.delete(
+    "/boards/{board}/message",
+    response_model=MessageResponse,
+    responses=errors(404, 500, 503),
+    summary="Clear a board and let its schedule take over",
+    description=(
+        "Undoes a `POST` to this path. Any timed message is cancelled, the board's content cache is dropped, and "
+        "the display loop re-renders whatever the schedule or the pinned page says should be there — which is a "
+        "blank board when nothing is scheduled. `sent` reports whether that re-render reached the board."
+    ),
+)
+async def clear_board_message(board: str) -> MessageResponse:
+    from src.service_api.routes import refresh_display
+
+    board_id, entry = resolve_board(board)
+    settings_service = _settings_service()
+
+    # A timed message is the one piece of state a POST leaves behind.
+    if board_id == settings_service.get_primary_board_id():
+        settings_service.clear_temporary_override()
+
+    service = runtime.get_service()
+    if not service:
+        raise HTTPException(status_code=503, detail="Service not initialized")
+    rt = service.get_runtime(board_id)
+    if rt is not None:
+        # Drop the dedupe cache so the next render is not skipped as unchanged
+        # — the out-of-band write left the board showing content the loop did
+        # not put there (#1794).
+        rt.last_active_page_content = None
+
+    refreshed = await refresh_display(board_id=board_id)
+    dims = board_dimensions(entry)
+    return MessageResponse(
+        sent=bool(refreshed.sent),
+        board_id=board_id,
+        characters=[[0] * dims.cols for _ in range(dims.rows)],
+        text="",
+        expires_at=None,
+        reason=None if refreshed.sent else "Nothing changed on the board — it already showed the scheduled content.",
+    )
+
+
+@router.put(
+    "/boards/{board}/active-page",
+    response_model=ActivePageResponse,
+    responses=errors(400, 404, 502),
+    summary="Pin a page to a board",
+    description=(
+        "Sets the page (or collection) this board shows until something changes it — the sticky selection a "
+        "schedule falls back from. The page is rendered and sent immediately. Send `null` to unpin, after which "
+        "the board follows its schedule again. Pinning a page whose size does not match the board is rejected."
+    ),
+)
+async def set_board_active_page(board: str, request: ActivePageRequest) -> ActivePageResponse:
+    from src.settings.models import SetActivePageRequest
+    from src.settings.routes import set_active_page
+
+    board_id = resolve_board_id(board)
+    response = await set_active_page(SetActivePageRequest(page_id=request.page_id, board_id=board_id))
+    return ActivePageResponse(
+        board_id=board_id,
+        page_id=response.get("page_id"),
+        sent=bool(response.get("sent_to_board")),
+        warnings=list(response.get("warnings") or []),
+    )

--- a/src/v1/routes_content.py
+++ b/src/v1/routes_content.py
@@ -1,0 +1,279 @@
+"""``/v1/pages``, ``/v1/schedules``, ``/v1/collections`` — the saved content.
+
+Fifteen operations, five per resource, all plain CRUD over the models the
+domains already publish. Each handler delegates to the domain router's own
+handler, so the validation, the 404 wording and the response shape are one
+implementation, not two.
+
+Reusing the domain handlers rather than the services is deliberate: the
+domain routers hold the parts a service does not — the transition-plugin
+beta gate on a page, the sun-time enrichment on a schedule, the page-exists
+checks on a collection's members. Calling the service directly would drop
+them silently.
+"""
+
+from __future__ import annotations
+
+from src.api_errors import errors
+from src.collections import routes as collections_routes
+from src.collections.models import (
+    Collection,
+    CollectionCreate,
+    CollectionDeleteResponse,
+    CollectionListResponse,
+    CollectionUpdate,
+)
+from src.pages import routes as pages_routes
+from src.pages.models import (
+    Page,
+    PageCreate,
+    PageDeleteResponse,
+    PageListResponse,
+    PageUpdate,
+    PageUpdateResponse,
+)
+from src.schedules import routes as schedules_routes
+from src.schedules.models import (
+    ScheduleCreate,
+    ScheduleDeleteResponse,
+    ScheduleListResponse,
+    ScheduleResponse,
+    ScheduleUpdate,
+    ScheduleWriteResponse,
+)
+
+from .router import router
+
+# ---------------------------------------------------------------------------
+# Pages
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/pages",
+    response_model=PageListResponse,
+    responses=errors(503),
+    summary="List saved pages",
+    description=(
+        "Every page saved on this install. A page is a reusable board layout — literal text, plugin variables, or "
+        "rows composed from other sources — that a schedule, a collection or `POST /v1/boards/{board}/message` can "
+        "refer to by id."
+    ),
+)
+async def list_pages() -> PageListResponse:
+    return await pages_routes.list_pages()
+
+
+@router.post(
+    "/pages",
+    response_model=Page,
+    status_code=201,
+    responses=errors(400),
+    summary="Create a page",
+    description=(
+        "Saves a new page and answers with it, including the generated `id` you refer to it by. `type` picks how it "
+        "is built: `template` for text with `{{variables}}`, `single` for one plugin's output, `composite` for rows "
+        "drawn from several sources. `device_type` must match the boards you intend to show it on."
+    ),
+)
+async def create_page(request: PageCreate) -> Page:
+    return await pages_routes.create_page(request)
+
+
+@router.get(
+    "/pages/{page_id}",
+    response_model=Page,
+    responses=errors(404),
+    summary="Read one page",
+    description=(
+        "The saved page with this id, exactly as stored — its type, its device size, its template or row "
+        "configuration, and its per-page transition overrides. 404 when no page has this id."
+    ),
+)
+async def get_page(page_id: str) -> Page:
+    return await pages_routes.get_page(page_id)
+
+
+@router.put(
+    "/pages/{page_id}",
+    response_model=PageUpdateResponse,
+    responses=errors(400, 404),
+    summary="Update a page",
+    description=(
+        "Applies the fields you send and leaves the rest alone. The response carries the updated page plus "
+        "`incompatible_references`: places that still point at this page — a board's schedule, a pinned selection — "
+        "where your change has made the size no longer fit."
+    ),
+)
+async def update_page(page_id: str, request: PageUpdate) -> PageUpdateResponse:
+    return await pages_routes.update_page(page_id, request)
+
+
+@router.delete(
+    "/pages/{page_id}",
+    response_model=PageDeleteResponse,
+    responses=errors(404),
+    summary="Delete a page",
+    description=(
+        "Removes the page. If it was the last page, or was the one a board was showing, the response says what was "
+        "put in its place so nothing is left pointing at a page that no longer exists."
+    ),
+)
+async def delete_page(page_id: str) -> PageDeleteResponse:
+    return await pages_routes.delete_page(page_id)
+
+
+# ---------------------------------------------------------------------------
+# Schedules
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/schedules",
+    response_model=ScheduleListResponse,
+    responses=errors(503),
+    summary="List schedule entries",
+    description=(
+        "Every schedule entry, newest rules included. Pass `board_id` to narrow it to one board, or `*` for all "
+        "boards at once. Each entry says which page shows between which times, on which days; the response also "
+        "carries the fallback page and whether scheduling is switched on."
+    ),
+)
+async def list_schedules(board_id: str | None = None) -> ScheduleListResponse:
+    return await schedules_routes.list_schedules(board_id)
+
+
+@router.post(
+    "/schedules",
+    response_model=ScheduleWriteResponse,
+    status_code=201,
+    responses=errors(400, 404),
+    summary="Create a schedule entry",
+    description=(
+        "Adds a rule: show `page_id` from `start_time` to `end_time` on the days `day_pattern` selects. Times may "
+        "also be relative to sunrise or sunset (`start_type`, `start_sun_offset`), and a rule may recur weekly, on "
+        "a calendar date every year, or once. Omit `board_id` for the default board."
+    ),
+)
+async def create_schedule(request: ScheduleCreate) -> ScheduleWriteResponse:
+    return await schedules_routes.create_schedule(request)
+
+
+@router.get(
+    "/schedules/{schedule_id}",
+    response_model=ScheduleResponse,
+    responses=errors(404),
+    summary="Read one schedule entry",
+    description=(
+        "The schedule entry with this id, plus `resolved_start_time` and `resolved_end_time` — the wall-clock times "
+        "a sunrise- or sunset-relative rule works out to today."
+    ),
+)
+async def get_schedule(schedule_id: str) -> ScheduleResponse:
+    return await schedules_routes.get_schedule(schedule_id)
+
+
+@router.put(
+    "/schedules/{schedule_id}",
+    response_model=ScheduleWriteResponse,
+    responses=errors(400, 404),
+    summary="Update a schedule entry",
+    description=(
+        "Applies only the fields you send, so a partial update cannot silently clear the ones you left out. "
+        "`warnings` reports rules that now overlap or leave a gap without failing the write."
+    ),
+)
+async def update_schedule(schedule_id: str, request: ScheduleUpdate) -> ScheduleWriteResponse:
+    return await schedules_routes.update_schedule(schedule_id, request)
+
+
+@router.delete(
+    "/schedules/{schedule_id}",
+    response_model=ScheduleDeleteResponse,
+    responses=errors(404),
+    summary="Delete a schedule entry",
+    description=(
+        "Removes this schedule rule. The page it pointed at is untouched, and the board falls back to its "
+        "remaining rules — or to its gap page when none of them match."
+    ),
+)
+async def delete_schedule(schedule_id: str) -> ScheduleDeleteResponse:
+    return await schedules_routes.delete_schedule(schedule_id)
+
+
+# ---------------------------------------------------------------------------
+# Collections
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/collections",
+    response_model=CollectionListResponse,
+    responses=errors(503),
+    summary="List the saved collections",
+    description=(
+        "Every collection. A collection is a set of pages plus a rule for choosing between them — rotate on a "
+        "timer, pick at random, or switch on the value of a template expression — and it can be used anywhere a "
+        "page id can."
+    ),
+)
+async def list_collections() -> CollectionListResponse:
+    return await collections_routes.list_collections()
+
+
+@router.post(
+    "/collections",
+    response_model=Collection,
+    status_code=201,
+    responses=errors(400),
+    summary="Create a collection",
+    description=(
+        "Saves a set of pages and how to choose between them. `selection_mode` is `time` (rotate every "
+        "`time.interval_seconds`), `random`, or `variable` (evaluate `variable.rules` in order and show the first "
+        "match). The generated id is prefixed `collection:` and is usable wherever a page id is."
+    ),
+)
+async def create_collection(request: CollectionCreate) -> Collection:
+    return await collections_routes.create_collection(request)
+
+
+@router.get(
+    "/collections/{collection_id}",
+    response_model=Collection,
+    responses=errors(404),
+    summary="Read one collection",
+    description=(
+        "The collection with this id: its member page ids in order, its selection mode, and the config block "
+        "for that mode — the rotation interval, or the expression rules that pick between the members."
+    ),
+)
+async def get_collection(collection_id: str) -> Collection:
+    return await collections_routes.get_collection(collection_id)
+
+
+@router.put(
+    "/collections/{collection_id}",
+    response_model=Collection,
+    responses=errors(400, 404),
+    summary="Update a collection",
+    description=(
+        "Applies only the fields you send. Every page id in `page_ids` must exist, and a `variable` rule may only "
+        "point at a page the collection contains."
+    ),
+)
+async def update_collection(collection_id: str, request: CollectionUpdate) -> Collection:
+    return await collections_routes.update_collection(collection_id, request)
+
+
+@router.delete(
+    "/collections/{collection_id}",
+    response_model=CollectionDeleteResponse,
+    responses=errors(404),
+    summary="Delete a collection",
+    description=(
+        "Removes the collection. Its member pages are untouched, but anything still referring to the "
+        "collection id — a schedule rule, a board's pinned selection — will stop resolving."
+    ),
+)
+async def delete_collection(collection_id: str) -> CollectionDeleteResponse:
+    return await collections_routes.delete_collection(collection_id)

--- a/src/v1/routes_meta.py
+++ b/src/v1/routes_meta.py
@@ -1,0 +1,138 @@
+"""``/v1/variables``, ``/v1/render``, ``/v1/functions``, ``/v1/health``, ``/v1/status``.
+
+Everything a caller needs to *write* a template and to check the instance is
+alive. ``GET /v1/variables`` is the merge the design names: the internal API
+answers "what names can I use in a template" at two endpoints —
+``GET /templates/variables`` for the engine's own vocabulary and
+``GET /plugins/variables/all`` for what plugins contribute — and a caller has
+to know to ask both.
+"""
+
+from __future__ import annotations
+
+from fastapi import Query
+
+from src.api_errors import errors
+from src.plugins import routes as plugins_routes
+from src.service_api import routes as service_routes
+from src.service_api.models import HealthResponse, StatusResponse
+from src.templates import routes as templates_routes
+from src.templates.models import FormulaFunctionsResponse, TemplateRenderRequest, TemplateRenderResponse
+
+from .boards import resolve_board
+from .models import RenderRequest, VariableCatalog
+from .router import router
+
+
+@router.get(
+    "/variables",
+    response_model=VariableCatalog,
+    responses=errors(503),
+    summary="List every name a template can use",
+    description=(
+        "The whole template vocabulary in one answer: the built-in variables, everything the installed plugins "
+        "contribute, the colour and symbol names, and the filters you can apply. `max_lengths` gives the longest "
+        "value each variable can render to, which is what you size a row against."
+    ),
+)
+async def list_variables() -> VariableCatalog:
+    template_view = await templates_routes.get_template_variables()
+    plugin_view = await plugins_routes.get_all_plugin_variables()
+
+    variables = {**template_view.variables}
+    for namespace, names in (plugin_view.variables or {}).items():
+        if isinstance(names, list):
+            variables.setdefault(namespace, names)
+
+    max_lengths = {**template_view.max_lengths}
+    for name, length in (plugin_view.max_lengths or {}).items():
+        if isinstance(length, int):
+            max_lengths.setdefault(name, length)
+
+    return VariableCatalog(
+        variables=variables,
+        max_lengths=max_lengths,
+        variable_metadata=template_view.variable_metadata,
+        variable_groups=template_view.variable_groups,
+        colors=template_view.colors,
+        symbols=template_view.symbols,
+        filters=template_view.filters,
+        formatting=template_view.formatting,
+        syntax_examples=template_view.syntax_examples,
+        plugin_system_enabled=bool(plugin_view.plugin_system_enabled),
+    )
+
+
+@router.get(
+    "/functions",
+    response_model=FormulaFunctionsResponse,
+    responses=errors(503),
+    summary="List the functions a template expression can call",
+    description=(
+        "Every function usable inside `{{ }}` — conditionals, arithmetic, text and date helpers — with its "
+        "signature and a one-line summary. This is the reference for writing a collection's `variable` rules as "
+        "well as for page templates."
+    ),
+)
+async def list_functions() -> FormulaFunctionsResponse:
+    return await templates_routes.get_formula_functions()
+
+
+@router.post(
+    "/render",
+    response_model=TemplateRenderResponse,
+    responses=errors(400, 404),
+    summary="Render a template without saving or sending it",
+    description=(
+        "Runs a template against the current data and gives you back the text, so you can see what a page would "
+        "look like before you save it. Pass `board` — a board id or `primary` — to lay it out for that board's "
+        "size; without it the template is rendered at the default flagship geometry. Nothing is written to any "
+        "board."
+    ),
+)
+async def render_template(
+    request: RenderRequest,
+    board: str | None = Query(
+        default=None,
+        description="Board id, or 'primary', whose geometry the template should be laid out for.",
+    ),
+) -> TemplateRenderResponse:
+    device_type = None
+    if board is not None:
+        device_type = resolve_board(board)[1].get("device_type") or "flagship"
+    return await templates_routes.render_template(
+        TemplateRenderRequest(
+            template=request.template,
+            device_type=device_type,
+            line_metadata=request.line_metadata,
+        )
+    )
+
+
+@router.get(
+    "/health",
+    response_model=HealthResponse,
+    responses=errors(503),
+    summary="Check that the instance is up",
+    description=(
+        "Answers 200 whenever the process is serving. `service_running` reports whether the display loop — the "
+        "thing that actually drives the boards — is running, which is separate from the API being reachable."
+    ),
+)
+async def health() -> HealthResponse:
+    return await service_routes.health()
+
+
+@router.get(
+    "/status",
+    response_model=StatusResponse,
+    responses=errors(503),
+    summary="Read the display loop's state, board by board",
+    description=(
+        "What the instance is doing: whether the display loop is running, a summary of the resolved configuration, "
+        "and per board whether it has a working connection, whether it is paused, which page it is showing, and "
+        "why it failed to start if it did."
+    ),
+)
+async def status() -> StatusResponse:
+    return await service_routes.get_status()

--- a/src/v1/routes_plugins.py
+++ b/src/v1/routes_plugins.py
@@ -1,0 +1,149 @@
+"""``/v1/plugins`` — one catalogue instead of two, one write instead of three.
+
+The internal API publishes the plugin registry twice: ``GET /plugins`` with
+eighteen fields and ``GET /displays`` with four, both built from the same
+``registry.list_plugins()`` call. It also splits one write — "change this
+plugin" — across ``POST /enable``, ``POST /disable`` and ``PUT /config``.
+v1 serves one catalogue and one ``PATCH``.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, Request
+
+from src.api_errors import errors
+from src.plugins import routes as plugins_routes
+from src.plugins.models import PluginDetail, PluginReceiveResponse
+
+from .models import PluginData, PluginEntry, PluginListResponse, PluginUpdate
+from .router import router
+
+
+@router.get(
+    "/plugins",
+    response_model=PluginListResponse,
+    responses=errors(503),
+    summary="List installed plugins",
+    description=(
+        "Every plugin installed on this instance, whether or not it is switched on. A plugin is a data source — "
+        "weather, transit, a stock ticker — that contributes template variables you can put on a page. `enabled` "
+        "says whether it runs; `configured` says whether its required settings have been filled in."
+    ),
+)
+async def list_plugins() -> PluginListResponse:
+    listing = await plugins_routes.list_plugins()
+    entries = [
+        PluginEntry(
+            id=plugin.id,
+            name=plugin.name,
+            version=plugin.version,
+            description=plugin.description,
+            author=plugin.author,
+            category=plugin.category,
+            plugin_type=plugin.plugin_type,
+            icon=plugin.icon,
+            enabled=bool(plugin.enabled),
+            configured=bool(plugin.configured),
+        )
+        for plugin in listing.plugins
+    ]
+    return PluginListResponse(
+        plugins=entries,
+        total=len(entries),
+        enabled_count=sum(1 for entry in entries if entry.enabled),
+    )
+
+
+@router.get(
+    "/plugins/{plugin_id}",
+    response_model=PluginDetail,
+    responses=errors(404, 503),
+    summary="Read one plugin",
+    description=(
+        "Everything about one plugin: its manifest, the template variables it contributes and their maximum "
+        "lengths, its settings schema, and its current configuration. Stored secrets come back masked as `***`; "
+        "sending that value back in a `PATCH` leaves the stored secret untouched."
+    ),
+)
+async def get_plugin(plugin_id: str) -> PluginDetail:
+    return await plugins_routes.get_plugin(plugin_id)
+
+
+@router.patch(
+    "/plugins/{plugin_id}",
+    response_model=PluginDetail,
+    responses=errors(400, 404, 503),
+    summary="Enable, disable or configure a plugin",
+    description=(
+        "One call for the three things you can do to a plugin. Send `enabled` to switch it on or off, `config` to "
+        "replace its settings, or both — the settings are written first so a plugin is never enabled with a "
+        "configuration you meant to replace. Answers with the plugin's full detail, secrets masked."
+    ),
+)
+async def update_plugin(plugin_id: str, request: PluginUpdate) -> PluginDetail:
+    provided = request.model_dump(exclude_unset=True)
+    if not provided:
+        raise HTTPException(status_code=400, detail="Send at least one of enabled or config.")
+
+    if "config" in provided and provided["config"] is not None:
+        from src.plugins.models import PluginConfigRequest
+
+        await plugins_routes.update_plugin_config(plugin_id, PluginConfigRequest(config=provided["config"]))
+
+    if "enabled" in provided and provided["enabled"] is not None:
+        if provided["enabled"]:
+            await plugins_routes.enable_plugin(plugin_id)
+        else:
+            await plugins_routes.disable_plugin(plugin_id)
+
+    return await plugins_routes.get_plugin(plugin_id)
+
+
+@router.get(
+    "/plugins/{plugin_id}/data",
+    response_model=PluginData,
+    responses=errors(400, 404, 503),
+    summary="Read what a plugin is currently reporting",
+    description=(
+        "The plugin's latest fetch, in both forms the internal API served separately: `data` is the raw variable "
+        "payload a template reads from, and `lines`/`text` are the board-ready rendering of it. `available` is "
+        "false, with `error` set, when the plugin is disabled, unconfigured, or its source could not be reached."
+    ),
+)
+async def get_plugin_data(plugin_id: str) -> PluginData:
+    from src.displays.service import get_display_service
+
+    payload = await plugins_routes.get_plugin_data(plugin_id)
+    lines: list[str] = list(payload.formatted_lines or [])
+    if not lines and payload.available:
+        # The /displays half of the merge. A plugin that publishes no
+        # formatted_lines of its own still has a board rendering — the display
+        # service falls back to its data's "formatted" key — and GET
+        # /displays/{type} is where that used to be readable.
+        display = get_display_service().get_display(plugin_id)
+        if display.available and display.formatted:
+            lines = display.formatted.split("\n")
+
+    return PluginData(
+        plugin_id=payload.plugin_id,
+        available=bool(payload.available),
+        data=payload.data,
+        lines=lines,
+        text="\n".join(lines),
+        error=payload.error,
+    )
+
+
+@router.post(
+    "/plugins/{plugin_id}/receive",
+    response_model=PluginReceiveResponse,
+    responses=errors(400, 403, 404, 405, 503),
+    summary="Push data into a plugin from outside",
+    description=(
+        "The webhook target. A plugin that declares a `receive` handler accepts a JSON body here and updates what "
+        "it reports without polling anything — the way to drive a board from a system FiestaBoard cannot reach out "
+        "to. 405 means this plugin does not accept pushes."
+    ),
+)
+async def receive_plugin_payload(plugin_id: str, request: Request) -> PluginReceiveResponse:
+    return await plugins_routes.receive_plugin_payload(plugin_id, request)

--- a/tests/conventions_manifest.json
+++ b/tests/conventions_manifest.json
@@ -21,7 +21,8 @@
     "system",
     "templates",
     "transitions",
-    "triggers"
+    "triggers",
+    "v1"
   ],
   "exceptions": [
     {

--- a/tests/golden/api_routes.json
+++ b/tests/golden/api_routes.json
@@ -1636,6 +1636,254 @@
       "kind": "APIRoute"
     },
     {
+      "path": "/v1/boards",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_boards",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/boards/{board}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_board",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/boards/{board}",
+      "methods": [
+        "PATCH"
+      ],
+      "name": "update_board",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/boards/{board}/active-page",
+      "methods": [
+        "PUT"
+      ],
+      "name": "set_board_active_page",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/boards/{board}/message",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "clear_board_message",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/boards/{board}/message",
+      "methods": [
+        "POST"
+      ],
+      "name": "send_to_board",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/collections",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_collections",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/collections",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_collection",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/collections/{collection_id}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_collection",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/collections/{collection_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_collection",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/collections/{collection_id}",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_collection",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/functions",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_functions",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/health",
+      "methods": [
+        "GET"
+      ],
+      "name": "health",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/pages",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_pages",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/pages",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_page",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/pages/{page_id}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_page",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/pages/{page_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_page",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/pages/{page_id}",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_page",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/plugins",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_plugins",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/plugins/{plugin_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_plugin",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/plugins/{plugin_id}",
+      "methods": [
+        "PATCH"
+      ],
+      "name": "update_plugin",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/plugins/{plugin_id}/data",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_plugin_data",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/plugins/{plugin_id}/receive",
+      "methods": [
+        "POST"
+      ],
+      "name": "receive_plugin_payload",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/render",
+      "methods": [
+        "POST"
+      ],
+      "name": "render_template",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/schedules",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_schedules",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/schedules",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_schedule",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/schedules/{schedule_id}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_schedule",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/schedules/{schedule_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_schedule",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/schedules/{schedule_id}",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_schedule",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/status",
+      "methods": [
+        "GET"
+      ],
+      "name": "status",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/v1/variables",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_variables",
+      "kind": "APIRoute"
+    },
+    {
       "path": "/version",
       "methods": [
         "GET"

--- a/tests/test_openapi_front_page.py
+++ b/tests/test_openapi_front_page.py
@@ -36,24 +36,37 @@ def used_tags(schema) -> set[str]:
     return tags
 
 
-def test_every_tag_a_route_uses_is_described(used_tags):
-    """An undescribed tag is a bare heading in the docs sidebar."""
-    described = {tag["name"] for tag in OPENAPI_TAGS if tag.get("description")}
+def test_every_tag_a_route_uses_is_described(used_tags, schema):
+    """An undescribed tag is a bare heading in the docs sidebar.
+
+    Checked against the published schema, not ``OPENAPI_TAGS``: `v1` describes
+    itself in ``src/v1/openapi.py`` and is prepended there, so the constant is
+    only one of the document's two inputs.
+    """
+    described = {tag["name"] for tag in schema["tags"] if tag.get("description")}
     assert used_tags <= described, (
-        f"tags used by routes but not described in OPENAPI_TAGS: {sorted(used_tags - described)}"
+        f"tags used by routes but not described in the published schema: {sorted(used_tags - described)}"
     )
 
 
-def test_no_described_tag_is_stale(used_tags):
+def test_no_described_tag_is_stale(used_tags, schema):
     """A described tag no route uses renders an empty section."""
-    declared = {tag["name"] for tag in OPENAPI_TAGS}
+    declared = {tag["name"] for tag in schema["tags"]}
     assert declared <= used_tags, f"described tags no route uses: {sorted(declared - used_tags)}"
 
 
 def test_the_tag_order_is_the_declared_order(schema):
-    """Swagger renders tags in ``openapi_tags`` order; boards/content lead."""
-    assert [tag["name"] for tag in schema["tags"]] == [tag["name"] for tag in OPENAPI_TAGS]
-    assert schema["tags"][0]["name"] == "service"
+    """Swagger renders tags in schema order; the consumer surface leads.
+
+    Asserted against the **published schema** rather than ``OPENAPI_TAGS``.
+    That constant is only one input: ``src/v1/openapi.py`` prepends the ``v1``
+    tag, because v1 owns its own description and cannot be imported this early
+    in ``api_server``. Comparing to the input would have pinned a list the
+    document does not actually publish.
+    """
+    published = [tag["name"] for tag in schema["tags"]]
+    assert published == ["v1"] + [tag["name"] for tag in OPENAPI_TAGS]
+    assert published[0] == "v1", "the consumer surface must be the first thing a newcomer sees"
     assert [t["name"] for t in schema["tags"]].index("pages") < [t["name"] for t in schema["tags"]].index("debug")
 
 

--- a/tests/test_v1_contract.py
+++ b/tests/test_v1_contract.py
@@ -1,0 +1,930 @@
+"""Value-level contract goldens for the consumer-facing ``/v1`` API.
+
+These routes are new, so there is no "before" to preserve — which makes this
+file the contract rather than a record of one. Every assertion is a promise
+to a consumer this repo cannot see and cannot update in lockstep, so it is
+pinned by **value**: exact status codes, exact ``detail`` strings, exact body
+keys. A shape golden would not see a ``sent`` that stopped meaning "flaps
+moved", and that is the whole point of the surface.
+
+Three decisions are pinned here on purpose, because they are the ones a
+future change is most likely to unpick:
+
+1. **A v1 write honours the install's output target.** With the target set to
+   UI-only nothing reaches the board and the response says so — ``sent:
+   false`` plus a ``reason``. Today ``POST /pages/{id}/send`` honours the
+   target and ``POST /send-message`` ignores it; v1 has one rule.
+2. **The write goes through** :func:`src.ops.executors.send_message`, so the
+   silence, pause, throttle and out-of-band-bookkeeping sequence is one
+   implementation. ``test_paused_board_refuses_the_write`` and
+   ``test_a_write_the_send_floor_dropped_is_a_429`` are the gates observed
+   through v1; if the executor's sequence changes, they change.
+3. **``primary`` is a board id.** Every ``/v1/boards/...`` path accepts it,
+   and it resolves to the same board a real id does.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+#: The executor resolves the DisplayService through ``src.api_server``; the
+#: routes resolve it through ``src.display_runtime``. conftest's autouse
+#: forwarder makes one stub cover both, but both are named here so the file
+#: reads as what it patches.
+SERVICE = "src.api_server.get_service"
+RUNTIME_SERVICE = "src.display_runtime.get_service"
+
+FLAGSHIP_ROWS, FLAGSHIP_COLS = 6, 22
+NOTE_ROWS, NOTE_COLS = 3, 15
+
+BLANK_FLAGSHIP = [[0] * FLAGSHIP_COLS for _ in range(FLAGSHIP_ROWS)]
+
+
+@pytest.fixture
+def client(_isolated_data_dir):
+    from src.api_server import app
+
+    return TestClient(app)
+
+
+@pytest.fixture
+def boards(client):
+    """A flagship primary board and a note secondary, both real settings rows."""
+    from src.settings.service import get_settings_service
+
+    settings = get_settings_service()
+    stored = settings.set_boards(
+        [
+            {"device_type": "flagship", "name": "Kitchen"},
+            {"device_type": "note", "name": "Hallway"},
+        ]
+    )
+    return stored.boards[0]["id"], stored.boards[1]["id"]
+
+
+def _board_client(*, render=(True, True), throttled=False):
+    client = Mock()
+    client.render.return_value = render
+    client.last_send_throttled = throttled
+    client.min_send_interval_ms = 15000
+    client._last_characters = None
+    return client
+
+
+@pytest.fixture
+def board_client():
+    """A reachable board client behind a stubbed DisplayService."""
+    client = _board_client()
+    service = Mock()
+    service.get_board_client.return_value = client
+    service.vb_client = client
+    runtime = Mock()
+    runtime.polled_characters = None
+    runtime.polled_at = None
+    runtime.client = client
+    runtime.last_active_page_content = None
+    service.get_runtime.return_value = runtime
+    with patch(SERVICE, return_value=service), patch(RUNTIME_SERVICE, return_value=service):
+        yield client
+
+
+def _seed_page(client: TestClient, name: str = "Contract Page") -> str:
+    response = client.post(
+        "/v1/pages",
+        json={
+            "name": name,
+            "type": "template",
+            "device_type": "flagship",
+            "template": ["HI", "", "", "", "", ""],
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+# ── the surface itself ──────────────────────────────────────────────────────
+
+
+def test_v1_publishes_exactly_thirty_one_operations():
+    """The contract is 31 operations. A 32nd is a decision, not a side effect."""
+    from tests.test_route_inventory import build_route_inventory
+
+    operations = [
+        f"{method} {record['path']}"
+        for record in build_route_inventory()
+        if record["path"].startswith("/v1")
+        for method in record["methods"]
+    ]
+
+    assert sorted(operations) == sorted(
+        [
+            "GET /v1/boards",
+            "GET /v1/boards/{board}",
+            "PATCH /v1/boards/{board}",
+            "POST /v1/boards/{board}/message",
+            "DELETE /v1/boards/{board}/message",
+            "PUT /v1/boards/{board}/active-page",
+            "GET /v1/pages",
+            "POST /v1/pages",
+            "GET /v1/pages/{page_id}",
+            "PUT /v1/pages/{page_id}",
+            "DELETE /v1/pages/{page_id}",
+            "GET /v1/schedules",
+            "POST /v1/schedules",
+            "GET /v1/schedules/{schedule_id}",
+            "PUT /v1/schedules/{schedule_id}",
+            "DELETE /v1/schedules/{schedule_id}",
+            "GET /v1/collections",
+            "POST /v1/collections",
+            "GET /v1/collections/{collection_id}",
+            "PUT /v1/collections/{collection_id}",
+            "DELETE /v1/collections/{collection_id}",
+            "GET /v1/plugins",
+            "GET /v1/plugins/{plugin_id}",
+            "PATCH /v1/plugins/{plugin_id}",
+            "GET /v1/plugins/{plugin_id}/data",
+            "POST /v1/plugins/{plugin_id}/receive",
+            "GET /v1/variables",
+            "POST /v1/render",
+            "GET /v1/functions",
+            "GET /v1/health",
+            "GET /v1/status",
+        ]
+    )
+
+
+def test_every_v1_operation_has_a_written_summary_and_description():
+    """187 of 187 existing summaries are FastAPI's function names. Not here."""
+    from src.api_server import app
+
+    schema = app.openapi()
+    missing = []
+    for path, operations in schema["paths"].items():
+        if not path.startswith("/v1"):
+            continue
+        for method, operation in operations.items():
+            summary = operation.get("summary", "")
+            description = operation.get("description", "")
+            # An auto-generated summary is the title-cased function name, so
+            # it never contains a lowercase connecting word.
+            if len(summary.split()) < 3 or len(description) < 80:
+                missing.append(f"{method.upper()} {path}")
+
+    assert missing == []
+
+
+def test_the_schema_declares_the_authentication_the_middleware_enforces():
+    """Measured on `next`: no securitySchemes at all, so auth was undiscoverable."""
+    from src.api_server import app
+
+    schema = app.openapi()
+
+    assert schema["components"]["securitySchemes"]["apiToken"]["type"] == "http"
+    assert schema["components"]["securitySchemes"]["apiToken"]["scheme"] == "bearer"
+    assert schema["components"]["securitySchemes"]["session"]["type"] == "apiKey"
+    assert schema["components"]["securitySchemes"]["session"]["in"] == "cookie"
+    assert schema["security"] == [{"apiToken": []}, {"session": []}]
+
+
+# ── boards: read ────────────────────────────────────────────────────────────
+
+
+def test_list_boards_projects_the_fields_a_consumer_needs(client, boards):
+    primary_id, secondary_id = boards
+
+    response = client.get("/v1/boards")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 2
+    assert body["boards"][0] == {
+        "id": primary_id,
+        "name": "Kitchen",
+        "device_type": "flagship",
+        "rows": FLAGSHIP_ROWS,
+        "cols": FLAGSHIP_COLS,
+        "is_primary": True,
+        "paused": False,
+        "schedule_enabled": False,
+    }
+    assert body["boards"][1]["id"] == secondary_id
+    assert body["boards"][1]["is_primary"] is False
+    assert (body["boards"][1]["rows"], body["boards"][1]["cols"]) == (NOTE_ROWS, NOTE_COLS)
+
+
+def test_list_boards_never_serves_board_credentials(client, boards):
+    """A consumer projection, not the stored entry. Not even masked secrets."""
+    response = client.get("/v1/boards")
+
+    for board in response.json()["boards"]:
+        assert set(board) == {
+            "id",
+            "name",
+            "device_type",
+            "rows",
+            "cols",
+            "is_primary",
+            "paused",
+            "schedule_enabled",
+        }
+
+
+def test_primary_resolves_to_the_same_board_as_its_id(client, boards):
+    primary_id, _ = boards
+
+    by_alias = client.get("/v1/boards/primary")
+    by_id = client.get(f"/v1/boards/{primary_id}")
+
+    assert by_alias.status_code == 200
+    assert by_alias.json() == by_id.json()
+    assert by_alias.json()["id"] == primary_id
+
+
+def test_reading_an_unknown_board_is_a_404(client, boards):
+    response = client.get("/v1/boards/no-such-board")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Board not found: no-such-board"}
+
+
+def test_primary_on_an_install_with_no_boards_is_a_404(client):
+    from src.settings.service import get_settings_service
+
+    get_settings_service()._board.boards = []
+
+    response = client.get("/v1/boards/primary")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "No board is configured on this install."}
+
+
+def test_get_board_merges_the_three_reads_into_one_answer(client, boards, board_client):
+    """current-message + settings/active-page + schedules/active/page, once."""
+    primary_id, _ = boards
+    page_id = _seed_page(client)
+    client.put("/v1/boards/primary/active-page", json={"page_id": page_id})
+
+    response = client.get("/v1/boards/primary")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["active_page_id"] == page_id
+    assert body["resolved_page_id"] == page_id
+    assert body["source"] == "manual"
+    assert body["scheduled_page_id"] is None
+    assert body["id"] == primary_id
+    assert set(body) == {
+        "id",
+        "name",
+        "device_type",
+        "rows",
+        "cols",
+        "is_primary",
+        "paused",
+        "schedule_enabled",
+        "characters",
+        "text",
+        "read_at",
+        "active_page_id",
+        "scheduled_page_id",
+        "resolved_page_id",
+        "source",
+        "default_page_id",
+        "override_expires_at",
+    }
+
+
+def test_get_board_reports_the_flaps_currently_on_it(client, boards):
+    grid = [[63] * FLAGSHIP_COLS for _ in range(FLAGSHIP_ROWS)]
+    service = Mock()
+    runtime = Mock()
+    runtime.polled_characters = grid
+    runtime.polled_at = 1_700_000_000.0
+    runtime.client = _board_client()
+    service.get_runtime.return_value = runtime
+    with patch(SERVICE, return_value=service), patch(RUNTIME_SERVICE, return_value=service):
+        response = client.get("/v1/boards/primary")
+
+    assert response.status_code == 200
+    assert response.json()["characters"] == grid
+    assert response.json()["read_at"] == "2023-11-14T22:13:20+00:00"
+
+
+# ── boards: patch ───────────────────────────────────────────────────────────
+
+
+def test_patch_applies_only_the_fields_sent(client, boards):
+    response = client.patch("/v1/boards/primary", json={"paused": True})
+
+    assert response.status_code == 200
+    assert response.json()["paused"] is True
+    assert response.json()["name"] == "Kitchen"
+    assert response.json()["schedule_enabled"] is False
+
+
+def test_patch_renames_a_board(client, boards):
+    response = client.patch("/v1/boards/primary", json={"name": "Living Room"})
+
+    assert response.status_code == 200
+    assert response.json()["name"] == "Living Room"
+    assert client.get("/v1/boards").json()["boards"][0]["name"] == "Living Room"
+
+
+def test_patch_sets_the_schedule_gap_page(client, boards):
+    page_id = _seed_page(client)
+
+    response = client.patch("/v1/boards/primary", json={"default_page_id": page_id})
+
+    assert response.status_code == 200
+    assert response.json()["default_page_id"] == page_id
+
+
+def test_patch_with_an_unknown_default_page_is_a_404(client, boards):
+    response = client.patch("/v1/boards/primary", json={"default_page_id": "nope"})
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Page not found: nope"}
+
+
+def test_patch_rejects_a_coerced_boolean(client, boards):
+    """StrictBool: "yes" must not silently stop the board (the #1887 hole)."""
+    response = client.patch("/v1/boards/primary", json={"paused": "yes"})
+
+    assert response.status_code == 422
+
+
+# ── boards: the front door ──────────────────────────────────────────────────
+
+
+def test_text_is_wrapped_to_the_board_and_sent(client, boards, board_client):
+    primary_id, _ = boards
+
+    response = client.post("/v1/boards/primary/message", json={"text": "Hello World"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["sent"] is True
+    assert body["board_id"] == primary_id
+    assert body["text"] == "Hello World"
+    assert body["expires_at"] is None
+    assert body["reason"] is None
+    assert len(body["characters"]) == FLAGSHIP_ROWS
+    assert all(len(row) == FLAGSHIP_COLS for row in body["characters"])
+    assert board_client.render.called
+
+
+def test_the_message_reaches_a_secondary_board(client, boards, board_client):
+    """The defect this API exists to fix: POST /send-message cannot address board 2."""
+    _, secondary_id = boards
+
+    response = client.post(f"/v1/boards/{secondary_id}/message", json={"text": "Board two"})
+
+    assert response.status_code == 200
+    assert response.json()["sent"] is True
+    assert response.json()["board_id"] == secondary_id
+    grid = response.json()["characters"]
+    assert (len(grid), len(grid[0])) == (NOTE_ROWS, NOTE_COLS)
+
+
+def test_fill_paints_the_whole_board_with_one_code(client, boards, board_client):
+    response = client.post("/v1/boards/primary/message", json={"fill": 63})
+
+    assert response.status_code == 200
+    assert response.json()["characters"] == [[63] * FLAGSHIP_COLS for _ in range(FLAGSHIP_ROWS)]
+
+
+def test_fill_zero_blanks_the_board(client, boards, board_client):
+    response = client.post("/v1/boards/primary/message", json={"fill": 0})
+
+    assert response.status_code == 200
+    assert response.json()["characters"] == BLANK_FLAGSHIP
+
+
+def test_a_raw_grid_is_sent_verbatim(client, boards, board_client):
+    grid = [[i % 26 + 1] * FLAGSHIP_COLS for i in range(FLAGSHIP_ROWS)]
+
+    response = client.post("/v1/boards/primary/message", json={"characters": grid})
+
+    assert response.status_code == 200
+    assert response.json()["characters"] == grid
+    assert board_client.render.call_args.args[0] == grid
+
+
+def test_a_grid_of_the_wrong_size_is_a_400(client, boards, board_client):
+    response = client.post("/v1/boards/primary/message", json={"characters": [[0, 0, 0]]})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "characters must be a 6x22 grid for this board, got 1x3"}
+
+
+def test_an_out_of_range_flap_code_is_a_422(client, boards, board_client):
+    response = client.post("/v1/boards/primary/message", json={"fill": 99})
+
+    assert response.status_code == 422
+
+
+def test_a_boolean_flap_code_is_rejected(client, boards, board_client):
+    """StrictInt: isinstance(True, int) is true, and true must not mean code 1."""
+    response = client.post("/v1/boards/primary/message", json={"fill": True})
+
+    assert response.status_code == 422
+
+
+def test_a_saved_page_is_rendered_and_sent(client, boards, board_client):
+    page_id = _seed_page(client)
+
+    response = client.post("/v1/boards/primary/message", json={"page_id": page_id})
+
+    assert response.status_code == 200
+    assert response.json()["sent"] is True
+    assert response.json()["text"].splitlines()[0].strip() == "HI"
+
+
+def test_sending_an_unknown_page_is_a_404(client, boards, board_client):
+    response = client.post("/v1/boards/primary/message", json={"page_id": "nope"})
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Page not found: nope"}
+
+
+def test_supplying_two_content_fields_is_a_422(client, boards, board_client):
+    response = client.post("/v1/boards/primary/message", json={"text": "a", "fill": 1})
+
+    assert response.status_code == 422
+    assert "Supply exactly one of text, lines, characters, page_id or fill" in response.text
+
+
+def test_supplying_no_content_field_is_a_422(client, boards, board_client):
+    response = client.post("/v1/boards/primary/message", json={})
+
+    assert response.status_code == 422
+    assert "got none" in response.text
+
+
+# ── boards: what "sent" actually means ──────────────────────────────────────
+
+
+def test_a_ui_only_output_target_writes_nothing_and_says_so(client, boards, board_client):
+    """Decision 1: v1 writes honour the global output target, and report it."""
+    from src.settings.service import get_settings_service
+
+    get_settings_service().set_output_target("ui")
+
+    response = client.post("/v1/boards/primary/message", json={"text": "Hello"})
+
+    assert response.status_code == 200
+    assert response.json()["sent"] is False
+    assert response.json()["reason"] == ("The install's output target is UI only, so nothing was written to the board.")
+    assert response.json()["characters"] != []
+    board_client.render.assert_not_called()
+
+
+def test_unchanged_content_is_reported_not_claimed_as_sent(client, boards):
+    client_stub = _board_client(render=(True, False))
+    service = Mock()
+    service.get_board_client.return_value = client_stub
+    service.vb_client = client_stub
+    with patch(SERVICE, return_value=service), patch(RUNTIME_SERVICE, return_value=service):
+        response = client.post("/v1/boards/primary/message", json={"text": "Hello"})
+
+    assert response.status_code == 200
+    assert response.json()["sent"] is False
+    assert response.json()["reason"] == (
+        "The board already shows this exact content. Send force=true to write it anyway."
+    )
+
+
+def test_force_is_passed_through_to_the_board_client(client, boards, board_client):
+    client.post("/v1/boards/primary/message", json={"text": "Hello", "force": True})
+
+    assert board_client.render.call_args.kwargs["force"] is True
+
+
+def test_a_per_send_transition_overrides_the_stored_settings(client, boards, board_client):
+    client.post(
+        "/v1/boards/primary/message",
+        json={"text": "Hello", "transition": {"strategy": "instant", "interval_ms": 40, "step_size": 3}},
+    )
+
+    kwargs = board_client.render.call_args.kwargs
+    assert kwargs["strategy"] == "instant"
+    assert kwargs["step_interval_ms"] == 40
+    assert kwargs["step_size"] == 3
+
+
+# ── boards: the gates, observed through v1 ──────────────────────────────────
+
+
+def test_paused_board_refuses_the_write(client, boards, board_client):
+    from src.settings.service import get_settings_service
+
+    primary_id, _ = boards
+    get_settings_service().set_paused(True, board_id=primary_id)
+
+    response = client.post("/v1/boards/primary/message", json={"text": "Hello"})
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "Board is paused — sends are blocked until it is resumed."}
+    board_client.render.assert_not_called()
+
+
+def test_the_silence_window_refuses_the_write(client, boards, board_client):
+    with patch("src.config.Config.is_silence_mode_active", return_value=True):
+        response = client.post("/v1/boards/primary/message", json={"text": "Hello"})
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "Manual sends blocked during silence mode to prevent wake-ups"}
+    board_client.render.assert_not_called()
+
+
+def test_a_write_the_send_floor_dropped_is_a_429(client, boards):
+    client_stub = _board_client(render=(True, False), throttled=True)
+    service = Mock()
+    service.get_board_client.return_value = client_stub
+    service.vb_client = client_stub
+    with patch(SERVICE, return_value=service), patch(RUNTIME_SERVICE, return_value=service):
+        response = client.post("/v1/boards/primary/message", json={"text": "Hello"})
+
+    assert response.status_code == 429
+    assert response.json() == {
+        "detail": "Send skipped: the board accepts at most one message every 15s. Retry shortly."
+    }
+    assert response.headers["Retry-After"] == "15"
+
+
+def test_a_refused_send_is_a_500_with_an_unstuttered_detail(client, boards):
+    client_stub = _board_client(render=(False, False))
+    service = Mock()
+    service.get_board_client.return_value = client_stub
+    service.vb_client = client_stub
+    with patch(SERVICE, return_value=service), patch(RUNTIME_SERVICE, return_value=service):
+        response = client.post("/v1/boards/primary/message", json={"text": "Hello"})
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Failed to send message to the board."}
+
+
+def test_writing_with_no_board_client_is_a_503(client, boards):
+    service = Mock()
+    service.get_board_client.return_value = None
+    primary_id = boards[0]
+    with patch(SERVICE, return_value=service), patch(RUNTIME_SERVICE, return_value=service):
+        response = client.post("/v1/boards/primary/message", json={"text": "Hello"})
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": f"Board client not initialized: {primary_id}"}
+
+
+# ── boards: timed messages ──────────────────────────────────────────────────
+
+
+def test_duration_arms_a_timed_message_and_reports_when_it_expires(client, boards, board_client):
+    response = client.post("/v1/boards/primary/message", json={"text": "Back soon", "duration_minutes": 20})
+
+    assert response.status_code == 200
+    assert response.json()["sent"] is True
+    assert response.json()["expires_at"] is not None
+    stored = client.get("/settings/temporary-override").json()
+    assert stored["template"] is not None
+    assert stored["revert_mode"] == "schedule"
+
+
+def test_duration_on_a_secondary_board_is_refused_rather_than_faked(client, boards, board_client):
+    """The override store is global and the loop applies it primary-only."""
+    _, secondary_id = boards
+
+    response = client.post(f"/v1/boards/{secondary_id}/message", json={"text": "x", "duration_minutes": 5})
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": (
+            "duration_minutes is only supported on the primary board — "
+            "timed messages are applied by the display loop for the primary board only."
+        )
+    }
+
+
+def test_duration_with_a_raw_grid_is_refused(client, boards, board_client):
+    response = client.post("/v1/boards/primary/message", json={"fill": 0, "duration_minutes": 5})
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "duration_minutes cannot be combined with characters or fill; use text, lines or page_id"
+    }
+
+
+def test_revert_mode_without_a_duration_is_refused(client, boards, board_client):
+    response = client.post("/v1/boards/primary/message", json={"text": "x", "revert_mode": "blank"})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "revert_mode requires duration_minutes"}
+
+
+def test_revert_page_id_without_page_mode_is_refused(client, boards, board_client):
+    response = client.post(
+        "/v1/boards/primary/message",
+        json={"text": "x", "duration_minutes": 5, "revert_mode": "blank", "revert_page_id": "p"},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": 'revert_page_id requires revert_mode "page"'}
+
+
+# ── boards: clearing ────────────────────────────────────────────────────────
+
+
+def test_delete_cancels_a_timed_message_and_re_renders(client, boards, board_client):
+    client.post("/v1/boards/primary/message", json={"text": "Back soon", "duration_minutes": 20})
+
+    response = client.delete("/v1/boards/primary/message")
+
+    assert response.status_code == 200
+    assert response.json()["expires_at"] is None
+    assert client.get("/settings/temporary-override").json()["template"] is None
+
+
+# ── boards: active page ─────────────────────────────────────────────────────
+
+
+def test_pinning_a_page_sets_it_and_reports_delivery(client, boards, board_client):
+    primary_id, _ = boards
+    page_id = _seed_page(client)
+
+    response = client.put("/v1/boards/primary/active-page", json={"page_id": page_id})
+
+    assert response.status_code == 200
+    assert response.json() == {"board_id": primary_id, "page_id": page_id, "sent": True, "warnings": []}
+
+
+def test_unpinning_clears_the_selection(client, boards, board_client):
+    page_id = _seed_page(client)
+    client.put("/v1/boards/primary/active-page", json={"page_id": page_id})
+
+    response = client.put("/v1/boards/primary/active-page", json={"page_id": None})
+
+    assert response.status_code == 200
+    assert response.json()["page_id"] is None
+    assert client.get("/v1/boards/primary").json()["active_page_id"] is None
+
+
+def test_pinning_a_page_that_does_not_fit_the_board_is_a_400(client, boards, board_client):
+    _, secondary_id = boards
+    page_id = _seed_page(client)
+
+    response = client.put(f"/v1/boards/{secondary_id}/active-page", json={"page_id": page_id})
+
+    assert response.status_code == 400
+    assert "not compatible with board" in response.json()["detail"]
+
+
+# ── pages, schedules, collections ───────────────────────────────────────────
+
+
+def test_page_crud_round_trips(client):
+    created = client.post(
+        "/v1/pages",
+        json={"name": "Round Trip", "type": "template", "device_type": "flagship", "template": ["A"]},
+    )
+    assert created.status_code == 201
+    page_id = created.json()["id"]
+
+    assert client.get(f"/v1/pages/{page_id}").json()["name"] == "Round Trip"
+    assert client.get("/v1/pages").json()["total"] == 1
+
+    updated = client.put(f"/v1/pages/{page_id}", json={"name": "Renamed"})
+    assert updated.status_code == 200
+    assert updated.json()["page"]["name"] == "Renamed"
+
+    deleted = client.delete(f"/v1/pages/{page_id}")
+    assert deleted.status_code == 200
+    assert deleted.json()["id"] == page_id
+    assert client.get(f"/v1/pages/{page_id}").status_code == 404
+
+
+def test_an_unknown_page_is_a_404_with_the_id_in_the_detail(client):
+    response = client.get("/v1/pages/nope")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Page not found: nope"}
+
+
+def test_schedule_crud_round_trips(client, boards):
+    page_id = _seed_page(client)
+    primary_id, _ = boards
+
+    created = client.post(
+        "/v1/schedules",
+        json={"board_id": primary_id, "page_id": page_id, "start_time": "08:00", "end_time": "09:00"},
+    )
+    assert created.status_code == 201
+    schedule_id = created.json()["id"]
+
+    assert client.get(f"/v1/schedules/{schedule_id}").json()["start_time"] == "08:00"
+    assert client.get("/v1/schedules", params={"board_id": primary_id}).json()["total"] == 1
+
+    updated = client.put(f"/v1/schedules/{schedule_id}", json={"start_time": "10:00"})
+    assert updated.status_code == 200
+    assert updated.json()["start_time"] == "10:00"
+    assert updated.json()["end_time"] == "09:00", "a partial update must not wipe the fields it omits"
+
+    deleted = client.delete(f"/v1/schedules/{schedule_id}")
+    assert deleted.status_code == 200
+    assert deleted.json() == {"id": schedule_id}
+
+
+def test_creating_a_schedule_on_an_unknown_board_is_a_404(client):
+    page_id = _seed_page(client)
+
+    response = client.post(
+        "/v1/schedules",
+        json={"board_id": "nope", "page_id": page_id, "start_time": "08:00"},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Board not found: nope"}
+
+
+def test_collection_crud_round_trips(client):
+    first = _seed_page(client, "One")
+    second = _seed_page(client, "Two")
+
+    created = client.post("/v1/collections", json={"name": "Rotation", "page_ids": [first, second]})
+    assert created.status_code == 201
+    collection_id = created.json()["id"]
+    assert collection_id.startswith("collection:")
+
+    assert client.get(f"/v1/collections/{collection_id}").json()["page_ids"] == [first, second]
+    assert client.get("/v1/collections").json()["total"] == 1
+
+    updated = client.put(f"/v1/collections/{collection_id}", json={"name": "Renamed"})
+    assert updated.status_code == 200
+    assert updated.json()["name"] == "Renamed"
+
+    deleted = client.delete(f"/v1/collections/{collection_id}")
+    assert deleted.status_code == 200
+    assert deleted.json() == {"id": collection_id}
+
+
+def test_a_collection_referencing_a_missing_page_is_a_400(client):
+    response = client.post("/v1/collections", json={"name": "Bad", "page_ids": ["nope"]})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Page not found: nope"}
+
+
+# ── plugins ─────────────────────────────────────────────────────────────────
+
+
+def test_the_plugin_catalogue_merges_plugins_and_displays(client):
+    """/plugins and /displays were the same registry listing, published twice."""
+    response = client.get("/v1/plugins")
+
+    assert response.status_code == 200
+    body = response.json()
+    ids = {plugin["id"] for plugin in body["plugins"]}
+    assert "date_time" in ids
+    assert body["total"] == len(body["plugins"])
+    assert body["enabled_count"] == sum(1 for p in body["plugins"] if p["enabled"])
+    assert set(body["plugins"][0]) == {
+        "id",
+        "name",
+        "version",
+        "description",
+        "author",
+        "category",
+        "plugin_type",
+        "icon",
+        "enabled",
+        "configured",
+    }
+    # The legacy pair answers the same catalogue.
+    assert ids == {entry["type"] for entry in client.get("/displays").json()["displays"]}
+
+
+def test_patch_collapses_enable_disable_and_config(client):
+    enabled = client.patch("/v1/plugins/date_time", json={"enabled": True})
+    assert enabled.status_code == 200
+    assert enabled.json()["enabled"] is True
+
+    configured = client.patch("/v1/plugins/date_time", json={"config": {"time_format": "24h"}})
+    assert configured.status_code == 200
+    assert configured.json()["config"]["time_format"] == "24h"
+
+    disabled = client.patch("/v1/plugins/date_time", json={"enabled": False})
+    assert disabled.status_code == 200
+    assert disabled.json()["enabled"] is False
+
+
+def test_patch_with_an_empty_body_is_a_400(client):
+    response = client.patch("/v1/plugins/date_time", json={})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Send at least one of enabled or config."}
+
+
+def test_patching_an_unknown_plugin_is_a_404(client):
+    response = client.patch("/v1/plugins/nope", json={"enabled": True})
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Plugin not found: nope"}
+
+
+def test_plugin_data_serves_both_the_raw_payload_and_the_board_lines(client):
+    client.patch("/v1/plugins/date_time", json={"enabled": True})
+
+    response = client.get("/v1/plugins/date_time/data")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["plugin_id"] == "date_time"
+    assert body["available"] is True
+    assert "date" in body["data"]
+    assert body["text"] == "\n".join(body["lines"])
+    assert body["error"] is None
+
+
+def test_plugin_data_for_a_disabled_plugin_is_a_400(client):
+    response = client.get("/v1/plugins/date_time/data")
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Plugin not enabled: date_time"}
+
+
+# ── templating and service ──────────────────────────────────────────────────
+
+
+def test_variables_merges_the_engine_and_plugin_catalogues(client):
+    response = client.get("/v1/variables")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["colors"]["red"] == 63
+    assert "sun" in body["symbols"]
+    assert body["plugin_system_enabled"] is True
+    assert set(body) == {
+        "variables",
+        "max_lengths",
+        "variable_metadata",
+        "variable_groups",
+        "colors",
+        "symbols",
+        "filters",
+        "formatting",
+        "syntax_examples",
+        "plugin_system_enabled",
+    }
+
+
+def test_functions_lists_the_expression_helpers(client):
+    response = client.get("/v1/functions")
+
+    assert response.status_code == 200
+    assert response.json()["functions"]["IF"] == {
+        "category": "logic",
+        "signature": "IF(cond, then[, else])",
+        "summary": "Conditional value",
+    }
+
+
+def test_render_sizes_the_output_to_the_named_board(client, boards):
+    _, secondary_id = boards
+
+    flagship = client.post("/v1/render", json={"template": ["HI"]}, params={"board": "primary"})
+    note = client.post("/v1/render", json={"template": ["HI"]}, params={"board": secondary_id})
+
+    assert flagship.status_code == 200
+    assert flagship.json()["line_count"] == FLAGSHIP_ROWS
+    assert note.json()["line_count"] == NOTE_ROWS
+
+
+def test_render_against_an_unknown_board_is_a_404(client, boards):
+    response = client.post("/v1/render", json={"template": ["HI"]}, params={"board": "nope"})
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Board not found: nope"}
+
+
+def test_render_never_writes_to_a_board(client, boards, board_client):
+    client.post("/v1/render", json={"template": ["HI"]}, params={"board": "primary"})
+
+    board_client.render.assert_not_called()
+
+
+def test_health_answers_without_a_configured_board(client):
+    response = client.get("/v1/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+    assert response.json()["service_running"] is False
+
+
+def test_status_reports_per_board_state(client, boards, board_client):
+    primary_id, _ = boards
+
+    response = client.get("/v1/status")
+
+    assert response.status_code == 200
+    assert response.json()["boards"][primary_id]["paused"] is False


### PR DESCRIPTION
## What this is

Wave 1 of the API-ergonomics phase: the consumer-facing `/v1` surface, built to
the binding contract in `.superpowers/specs/2026-09-07-api-ergonomics-design.md`
("Wave 1 — the `/v1` route contract").

**Purely additive.** Not one existing route changes path, shape or behaviour.
The route golden gains 248 lines and removes zero.

## The 31 operations, as built

| | Path |
|---|---|
| `GET` | `/v1/boards` |
| `GET` `PATCH` | `/v1/boards/{board}` |
| `POST` `DELETE` | `/v1/boards/{board}/message` |
| `PUT` | `/v1/boards/{board}/active-page` |
| `GET` `POST` | `/v1/pages` |
| `GET` `PUT` `DELETE` | `/v1/pages/{page_id}` |
| `GET` `POST` | `/v1/schedules` |
| `GET` `PUT` `DELETE` | `/v1/schedules/{schedule_id}` |
| `GET` `POST` | `/v1/collections` |
| `GET` `PUT` `DELETE` | `/v1/collections/{collection_id}` |
| `GET` | `/v1/plugins` |
| `GET` `PATCH` | `/v1/plugins/{plugin_id}` |
| `GET` | `/v1/plugins/{plugin_id}/data` |
| `POST` | `/v1/plugins/{plugin_id}/receive` |
| `GET` | `/v1/variables` |
| `POST` | `/v1/render` |
| `GET` | `/v1/functions` |
| `GET` | `/v1/health` |
| `GET` | `/v1/status` |

Measured on the built image: 31 `/v1` operations out of 231 total.

## The three decisions, as implemented

1. **v1 writes honour the global output target.** `should_send_to_board()` is
   checked before anything is written; `sent` is true only when flaps moved,
   and `reason` says why when they did not (UI-only target, unchanged content).
   Pinned by `test_a_ui_only_output_target_writes_nothing_and_says_so`.
2. **The write goes through `src/ops/executors.py::send_message`.** The silence,
   pause, throttle and out-of-band-bookkeeping sequence is not re-implemented.
3. **`{board}` accepts a board id or `primary`**, and the two resolve to the
   same document (`test_primary_resolves_to_the_same_board_as_its_id`).

## What I changed outside `src/v1/`

* **`src/ops/executors.py`** — `send_message`'s gate sequence is factored into
  `_resolve_send_target` / `_after_send`, and a raw-grid sibling
  `send_characters` reuses it. Without this the `characters` / `fill` / `page_id`
  forms would have needed a second copy of the silence/pause/bookkeeping
  sequence, which is exactly what the contract forbids. `send_message`'s
  envelopes, ordering and observable behaviour are unchanged — the parity suites
  (`test_op_parity`, `test_mcp_state_effects`, `test_chat_op_http_parity`) pass
  untouched. Both executors gained optional keyword-only `strategy`,
  `step_interval_ms`, `step_size` and `force`, each defaulting to the prior
  behaviour, so v1 can expose the `transition` and `force` fields the contract
  lists without a settings round-trip.
* **`src/displays/messages.py`** — `render_message` gained `force: bool = False`,
  passed through to `client.render`. Additive.
* **`src/auth/middleware.py`** — bearer acceptance extended from `/mcp*` to
  `/v1/*`. One deliberate asymmetry: on `/mcp` a request with no `Authorization`
  header is still challenged, but on `/v1` it falls through to the ordinary
  session-cookie check, so configuring a token does not lock the browser out of
  a surface the web UI migrates onto in Wave 2.
* **`src/api_server.py`** — two adjacent lines at the bottom (`from .v1 import
  mount_v1` + `mount_v1(app)`). Placed at the bottom rather than in the import
  block because `src/v1` imports the domain routers it adapts.
* **`tests/conventions_manifest.json`** — `v1` appended to `converted_domains`,
  with **zero exceptions**.
* **`tests/golden/api_routes.json`** — +248 lines, −0.

## Deviations from the contract, and why

* **Hand-raised rejections are 400, not 422.** The contract says "422 on a bad
  body"; `API_CONVENTIONS.md` §Error contract says 422 belongs to FastAPI and a
  hand-raised semantic rejection is a 400. I followed the conventions doc and
  pushed as much validation as possible into Pydantic so the real 422s are
  FastAPI's: flap codes are `StrictInt` with `ge=0, le=71` (so `{"fill": true}`
  cannot mean code 1 — the hole `/debug/fill`'s hand-rolled check left open),
  `duration_minutes` is `ge=1, le=480`, and "exactly one content field" is a
  model validator. What stayed hand-raised and became 400: a grid whose *size*
  does not fit the board, and the `duration_minutes` / `revert_mode`
  combinations below.
* **`revert_page_id` added to the message body.** The contract lists
  `revert_mode`, and `revert_mode: "page"` is unusable without it.
* **`duration_minutes` is primary-board only, and refuses raw grids.** The
  temporary-override store it arms is global and `src/main.py` applies it for
  the primary board only, and it can hold text but not a flap grid. Rather than
  accept the request and silently do nothing, both cases are a 400 naming the
  limitation. Making the override per-board is a real feature, not an adapter's
  job.
* **Response body carries `board_id` and `reason` alongside the contract's
  `sent`/`characters`/`text`/`expires_at`.** `board_id` because `primary` needs
  resolving for the caller, `reason` because `sent: false` is otherwise
  unactionable.
* **One executor gate genuinely differs from REST, and REST is right.** A write
  the client-side send floor dropped is a 429 in `POST /send-message`
  (`_raise_if_throttled`) but a plain `skipped: true` from
  `executors.send_message`. v1 follows REST: it reuses the debug router's
  `_raise_if_throttled` so all three manual senders answer identically. The
  executor's own envelope is left alone — changing it would change MCP's
  behaviour, which is not this PR's business, but it is worth a follow-up.
* **Silence detail string.** v1 serves the executor's wording ("Manual sends
  blocked during silence mode to prevent wake-ups") rather than `board_api`'s
  `SILENCE_DETAIL`. Pinned by value; collapsing the two is a follow-up.

## The ratchet entry is load-bearing

`v1` added to `converted_domains`, then `responses=errors(503)` deleted from
`GET /v1/functions`:

```
tests/test_api_conventions_ratchet.py ...F....................         [100%]
=================================== FAILURES ===================================
________________ test_converted_domains_declare_error_responses ________________
tests/test_api_conventions_ratchet.py:350: in test_converted_domains_declare_error_responses
    assert offenders == [], (
E   AssertionError: Converted domains must declare the errors they raise so the OpenAPI schema and the web client agree (API_CONVENTIONS.md §errors). Add responses={404: ...}, or add a {"rule": "declared_errors", ...} exception to tests/conventions_manifest.json with a reason:
E       GET /v1/functions: declares no error status in responses=
E   assert ['GET /v1/fun...n responses='] == []
E     Left contains one more item: 'GET /v1/functions: declares no error status in responses='
=========================== short test summary info ============================
FAILED tests/test_api_conventions_ratchet.py::test_converted_domains_declare_error_responses
========================= 1 failed, 23 passed in 0.87s =========================
```

Restored; 24 passed.

Worth recording: deleting `response_model=` alone did **not** fail the ratchet,
because FastAPI infers the response model from the handler's return annotation.
Every v1 handler carries one, so that rule is satisfied twice over.

## The contract tests are not vacuous

`tests/test_v1_contract.py`, 64 tests, every route pinned by value. Proof for
the headline decision — replacing `if not settings_service.should_send_to_board():`
with `if False:`:

```
tests/test_v1_contract.py .F                                             [100%]
tests/test_v1_contract.py:480: in test_a_ui_only_output_target_writes_nothing_and_says_so
E   assert True is False
FAILED tests/test_v1_contract.py::test_a_ui_only_output_target_writes_nothing_and_says_so
================== 1 failed, 1 passed, 62 deselected in 0.70s ==================
```

Three of the 64 were written before the code and failed first: the
summary/description gate caught four routes whose descriptions were under 80
characters and one two-word summary, all fixed rather than the assertion
weakened.

## Suite

Both runs: `docker run --rm -m 3g -v "$PWD":/app -v "$PWD/.pytest-data":/app/data -w /app fb-test:latest python -m pytest tests/ -q`

| | before (`origin/next`) | after |
|---|---|---|
| passed | 6610 | **6674** (+64, exactly the new file) |
| skipped | 2 | 2 |
| failed | 1 | 1 |

The single failure is identical before and after and is an artefact of running
in a git worktree: `scripts/check_image_formats.py` shells out to `git ls-files`,
and the worktree's `.git` is a file pointing outside the container mount.

**Data-dir leak count: 0** (explicit `-v .pytest-data:/app/data` mount, empty
after the run).

Lint at the CI pin: `ruff==0.16.5 check` + `format --check` clean over
`src/ plugins/ tests/ scripts/`.

## Verified against a running container, not asserted

Built the production image from this branch, ran it with
`FIESTABOARD_AUTH_ENABLED=true` and a `FIESTABOARD_MCP_TOKEN`, two virtual
boards configured (flagship + note).

The spec's hello-world:

```console
$ curl -X POST http://localhost:4433/api/v1/boards/primary/message \
    -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
    -d '{"text": "Hello World"}'
{
  "sent": true,
  "board_id": "a45ac824-95c9-4cb7-b07d-37f52211fb46",
  "characters": [[8,5,12,12,15,0,23,15,18,12,4,0,0,0,0,0,0,0,0,0,0,0], ...],
  "text": "Hello World",
  "expires_at": null,
  "reason": null
}
```

Board 2, reachable over HTTP for the first time, and sized to its own geometry:

```console
$ curl -X POST http://localhost:4433/api/v1/boards/$B2/message \
    -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
    -d '{"text":"Board two"}'
{"sent": true, "board_id": "42f70ce1-...", "text": "Board two", "expires_at": null, "reason": null}
grid: 3 x 15

$ curl -H "Authorization: Bearer $TOKEN" http://localhost:4433/api/v1/boards/$B2
{ ..., "device_type": "note", "rows": 3, "cols": 15, "is_primary": false,
  "text": "BOARD TWO      \n               \n               ", ... }
```

Auth, live:

```console
$ curl -o /dev/null -w '%{http_code}\n' -X POST .../v1/boards/primary/message -d '{"text":"Hello World"}'
409      # no credential -> the pre-existing setup-required response
$ curl ... -H "Authorization: Bearer wrong" ...
401
```

`POST /api/send-message` with the same bearer token answers **409** — it is not
a bearer path, which is the mechanical reason a script could not authenticate
against the REST API before this PR.

Gates, live:

```console
PATCH {"paused": true}  -> 200
POST  {"text":"x"}      -> {"detail": "Board is paused — sends are blocked until it is resumed."}   (409)
POST  {"characters":[[0,0,0]]} -> {"detail": "characters must be a 6x22 grid for this board, got 1x3"}  (400)
```

And the schema now says authentication exists:

```console
$ curl -s http://localhost:4433/api/openapi.json | jq '.components.securitySchemes.apiToken.scheme, .security'
"bearer"
[{"apiToken": []}, {"session": []}]
```

## Left open

* **"API token" rename in web UI copy.** Done in the OpenAPI security-scheme
  description and the middleware docstrings. Deliberately **not** done in
  `web/messages/*.json`: that is 14 locale files, and changing English values
  alone leaves 13 locales saying "MCP token". It belongs in a web-side PR, not
  in an additive backend one.
* **Generating `docs/reference/api-endpoints.md` from the schema.** Named in the
  design; not in Wave 1's scope. The hand-written reference still documents ~51
  of 199 operations and still drifts.
* **Hiding the 185 internal operations** and the `Deprecation`/`Sunset` headers
  on `/send-message` and `/refresh` — Wave 2, as scoped.
* **Two string/behaviour duplications v1 now pins by value** and which should
  collapse later: the silence-refusal wording, and the executor's non-429
  answer to a throttled write.
