### PR TITLE
perf(api): lazy MCP mount, a real /api/docs front page, sunset headers, and two seam removals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -920,14 +920,19 @@ jobs:
         # since mcp 2.0 a GET opens a never-ending SSE listen stream, so a
         # plain curl GET hangs until the job timeout. An empty POST returns
         # a JSON-RPC validation error (400) immediately.
+        #
+        # 503 counts as a failure too: the mount is registered eagerly and the
+        # mcp package imported on first request, so a broken install now shows
+        # up as "MCP server unavailable" from the mount rather than a 404 from
+        # a missing route. This is the request that pays that first import.
         run: |
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" -m 15 \
             -X POST -H "Content-Type: application/json" \
             -H "Accept: application/json, text/event-stream" \
             -d '{}' "$BASE_URL/api/mcp/" || echo "000")
           echo "POST /api/mcp/ -> $STATUS"
-          if [ "$STATUS" = "404" ]; then
-            echo "❌ MCP endpoint returned 404 — mcp package likely missing or mount failed"
+          if [ "$STATUS" = "404" ] || [ "$STATUS" = "503" ]; then
+            echo "❌ MCP endpoint returned $STATUS — mcp package likely missing or activation failed"
             docker logs fiestaboard-ai | grep -i mcp | tail -20
             exit 1
           fi

--- a/docs/internal/reference/API_CONVENTIONS.md
+++ b/docs/internal/reference/API_CONVENTIONS.md
@@ -197,6 +197,21 @@ response body we intend to delete buys a lockstep web change and nothing else.
 "deprecation, never deletion" applies to unused routes too — "nothing in this
 repo calls it" is not the same claim as "nothing calls it".
 
+Since then those eleven serve the notice on the wire rather than only in the
+OpenAPI schema. Every one sends `Deprecation: true` and
+`Sunset: Tue, 01 Dec 2026 00:00:00 GMT`; the ten replaced by the generic
+remote-options endpoint also send a `rel="successor-version"` link to
+`/api/plugins/<plugin_id>/options/{options_id}`, with the plugin id filled in
+and `options_id` left as a template because only the plugin's own manifest
+declares it. `/transit/cache/status` has no successor and sends no link. The
+date lives in `DEPRECATED_ROUTES_SUNSET` in `src/api_server.py`, and
+`tests/test_deprecated_route_headers.py` pins which route points where.
+
+A quarter, not "two releases": FiestaBoard cuts a minor release every few
+days, so a release count is not a window an outside integrator can plan
+against — and callers this repo cannot see are the entire reason these routes
+still exist.
+
 ## Identifiers
 
 - Resource ids are validated against reserved route words so

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -14,6 +14,7 @@ from typing import Any
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import PlainTextResponse
 
 # Load environment variables from .env file before importing modules that may
 # read them at import time. The intra-package imports below intentionally come
@@ -167,35 +168,16 @@ def _run_startup_migrations() -> None:
 async def lifespan(app: FastAPI):
     """Lifespan context manager for startup and shutdown events.
 
-    Also runs the MCP server's ``StreamableHTTPSessionManager`` for the
-    duration of the API. FastAPI's ``app.mount(...)`` does NOT propagate
-    a sub-app's lifespan, so without wiring this here the MCP session
-    manager's ``_task_group`` is never created and every request to
-    ``/api/mcp/*`` returns 404. The wrapping is best-effort: if the mcp
-    package failed to load or the session manager init throws, the rest
-    of the API still comes up — MCP just stays disabled.
+    Startup does **not** touch MCP: the ``mcp`` package is imported by the
+    lazy mount (``_LazyMCPMount``) on the first request to ``/api/mcp``,
+    and that mount also owns the session manager's lifecycle. Shutdown
+    closes it if it was ever activated.
     """
-    global _service_thread, _shutting_down, _service_running
-
-    # Resolve the MCP context manager (or fall back to a no-op) before we
-    # decide which branch to take. The mount at the bottom of this module
-    # already called ``streamable_http_app()`` (which lazily creates the
-    # session manager), so it's safe to access ``session_manager`` here.
-    _mcp_ctx = None
-    try:
-        from .mcp_server import mcp_server as _mcp_for_lifespan
-
-        if _mcp_for_lifespan is not None:
-            _mcp_ctx = _mcp_for_lifespan.session_manager.run()
-    except Exception as _mcp_exc:  # pragma: no cover — defensive
-        logger.warning(
-            "MCP session manager could not be wired into lifespan: %s",
-            _mcp_exc,
-        )
-        _mcp_ctx = None
+    global _service_thread, _shutting_down, _service_running, _mcp_serving
 
     # --- Startup ---
     _shutting_down = False
+    _mcp_serving = True
     logger.info("API server starting up...")
 
     # Set up file-based logging
@@ -350,18 +332,14 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             logger.warning(f"Could not start system update checker: {e}")
 
-    # Hold the MCP session manager open for the lifetime of the API, then
-    # let it tear down on shutdown. ``_mcp_ctx`` is None when the mcp
-    # package didn't load — fall through to a bare yield in that case so
-    # the rest of the API still serves requests.
-    if _mcp_ctx is not None:
-        async with _mcp_ctx:
-            logger.info("MCP session manager started")
-            yield
-    else:
-        yield
+    yield
 
     # --- Shutdown ---
+    # Release the MCP session manager if a request ever activated it. No-op
+    # on the (overwhelmingly common) boot where nobody spoke MCP.
+    _mcp_serving = False
+    await _mcp_mount.aclose()
+
     if update_check_task is not None:
         update_check_task.cancel()
     if system_update_task is not None:
@@ -487,19 +465,130 @@ def cors_settings() -> dict:
 # Add CORS middleware
 app.add_middleware(CORSMiddleware, **cors_settings())
 
-# Mount the MCP server at /mcp (accessible at /api/mcp via nginx).
-# Gracefully skipped if the mcp package is not installed.
-try:
-    from .mcp_server import build_streamable_http_app as _build_mcp_app
 
-    _mcp_app = _build_mcp_app()
-    if _mcp_app is not None:
-        app.mount("/mcp", _mcp_app)
-        logger.info("FiestaBoard MCP server mounted at /mcp (public: /api/mcp)")
-    else:
-        logger.warning("MCP server disabled — mcp package not installed or failed to initialise")
-except Exception as _mcp_mount_err:  # pragma: no cover
-    logger.warning("Failed to mount MCP server: %s", _mcp_mount_err)
+# ---------------------------------------------------------------------------
+# MCP server mount
+# ---------------------------------------------------------------------------
+
+
+class _MCPActivation:
+    """One activation of the MCP sub-app, bound to one event loop.
+
+    Holds the streamable-HTTP session manager open in a dedicated task for as
+    long as the API is serving. ``StreamableHTTPSessionManager.run()`` is
+    once-per-instance, but ``build_streamable_http_app()`` mints a fresh
+    manager on every call, so re-activating (after ``aclose()``, or on a new
+    event loop) is safe.
+    """
+
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        self.loop = loop
+        self.app: Any = None
+        self.error: str | None = None
+        self._stop = asyncio.Event()
+        self._ready: asyncio.Future[None] = loop.create_future()
+        self._runner: asyncio.Task[None] | None = None
+
+    def _mark_ready(self) -> None:
+        if not self._ready.done():
+            self._ready.set_result(None)
+
+    async def _hold(self) -> None:
+        """Build the sub-app and keep its lifespan open until ``aclose()``."""
+        try:
+            from .mcp_server import build_streamable_http_app
+
+            sub_app = build_streamable_http_app()
+            if sub_app is None:
+                self.error = "mcp package not installed or failed to initialise"
+                logger.warning("MCP server disabled — %s", self.error)
+                return
+            # The sub-app's own lifespan *is* ``session_manager.run()``, and
+            # FastAPI's ``app.mount()`` does not propagate a sub-app lifespan.
+            # Without running it here the session manager has no task group
+            # and every request to ``/api/mcp/*`` fails.
+            async with sub_app.router.lifespan_context(sub_app):
+                self.app = sub_app
+                logger.info("FiestaBoard MCP server activated at /mcp (public: /api/mcp)")
+                self._mark_ready()
+                await self._stop.wait()
+        except Exception as exc:  # pragma: no cover — defensive
+            self.error = str(exc)
+            logger.warning("Failed to activate MCP server: %s", exc, exc_info=True)
+        finally:
+            self._mark_ready()
+
+    async def wait_ready(self) -> None:
+        """Start the holder task on first call; every caller awaits the same result."""
+        if self._runner is None:
+            self._runner = asyncio.create_task(self._hold(), name="fiestaboard-mcp-session-manager")
+        await self._ready
+
+    async def aclose(self) -> None:
+        self._stop.set()
+        if self._runner is not None:
+            await self._runner
+
+
+class _LazyMCPMount:
+    """ASGI app mounted at ``/mcp`` that imports ``mcp`` on first request.
+
+    Building the MCP app at module scope pulled the whole ``mcp`` package —
+    240 modules — into every boot whether or not anyone speaks MCP: measured
+    at +434 ms of import time and +34.7 MB RSS, a third of the process. On a
+    Raspberry Pi that is seconds of "did it survive the power cut?".
+
+    The mount itself is still registered eagerly, so the route table is
+    unchanged; only the import and the session manager are deferred.
+    """
+
+    def __init__(self) -> None:
+        self._state: _MCPActivation | None = None
+
+    async def _activation(self) -> _MCPActivation:
+        loop = asyncio.get_running_loop()
+        state = self._state
+        if state is None or state.loop is not loop:
+            # A previous activation's task group belongs to an event loop that
+            # is gone (each bare TestClient request gets its own). Build a
+            # fresh activation rather than dispatch into a dead task group.
+            state = self._state = _MCPActivation(loop)
+        await state.wait_ready()
+        return state
+
+    async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+        if not _mcp_serving:
+            # The session manager's lifetime is the app's lifetime: activating
+            # it outside a running lifespan would leave a task group nothing
+            # ever closes. Matches the pre-lazy behaviour, where the manager
+            # was only ever started from the lifespan.
+            response = PlainTextResponse("MCP server is not running", status_code=503)
+            await response(scope, receive, send)
+            return
+        state = await self._activation()
+        if state.app is None:
+            response = PlainTextResponse(
+                f"MCP server unavailable: {state.error or 'not initialised'}",
+                status_code=503,
+            )
+            await response(scope, receive, send)
+            return
+        await state.app(scope, receive, send)
+
+    async def aclose(self) -> None:
+        state, self._state = self._state, None
+        if state is not None:
+            await state.aclose()
+
+
+# Mount the MCP server at /mcp (accessible at /api/mcp via nginx).
+#
+# ``_mcp_serving`` is True only while the app lifespan is running. The mount
+# refuses to activate outside it, because the session manager it starts has to
+# be closed by that same lifespan.
+_mcp_serving = False
+_mcp_mount = _LazyMCPMount()
+app.mount("/mcp", _mcp_mount)
 
 # Optional authentication layer (opt-in via FIESTABOARD_AUTH_ENABLED env var).
 # Mounted unconditionally so /auth/* endpoints are always reachable; the

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -393,9 +393,80 @@ async def lifespan(app: FastAPI):
 
 
 # Create FastAPI app
+# The front page of /api/docs. Swagger renders this as markdown, so it is the
+# one place a newcomer can be told what the nouns are and be handed a request
+# that works. Keep it short and keep it true — no endpoint that does not exist.
+API_DESCRIPTION = """\
+FiestaBoard drives one or more split-flap displays from templated pages.
+
+### Hello world
+
+Put text on the board right now:
+
+```bash
+curl -X POST http://fiestaboard.local:4420/api/send-message \\
+  -H 'Content-Type: application/json' \\
+  -d '{"text": "HELLO WORLD"}'
+```
+
+### How the pieces fit
+
+* A **page** is a template: literal text plus `{{plugin_id.variable}}`
+  placeholders that **plugins** fill with live data.
+* A **schedule** or a **collection** decides which page a board shows at a
+  given moment. `POST /send-message` bypasses both for a one-off write.
+* `/settings/*` and `/config/*` are the install's configuration;
+  `/system/*`, `/network/*` and `/auth/*` administer the appliance itself.
+
+### Base URL
+
+nginx fronts the API under `/api`, so every path below is reached as
+`/api/<path>` — `GET /status` is `http://fiestaboard.local:4420/api/status`.
+These docs live at `/api/docs`, the schema at `/api/openapi.json`.
+
+### Authentication
+
+Off by default: a fresh install answers every request. With
+`FIESTABOARD_AUTH_ENABLED=true`, requests carry the session cookie that
+`POST /auth/login` sets. MCP clients may instead send
+`Authorization: Bearer <token>` to `/api/mcp` (see `POST /auth/mcp-token`).
+"""
+
+# Deliberate order — Swagger lists tags in this order, and anything not listed
+# here falls in after them. Boards and the content on them come first; the
+# appliance-administration surfaces a newcomer does not need on day one
+# (settings, updates, Wi-Fi, diagnostics) come last. The previous default was
+# first-appearance-in-the-paths-object order, which opened on MQTT and put
+# `pages` fourteenth, below `debug`.
+OPENAPI_TAGS = [
+    {"name": "service", "description": "The display loop itself: health, status, start/stop/refresh."},
+    {"name": "board", "description": "Write to a board out of band, and read back what is physically on it."},
+    {"name": "pages", "description": "Pages — the unit of content. CRUD, preview, send, import/export."},
+    {"name": "templates", "description": "Render and validate template text; list the variables and formula functions it can use."},
+    {"name": "displays", "description": "Device shapes and raw character-code grids."},
+    {"name": "schedules", "description": "Time-of-day rules choosing which page a board shows."},
+    {"name": "collections", "description": "Ordered groups of pages that rotate as one."},
+    {"name": "triggers", "description": "Event-driven page interrupts, and the ones currently firing."},
+    {"name": "transitions", "description": "Transition plugins (beta): preview, test and restore board animations."},
+    {"name": "plugins", "description": "Install, configure, enable and inspect the data-source plugins that fill template variables."},
+    {"name": "plugin-support", "description": "Platform helpers that back a plugin's configuration form."},
+    {"name": "staff-picks", "description": "Curated example pages shipped with the app."},
+    {"name": "panels", "description": "FiestaPanel — the read-only browser view of a board."},
+    {"name": "ai", "description": "AI page generation, chat editing and the operation grammar shared with MCP."},
+    {"name": "settings", "description": "Install settings: boards, display, location, polling, output, MQTT, AI, beta flags."},
+    {"name": "config", "description": "Board connection configuration and its validation/discovery helpers."},
+    {"name": "backup", "description": "Export and import the whole install as one file."},
+    {"name": "mqtt", "description": "MQTT / Home Assistant discovery status and republish."},
+    {"name": "auth", "description": "Optional login, password/username management and MCP bearer tokens."},
+    {"name": "network", "description": "Wi-Fi configuration for the appliance."},
+    {"name": "system", "description": "Version, update checks, updates and rollback, restart and shutdown."},
+    {"name": "debug", "description": "Diagnostics: logs, caches, connection tests and board fill/blank probes."},
+]
+
 app = FastAPI(
     title="FiestaBoard Display API",
-    description="REST API for controlling and monitoring the FiestaBoard Display Service",
+    description=API_DESCRIPTION,
+    openapi_tags=OPENAPI_TAGS,
     version=__version__,
     lifespan=lifespan,
     # The API is served behind nginx under the /api/* prefix (which nginx

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -55,11 +55,13 @@ from .board_guards import (  # noqa: E402, F401  (patch seams, see above)
     _require_board,
 )
 from .collections.models import is_collection_id  # noqa: E402, F401  (patch seam)
-from .collections.service import (  # noqa: E402
-    get_collection_service,
-    resolve_active_page_id,
-    resolve_next_check_seconds,
-)
+
+# Patch seam: src/settings/routes.py resolves this through ``src.api_server``
+# at call time, so the 7 tests that stub it here steer the moved /settings
+# handlers. The two collection resolvers that used to be imported alongside it
+# are gone — settings/routes.py binds them from their canonical home now, the
+# way src/schedules/routes.py already did, so nothing resolved them here.
+from .collections.service import get_collection_service  # noqa: E402, F401  (patch seam)
 
 # ``unmask_sensitive_values`` / ``reset_display_service`` /
 # ``reset_template_engine`` used to be imported here purely as patch seams for
@@ -70,42 +72,48 @@ from .collections.service import (  # noqa: E402
 from .config import Config  # noqa: E402,F401  (41 tests patch src.api_server.Config.*)
 from .config_manager import get_config_manager  # noqa: E402
 from .devices import resolve_dimensions  # noqa: E402, F401  (patch seam)
+
+# The four underscored names are re-exports the suite patches at
+# ``src.api_server.<name>`` (counts measured, not assumed: _get_board_client
+# 40, _format_uptime / _get_server_ip / _get_service_uptime 5 each).
+# ``get_service``, ``mark_service_started`` and ``peek_service`` are called by
+# this module's own lifecycle code.
+#
+# Seven names that used to be listed here — _get_first_board_dims,
+# _note_out_of_band_write, _primary_board_entry, _primary_connection_info,
+# _publish_mqtt_state_update, _send_with_status, reinitialize_board_clients —
+# are gone: zero references through ``src.api_server`` anywhere in tests, src,
+# scripts, plugins or web, and no caller here. A re-export nothing resolves
+# advertises a patch target that steers nothing.
 from .display_runtime import (  # noqa: E402
     _format_uptime,  # noqa: F401  (re-export: pre-move patch target)
     _get_board_client,  # noqa: F401  (re-export: pre-move patch target)
-    _get_first_board_dims,  # noqa: F401  (re-export: pre-move patch target)
     _get_server_ip,  # noqa: F401  (re-export: pre-move patch target)
     _get_service_uptime,  # noqa: F401  (re-export: pre-move patch target)
-    _note_out_of_band_write,  # noqa: F401  (re-export: pre-move patch target)
-    _primary_board_entry,  # noqa: F401  (re-export: pre-move patch target)
-    _primary_connection_info,  # noqa: F401  (re-export: pre-move patch target)
-    _publish_mqtt_state_update,  # noqa: F401  (re-export: pre-move patch target)
-    _send_with_status,  # noqa: F401  (re-export: pre-move patch target)
-    get_service,  # noqa: F401  (re-export: pre-move patch target)
-    mark_service_started,  # noqa: F401  (re-export: pre-move patch target)
-    peek_service,  # noqa: F401  (re-export: pre-move patch target)
-    reinitialize_board_clients,  # noqa: F401  (re-export: pre-move patch target)
+    get_service,
+    mark_service_started,
+    peek_service,
 )
 from .displays.service import get_display_service, reset_display_service  # noqa: E402, F401
+
+# ``LogBufferHandler`` and ``_setup_file_logging`` are called by this module;
+# the five ``_log_*`` names are live patch targets. ``LOG_BACKUP_COUNT``,
+# ``LOG_MAX_BYTES``, ``JSONFileHandler`` and ``_create_log_entry`` were
+# neither — zero references through ``src.api_server`` — and are gone.
 from .log_store import (  # noqa: E402
-    LOG_BACKUP_COUNT,  # noqa: F401  (re-export: pre-move patch target)
-    LOG_MAX_BYTES,  # noqa: F401  (re-export: pre-move patch target)
-    JSONFileHandler,  # noqa: F401  (re-export: pre-move patch target)
-    LogBufferHandler,  # noqa: F401  (re-export: pre-move patch target)
-    _create_log_entry,  # noqa: F401  (re-export: pre-move patch target)
+    LogBufferHandler,
     _log_buffer,  # noqa: F401  (re-export: pre-move patch target)
     _log_dir,  # noqa: F401  (re-export: pre-move patch target)
     _log_file,  # noqa: F401  (re-export: pre-move patch target)
     _log_lock,  # noqa: F401  (re-export: pre-move patch target)
     _read_logs_from_files,  # noqa: F401  (re-export: pre-move patch target)
-    _setup_file_logging,  # noqa: F401  (re-export: pre-move patch target)
+    _setup_file_logging,
 )
 from .pages.service import (  # noqa: E402, F401  (patch seam)
     check_ref_board_compatibility,
     get_page_service,
 )
 from .panels.service import get_panel_service  # noqa: E402, F401  (patch seam, see above)
-from .paths import get_data_dir  # noqa: E402, F401  (re-export: patch seam)
 from .settings.service import get_settings_service  # noqa: E402, F401  (patch seam)
 from .text_to_board import text_to_board_array  # noqa: E402, F401  (patch seam)
 from .time_service import reset_time_service  # noqa: E402
@@ -1966,32 +1974,6 @@ async def validate_traffic_route(request: dict):
 from .transitions.routes import router as transitions_router  # noqa: E402
 
 app.include_router(transitions_router)
-
-
-def _resolve_active_page_id(page_id: str | None) -> str | None:
-    """This module's binding of :func:`src.collections.service.resolve_active_page_id`.
-
-    Passes *this* module's ``get_collection_service``, so the resolution goes on
-    resolving through the name the suite stubs when it exercises the handlers
-    that still live here.
-    """
-    return resolve_active_page_id(page_id, get_collection_service)
-
-
-def _resolve_next_check_seconds(page_id: str | None) -> int | None:
-    """This module's binding of :func:`src.collections.service.resolve_next_check_seconds`."""
-    return resolve_next_check_seconds(page_id, get_collection_service)
-
-
-def _reinitialize_board_clients() -> None:
-    """Rebuild board clients after a boards-list mutation.
-
-    Kept as a name here because unconverted domains patch
-    ``src.api_server._reinitialize_board_clients``; the implementation moved to
-    ``src/display_runtime.py`` so routers can reach it without importing this
-    module.
-    """
-    reinitialize_board_clients()
 
 
 # ==================== Beta Settings (HTTPS, etc.) ====================

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from typing import Any
 
 from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import Depends, FastAPI, HTTPException, Query, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse
 
@@ -1142,7 +1142,54 @@ app.include_router(displays_router)
 # and stay outside the conventions ratchet, because re-shaping a body we
 # intend to delete buys a lockstep web change and nothing else.
 
-@app.get("/baywheels/stations", deprecated=True)  # removal tracked in #1915
+# ── Deprecation window ───────────────────────────────────────────────────────
+#
+# ``deprecated=True`` alone only greys the operation out in Swagger; a caller
+# in another repo — the whole reason these were deprecated instead of deleted —
+# sees nothing. RFC 8594 / RFC 9745 put the notice on the wire, which is what
+# ``docs/internal/reference/API_CONVENTIONS.md`` asks for: ``Deprecation``,
+# ``Sunset`` and a ``successor-version`` link.
+#
+# The date is a quarter out, not "two releases": FiestaBoard cuts a minor
+# release every few days, so a release count is not a window an integrator can
+# plan against, and two of these routes (``/muni/stops*``, ``/stocks/*``) are
+# published as API reference in shipped plugin SETUP guides. A quarter gives
+# those plugin authors a release cycle of their own to migrate. Reasoning
+# recorded on #1915.
+DEPRECATED_ROUTES_SUNSET = "Tue, 01 Dec 2026 00:00:00 GMT"
+
+
+def _deprecated_route(successor_plugin_id: str | None = None):
+    """Dependency that stamps the deprecation notice onto a route's response.
+
+    Every one of these pickers was replaced by the generic remote-options
+    endpoint ``POST /plugins/{plugin_id}/options/{options_id}``. ``options_id``
+    is declared by the plugin's own manifest and is not knowable from here, so
+    the successor is emitted as a URI Template with the plugin id filled in.
+    ``successor_plugin_id=None`` means no successor exists yet
+    (``/transit/cache/status``), and only ``Deprecation``/``Sunset`` are sent.
+    """
+    link = None
+    if successor_plugin_id:
+        link = f'</api/plugins/{successor_plugin_id}/options/{{options_id}}>; rel="successor-version"'
+
+    def _set_deprecation_headers(response: Response) -> None:
+        response.headers["Deprecation"] = "true"
+        response.headers["Sunset"] = DEPRECATED_ROUTES_SUNSET
+        if link is not None:
+            response.headers["Link"] = link
+
+    # Read by tests/test_deprecated_route_headers.py to pin which route points
+    # at which successor without calling eleven upstream APIs.
+    _set_deprecation_headers.successor_plugin_id = successor_plugin_id  # type: ignore[attr-defined]
+    return Depends(_set_deprecation_headers)
+
+
+@app.get(
+    "/baywheels/stations",
+    deprecated=True,  # removal tracked in #1915
+    dependencies=[_deprecated_route("lyft_bike_share")],
+)
 async def list_all_baywheels_stations():
     """
     List all Bay Wheels stations with current status.
@@ -1203,7 +1250,11 @@ async def list_all_baywheels_stations():
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
-@app.get("/baywheels/stations/nearby", deprecated=True)  # removal tracked in #1915
+@app.get(
+    "/baywheels/stations/nearby",
+    deprecated=True,  # removal tracked in #1915
+    dependencies=[_deprecated_route("lyft_bike_share")],
+)
 async def find_nearby_baywheels_stations(
     lat: float = Query(..., description="Latitude"),
     lng: float = Query(..., description="Longitude"),
@@ -1272,7 +1323,11 @@ async def find_nearby_baywheels_stations(
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
-@app.get("/baywheels/stations/search", deprecated=True)  # removal tracked in #1915
+@app.get(
+    "/baywheels/stations/search",
+    deprecated=True,  # removal tracked in #1915
+    dependencies=[_deprecated_route("lyft_bike_share")],
+)
 async def search_baywheels_stations_by_address(
     address: str = Query(..., description="Address to search near"),
     radius: float = Query(2.0, description="Search radius in kilometers"),
@@ -1371,7 +1426,11 @@ async def search_baywheels_stations_by_address(
 # =============================================================================
 
 
-@app.get("/muni/stops", deprecated=True)  # removal tracked in #1915
+@app.get(
+    "/muni/stops",
+    deprecated=True,  # removal tracked in #1915
+    dependencies=[_deprecated_route("muni")],
+)
 async def list_all_muni_stops():
     """
     List all SF Muni stops with metadata.
@@ -1458,7 +1517,11 @@ async def list_all_muni_stops():
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
-@app.get("/muni/stops/nearby", deprecated=True)  # removal tracked in #1915
+@app.get(
+    "/muni/stops/nearby",
+    deprecated=True,  # removal tracked in #1915
+    dependencies=[_deprecated_route("muni")],
+)
 async def find_nearby_muni_stops(
     lat: float = Query(..., description="Latitude"),
     lng: float = Query(..., description="Longitude"),
@@ -1569,7 +1632,11 @@ async def find_nearby_muni_stops(
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
-@app.get("/muni/stops/search", deprecated=True)  # removal tracked in #1915
+@app.get(
+    "/muni/stops/search",
+    deprecated=True,  # removal tracked in #1915
+    dependencies=[_deprecated_route("muni")],
+)
 async def search_muni_stops_by_address(
     address: str = Query(..., description="Address to search near"),
     radius: float = Query(0.5, description="Search radius in kilometers"),
@@ -1630,7 +1697,11 @@ async def search_muni_stops_by_address(
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
-@app.get("/transit/cache/status", deprecated=True)  # removal tracked in #1915
+@app.get(
+    "/transit/cache/status",
+    deprecated=True,  # removal tracked in #1915
+    dependencies=[_deprecated_route()],
+)
 async def get_transit_cache_status():
     """
     Get status and health information about the regional transit cache.
@@ -1669,7 +1740,11 @@ async def get_transit_cache_status():
 # =============================================================================
 
 
-@app.get("/stocks/search", deprecated=True)  # removal tracked in #1915
+@app.get(
+    "/stocks/search",
+    deprecated=True,  # removal tracked in #1915
+    dependencies=[_deprecated_route("stocks")],
+)
 async def search_stock_symbols(
     query: str = Query(..., description="Search query (symbol or company name)"),
     limit: int = Query(10, ge=1, le=50, description="Maximum number of results"),
@@ -1702,7 +1777,11 @@ async def search_stock_symbols(
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
-@app.post("/stocks/validate", deprecated=True)  # removal tracked in #1915
+@app.post(
+    "/stocks/validate",
+    deprecated=True,  # removal tracked in #1915
+    dependencies=[_deprecated_route("stocks")],
+)
 async def validate_stock_symbol(request: dict):
     """
     Validate if a stock symbol is valid.
@@ -1740,7 +1819,11 @@ async def validate_stock_symbol(request: dict):
 # =============================================================================
 
 
-@app.post("/traffic/routes/geocode", deprecated=True)  # removal tracked in #1915
+@app.post(
+    "/traffic/routes/geocode",
+    deprecated=True,  # removal tracked in #1915
+    dependencies=[_deprecated_route("traffic")],
+)
 async def geocode_address(request: dict):
     """
     Geocode an address to coordinates.
@@ -1786,7 +1869,11 @@ async def geocode_address(request: dict):
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
-@app.post("/traffic/routes/validate", deprecated=True)  # removal tracked in #1915
+@app.post(
+    "/traffic/routes/validate",
+    deprecated=True,  # removal tracked in #1915
+    dependencies=[_deprecated_route("traffic")],
+)
 async def validate_traffic_route(request: dict):
     """
     Validate a traffic route and get basic info.

--- a/src/settings/routes.py
+++ b/src/settings/routes.py
@@ -8,8 +8,7 @@ must now be read back out of ``api_server`` at call time).
 
 **Collaborator resolution.** ``/settings`` is the widest domain in the app and
 its handlers reach 25 collaborators that still live in ``src/api_server.py``
-(``get_service``, ``_require_board``, ``_reinitialize_board_clients``, the
-updater-sidecar probes, ...) or that other, not-yet-converted routers still
+(``get_service``, ``_require_board``, ``_apply_mqtt_config``, ...) or that other, not-yet-converted routers still
 resolve through ``api_server`` (``get_settings_service`` alone is patched at
 160 sites). Per ``docs/internal/reference/API_CONVENTIONS.md`` ("during
 extraction, moved handlers resolve api_server-patched names at call time") and
@@ -21,8 +20,11 @@ remaining domains convert.
 
 Collaborators that already have a canonical home *and* are not patched through
 ``src.api_server`` anywhere in the suite (``classify_dimensions``,
-``run_board_send``, ``VALID_STRATEGIES``, ``VALID_OUTPUT_TARGETS``) are
-imported normally at module import time.
+``run_board_send``, ``VALID_STRATEGIES``, ``VALID_OUTPUT_TARGETS``,
+``reinitialize_board_clients``, ``resolve_active_page_id`` /
+``resolve_next_check_seconds``) are imported normally at module import time —
+the same way ``src/panels/routes.py`` and ``src/schedules/routes.py`` bind
+them.
 """
 
 from __future__ import annotations
@@ -42,7 +44,9 @@ from src.board_guards import (
     validate_board_host_is_local_network as _validate_board_host_is_local_network,
 )
 from src.board_send_executor import run_board_send
+from src.collections.service import resolve_active_page_id, resolve_next_check_seconds
 from src.devices import classify_dimensions
+from src.display_runtime import reinitialize_board_clients
 
 from .models import (
     ERROR_400,
@@ -143,12 +147,6 @@ _require_board = _seam("_require_board")
 _board_is_paused = _seam("_board_is_paused")
 _board_dims = _seam("_board_dims")
 _apply_mqtt_config = _seam("_apply_mqtt_config")
-_reinitialize_board_clients = _seam("_reinitialize_board_clients")
-
-# Shared with ``src/schedules/routes.py``; cannot move until that domain owns
-# a copy or a common module exists (addendum 3).
-_resolve_active_page_id = _seam("_resolve_active_page_id")
-_resolve_next_check_seconds = _seam("_resolve_next_check_seconds")
 
 
 # fiestaupdater sidecar probes. These resolve against their canonical home,
@@ -512,8 +510,8 @@ async def get_active_page(board_id: str | None = None):
         page_id = settings_service.get_active_page_id()
     return {
         "page_id": page_id,
-        "resolved_page_id": _resolve_active_page_id(page_id),
-        "resolved_next_check_seconds": _resolve_next_check_seconds(page_id),
+        "resolved_page_id": resolve_active_page_id(page_id, get_collection_service),
+        "resolved_next_check_seconds": resolve_next_check_seconds(page_id, get_collection_service),
         "board_id": board_id,
     }
 
@@ -931,11 +929,11 @@ async def update_board_settings(request: BoardSettingsUpdate):
     try:
         if "devices" in provided:
             board = settings_service.set_devices(provided["devices"])
-            _reinitialize_board_clients()
+            reinitialize_board_clients()
             return board.to_dict()
         if "boards" in provided:
             board = settings_service.set_boards(provided["boards"])
-            _reinitialize_board_clients()
+            reinitialize_board_clients()
             return board.to_dict()
         if "board_type" in provided:
             board = settings_service.set_board_type(provided["board_type"])
@@ -966,7 +964,7 @@ async def add_board_instance(request: AddBoardRequest):
     settings_service = get_settings_service()
     try:
         board = settings_service.add_board(request.model_dump(exclude_unset=True))
-        _reinitialize_board_clients()
+        reinitialize_board_clients()
         return board.to_dict()
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
@@ -1001,7 +999,7 @@ async def remove_board_instance(board_id: str):
         board = settings_service.remove_board(board_id)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
-    _reinitialize_board_clients()
+    reinitialize_board_clients()
     return board.to_dict()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -239,21 +239,23 @@ def _isolated_data_dir(tmp_path, monkeypatch):
 #: Collaborators that moved from ``src.api_server`` to ``src.display_runtime``
 #: in the Phase 2 debug slice. ``api_server`` re-exports every one of them, so
 #: both module attributes exist and both are legitimate patch targets.
+#:
+#: Six names left this tuple with their re-exports: ``_primary_board_entry``,
+#: ``_primary_connection_info``, ``_get_first_board_dims``,
+#: ``_note_out_of_band_write``, ``_publish_mqtt_state_update`` and
+#: ``_send_with_status``. No test patches any of them at
+#: ``src.api_server.<name>``, so forwarding them there steered nothing —
+#: it only kept six re-exports alive that had no other consumer. Patch
+#: ``src.display_runtime.<name>`` for these; the rest still work both ways.
 _DISPLAY_RUNTIME_SEAMS = (
     "get_settings_service",
     "get_service",
     "peek_service",
     "_get_board_client",
     "_board_is_paused",
-    "_primary_board_entry",
-    "_primary_connection_info",
-    "_get_first_board_dims",
     "_get_server_ip",
     "_get_service_uptime",
     "_format_uptime",
-    "_note_out_of_band_write",
-    "_publish_mqtt_state_update",
-    "_send_with_status",
 )
 
 

--- a/tests/test_deprecated_route_headers.py
+++ b/tests/test_deprecated_route_headers.py
@@ -1,0 +1,101 @@
+"""The eleven deprecated plugin-specific routes announce their removal.
+
+``deprecated=True`` on its own only greys the operation out in Swagger. These
+routes exist *because* of callers this repo cannot see — two of them are
+published as API reference in shipped plugin SETUP guides — and those callers
+never open Swagger. Without the headers the deprecation is a note to
+ourselves, and #1915's ~2,275-line deletion stays blocked indefinitely rather
+than scheduled.
+
+The successor map is pinned by value rather than exercised over the wire:
+eleven live calls would mean eleven upstream APIs. One route
+(``GET /stocks/search`` with no Finnhub key configured, which searches a
+curated in-process list) is called for real, so the headers are proven to
+reach an actual response and not just a decorator.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api_server import DEPRECATED_ROUTES_SUNSET, app
+
+# path -> the plugin whose remote-options endpoint replaced it, or None where
+# no successor exists yet. Every deprecated route in the app must appear here.
+EXPECTED_SUCCESSORS = {
+    "/baywheels/stations": "lyft_bike_share",
+    "/baywheels/stations/nearby": "lyft_bike_share",
+    "/baywheels/stations/search": "lyft_bike_share",
+    "/muni/stops": "muni",
+    "/muni/stops/nearby": "muni",
+    "/muni/stops/search": "muni",
+    "/transit/cache/status": None,
+    "/stocks/search": "stocks",
+    "/stocks/validate": "stocks",
+    "/traffic/routes/geocode": "traffic",
+    "/traffic/routes/validate": "traffic",
+}
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """A client without the app lifespan.
+
+    These routes need nothing the lifespan starts, and starting it costs ~11
+    seconds of service/registry/mDNS boot per test.
+    """
+    return TestClient(app)
+
+
+def _deprecated_routes():
+    return [r for r in app.routes if getattr(r, "deprecated", False)]
+
+
+def _successor_of(route) -> str | None:
+    """The successor plugin id the route's deprecation dependency carries."""
+    for dependency in route.dependencies:
+        successor = getattr(dependency.dependency, "successor_plugin_id", "unset")
+        if successor != "unset":
+            return successor
+    raise AssertionError(f"{route.path} is deprecated but declares no deprecation dependency")
+
+
+def test_every_deprecated_route_is_in_the_successor_map():
+    """A new deprecation must decide its successor, not inherit silence."""
+    assert sorted({r.path for r in _deprecated_routes()}) == sorted(EXPECTED_SUCCESSORS)
+
+
+@pytest.mark.parametrize("path,expected", sorted(EXPECTED_SUCCESSORS.items()))
+def test_each_deprecated_route_points_at_its_successor(path, expected):
+    routes = [r for r in _deprecated_routes() if r.path == path]
+    assert routes, f"no deprecated route at {path}"
+    for route in routes:
+        assert _successor_of(route) == expected
+
+
+def test_the_sunset_date_is_a_valid_http_date():
+    """``Sunset`` is an HTTP-date (RFC 8594 §3); a free-form string is unusable."""
+    from email.utils import parsedate_to_datetime
+
+    parsed = parsedate_to_datetime(DEPRECATED_ROUTES_SUNSET)
+    assert parsed.tzinfo is not None
+    assert parsed.year == 2026 and parsed.month == 12 and parsed.day == 1
+
+
+def test_a_deprecated_response_carries_the_headers(client):
+    """End to end on the one route that answers without an upstream call."""
+    response = client.get("/stocks/search", params={"query": "GOOG", "limit": 1})
+    assert response.status_code == 200, response.text
+    assert response.headers["Deprecation"] == "true"
+    assert response.headers["Sunset"] == DEPRECATED_ROUTES_SUNSET
+    assert response.headers["Link"] == '</api/plugins/stocks/options/{options_id}>; rel="successor-version"'
+
+
+def test_a_route_without_a_successor_sends_no_link(client):
+    """A ``successor-version`` link to nothing is worse than no link."""
+    response = client.get("/transit/cache/status")
+    assert response.status_code == 200, response.text
+    assert response.headers["Deprecation"] == "true"
+    assert response.headers["Sunset"] == DEPRECATED_ROUTES_SUNSET
+    assert "Link" not in response.headers

--- a/tests/test_mcp_lazy_mount.py
+++ b/tests/test_mcp_lazy_mount.py
@@ -1,0 +1,102 @@
+"""The MCP server is mounted eagerly but imported lazily.
+
+``src/api_server.py`` used to call ``build_streamable_http_app()`` at module
+scope, which dragged the whole ``mcp`` package into every boot whether or not
+anyone spoke MCP — measured at +434 ms of import time and +34.7 MB RSS (a
+third of the process) on a warm CPython. On a Raspberry Pi that is seconds of
+"did it survive the power cut?" for a feature most installs never touch.
+
+Both halves of the contract need holding down, because either one alone is
+easy to satisfy by accident:
+
+1. importing the app must NOT import ``mcp`` — and the ``/mcp`` Mount must
+   still be in the route table, so the deferral is invisible to the OpenAPI
+   schema and to ``tests/golden/api_routes.json``;
+2. a real request to ``/api/mcp/`` must still be served by a working MCP
+   server, which is what makes the deferral a deferral and not a removal.
+
+Both run in a **subprocess**: an in-process ``'mcp' not in sys.modules``
+assertion is vacuous the moment any earlier test in the session imports it,
+and ~10 test modules do.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run(code: str, tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    env = {
+        "PATH": "/usr/local/bin:/usr/bin:/bin",
+        "PYTHONPATH": str(REPO_ROOT),
+        "FIESTABOARD_DATA_DIR": str(tmp_path),
+        "FIESTABOARD_AUTH_ENABLED": "false",
+    }
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_importing_the_app_does_not_import_the_mcp_package(tmp_path):
+    """Boot cost: the ``mcp`` package stays out of ``sys.modules``."""
+    code = (
+        "import sys\n"
+        "import src.api_server\n"
+        "mcp_mods = sorted(m for m in sys.modules if m == 'mcp' or m.startswith('mcp.'))\n"
+        "assert not mcp_mods, mcp_mods\n"
+        "assert 'src.mcp_server' not in sys.modules\n"
+    )
+    result = _run(code, tmp_path)
+    assert result.returncode == 0, "importing src.api_server pulled in mcp:\n" + result.stdout + result.stderr
+
+
+def test_the_mcp_mount_is_registered_without_importing_mcp(tmp_path):
+    """Route table parity: the deferral must not cost the ``/mcp`` mount."""
+    code = (
+        "import sys\n"
+        "from starlette.routing import Mount\n"
+        "from src.api_server import app\n"
+        "mounts = [r for r in app.routes if isinstance(r, Mount) and r.path == '/mcp']\n"
+        "assert len(mounts) == 1, [getattr(r, 'path', r) for r in app.routes]\n"
+        "assert mounts[0].name is None, mounts[0].name\n"
+        "assert 'mcp' not in sys.modules\n"
+    )
+    result = _run(code, tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_first_request_activates_a_working_mcp_server(tmp_path):
+    """The deferral is a deferral: ``/api/mcp/`` still answers JSON-RPC.
+
+    Run in the same subprocess as the "not imported" assertion so the two
+    halves are proven about one process: nothing imported ``mcp``, then the
+    request did, and the handshake succeeded.
+    """
+    code = (
+        "import sys\n"
+        "from fastapi.testclient import TestClient\n"
+        "from src.api_server import app\n"
+        "assert 'mcp' not in sys.modules\n"
+        "with TestClient(app) as client:\n"
+        "    r = client.post(\n"
+        "        '/api/mcp/',\n"
+        "        json={'jsonrpc': '2.0', 'id': 1, 'method': 'initialize', 'params': {\n"
+        "            'protocolVersion': '2025-06-18', 'capabilities': {},\n"
+        "            'clientInfo': {'name': 'pytest', 'version': '0'}}},\n"
+        "        headers={'Accept': 'application/json, text/event-stream',\n"
+        "                 'Content-Type': 'application/json'},\n"
+        "    )\n"
+        "assert r.status_code == 200, (r.status_code, r.text)\n"
+        "assert r.json()['result']['serverInfo']['name'] == 'FiestaBoard', r.text\n"
+        "assert 'mcp' in sys.modules\n"
+    )
+    result = _run(code, tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_openapi_front_page.py
+++ b/tests/test_openapi_front_page.py
@@ -1,0 +1,74 @@
+"""`/api/docs` has to be readable by someone who has never seen this API.
+
+Before this, ``description`` was 71 characters ("REST API for controlling and
+monitoring the FiestaBoard Display Service") and ``openapi_tags`` was absent,
+so Swagger rendered 22 bare tag names in first-appearance-in-the-paths-object
+order: MQTT, AI, system updates and Wi-Fi configuration all scrolled past
+before anything about a board, with ``pages`` fourteenth — below ``debug``.
+
+These tests hold the two failure modes that silently return:
+
+* a new router lands with a tag nobody described, and Swagger grows another
+  bare heading at the bottom;
+* the front page's worked example drifts away from a route that exists.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from src.api_server import API_DESCRIPTION, OPENAPI_TAGS, app
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict:
+    return app.openapi()
+
+
+@pytest.fixture(scope="module")
+def used_tags(schema) -> set[str]:
+    tags: set[str] = set()
+    for operations in schema["paths"].values():
+        for operation in operations.values():
+            tags.update(operation.get("tags", []))
+    return tags
+
+
+def test_every_tag_a_route_uses_is_described(used_tags):
+    """An undescribed tag is a bare heading in the docs sidebar."""
+    described = {tag["name"] for tag in OPENAPI_TAGS if tag.get("description")}
+    assert used_tags <= described, (
+        f"tags used by routes but not described in OPENAPI_TAGS: {sorted(used_tags - described)}"
+    )
+
+
+def test_no_described_tag_is_stale(used_tags):
+    """A described tag no route uses renders an empty section."""
+    declared = {tag["name"] for tag in OPENAPI_TAGS}
+    assert declared <= used_tags, f"described tags no route uses: {sorted(declared - used_tags)}"
+
+
+def test_the_tag_order_is_the_declared_order(schema):
+    """Swagger renders tags in ``openapi_tags`` order; boards/content lead."""
+    assert [tag["name"] for tag in schema["tags"]] == [tag["name"] for tag in OPENAPI_TAGS]
+    assert schema["tags"][0]["name"] == "service"
+    assert [t["name"] for t in schema["tags"]].index("pages") < [t["name"] for t in schema["tags"]].index("debug")
+
+
+def test_the_front_page_worked_example_calls_a_route_that_exists():
+    """The hello-world curl must stay executable, not become folklore."""
+    match = re.search(r"curl -X (?P<method>[A-Z]+) https?://[^/]+/api(?P<path>/\S+)", API_DESCRIPTION)
+    assert match, "the front page must carry a runnable curl example"
+    path, method = match.group("path"), match.group("method").lower()
+    operations = app.openapi()["paths"].get(path)
+    assert operations is not None, f"front-page example calls {path}, which is not a route"
+    assert method in operations, f"front-page example uses {method.upper()} {path}; route offers {sorted(operations)}"
+
+
+def test_the_front_page_says_more_than_the_old_one_line():
+    """A one-sentence description is a placeholder, not a front page."""
+    assert "```bash" in API_DESCRIPTION
+    assert "/api/docs" in API_DESCRIPTION
+    assert "FIESTABOARD_AUTH_ENABLED" in API_DESCRIPTION


### PR DESCRIPTION
Four independent changes to `src/api_server.py`, each measured, each revertable on its own commit.

## Result

| | before (`origin/next` @ 2a725f4ea) | after |
|---|---|---|
| `import src.api_server` | 542.4 ms | **305.2 ms** (−43.7%) |
| RSS after import | 104.3 MB | **71.4 MB** (−32.9 MB, −31.5%) |
| `len(sys.modules)` after import | 976 | **735** (−241) |
| `len(app.routes)` | 39 | **39** |
| full suite (`tests/`) | 1 failed, 6636 passed, 2 skipped | 1 failed, **6659 passed**, 2 skipped |
| data-dir leak | 0 files | **0 files** |
| `tests/golden/api_routes.json` | — | **byte-identical** (`git diff origin/next -- tests/golden/` is empty) |
| `ruff==0.16.5 check` + `format --check` over `src/ plugins/ tests/ scripts/` | — | clean |

The one failure is **pre-existing on `origin/next`** and identical on both sides: `test_check_image_formats.py::TestRepositoryIsClean` shells out to `git ls-files`, which is not installed in the test container.

`6659 − 6636 = 23`, which is exactly the three new test files (15 + 5 + 3). Nothing was removed from the suite; it is a strict superset.

Measurement recipe (five runs each after a warm-up, in the same container image):

```bash
docker run --rm -v "$PWD":/app -v /tmp/measure_import.py:/measure.py -w /app \
  -e PYTHONPATH=/app -e FIESTABOARD_DATA_DIR=/tmp/fbdata fb-test:latest \
  sh -c "python /measure.py >/dev/null; for i in 1 2 3 4 5; do python /measure.py; done"
```

Spread was ≤11 ms before and ≤4 ms after; RSS and module counts were identical across every run.

---

## 1. `perf(api)`: import the `mcp` package on first request, not at boot

`build_streamable_http_app()` ran at module scope, so every boot loaded the whole `mcp` package — 241 modules — whether or not anyone spoke MCP. That is 44% of the app module's import time and a third of the process's RSS, spent on a feature most installs never touch. Imports dominate startup (835 ms of the 939 ms from process start to first frame), so on a Pi this is seconds of "did it survive the power cut?".

`_LazyMCPMount` is the ASGI app mounted at `/mcp`. The **mount is still registered eagerly**, so the route table and the OpenAPI schema do not change; only the import and the streamable-HTTP session manager are deferred. On the first request it builds the sub-app and runs the sub-app's own lifespan — which *is* `session_manager.run()` — in a dedicated task, then delegates. (FastAPI's `app.mount()` does not propagate a sub-app lifespan; that is why the previous code hand-wired the session manager into the API's lifespan.)

Two design points worth reviewing:

- **Activation is gated on the app lifespan running.** The manager has to be closed by the lifespan that opened it. This also preserves existing behaviour for a bare `TestClient` (no lifespan), which never had a working MCP endpoint. Without the gate, `GET /api/mcp/` starts working outside a lifespan and opens an endless SSE stream — `test_bearer_works_for_unstripped_api_mcp_path` went from 0.0s to **198s** before I added it.
- **An activation is bound to the event loop that created it**; a request on a different loop rebuilds. `StreamableHTTPSessionManager.run()` is once-per-instance, but `streamable_http_app()` mints a fresh manager per call, so a rebuild is safe. This incidentally removes the "a second lifespan startup in the same process raises" hazard that `TestProtocolIsError` works around with a class-scoped fixture.

If the `mcp` package is missing, `/api/mcp` now answers **503** rather than 404 (the mount exists; activation fails). CI's MCP sanity check was 404-only, so it would have silently stopped guarding anything — it now fails on 503 too, and that probe is also the request that pays the deferred import.

### Non-vacuity

`tests/test_mcp_lazy_mount.py` runs in a **subprocess**, because an in-process `'mcp' not in sys.modules` assertion is vacuous once any earlier test imports it — and about ten test modules do. Re-adding a module-scope `from .mcp_server import build_streamable_http_app` fails all three:

```
E   AssertionError: ['mcp', 'mcp.client', ..., 'mcp.types.version']   (103 modules)
FAILED tests/test_mcp_lazy_mount.py::test_importing_the_app_does_not_import_the_mcp_package
FAILED tests/test_mcp_lazy_mount.py::test_the_mcp_mount_is_registered_without_importing_mcp
FAILED tests/test_mcp_lazy_mount.py::test_first_request_activates_a_working_mcp_server
```

The third test is the other half of the contract: in the same subprocess, `mcp` is absent, then `POST /api/mcp/ initialize` returns 200 with `serverInfo.name == "FiestaBoard"`, then `mcp` is present. `tests/test_mcp_server.py` (112 tests, including the real JSON-RPC round trip through the mount), `test_mcp_state_effects.py`, `test_auth_mcp_bearer.py` and `test_auth_mcp_token_routes.py` all pass unchanged.

## 2. `docs(api)`: give `/api/docs` a front page and a deliberate tag order

Measured on `next`: `description` was **71 characters** and `openapi_tags` was **absent**, so Swagger rendered 22 bare tag names in first-appearance-in-the-paths-object order — MQTT, AI, system updates and Wi-Fi configuration all before anything about a board, with `pages` **fourteenth**, below `debug`.

- `OPENAPI_TAGS` describes all 22 tags and orders them: display loop, boards, pages, templates, displays, schedules, collections… then settings, backup, MQTT, auth, Wi-Fi, system, debug last.
- `API_DESCRIPTION` is a real front page: what a page/plugin/schedule is, the `/api` base URL, how auth works, and a hello-world `curl` that puts text on a board.

Nothing about routes, responses or schemas changes.

### Non-vacuity

Dropping one tag's description:

```
E   AssertionError: tags used by routes but not described in OPENAPI_TAGS: ['pages']
FAILED tests/test_openapi_front_page.py::test_every_tag_a_route_uses_is_described
```

`test_the_front_page_worked_example_calls_a_route_that_exists` parses the curl out of the description and looks the method+path up in the live schema, so the example cannot rot into folklore.

## 3. `feat(api)`: start the sunset clock on the eleven deprecated routes (#1915)

`deprecated=True` only greys an operation out in Swagger. The callers that keep these eleven alive are in *other repos* — `/muni/stops*` and `/stocks/*` are published as API reference in shipped plugin SETUP guides — and those callers never open Swagger. So the notice was a note to ourselves, and #1915's ~2,275-line deletion was blocked indefinitely rather than scheduled.

All eleven now send what `docs/internal/reference/API_CONVENTIONS.md` already specifies:

- `Deprecation: true`
- `Sunset: Tue, 01 Dec 2026 00:00:00 GMT`
- the ten replaced by the generic remote-options endpoint also send `Link: </api/plugins/<plugin_id>/options/{options_id}>; rel="successor-version"` — plugin id filled in (`lyft_bike_share`, `muni`, `stocks`, `traffic`), `options_id` left as a URI Template because only the plugin's own manifest declares it. `/transit/cache/status` has no successor and sends no link.

**The date, and why it is not "two releases".** FiestaBoard cuts a minor release every few days — v8.30.0 → v8.34.0 spans twelve days — so a release count is not a window an outside integrator can plan against. A quarter gives the muni and stocks plugin authors a release cycle of their own to drop the "API Endpoints" sections from their SETUP guides, which is step 2 of #1915's removal plan. Reasoning is recorded on the issue and in `API_CONVENTIONS.md`.

Implemented as a `Depends` that stamps the headers: no handler body, no response model, no route-table change.

### Non-vacuity

Deleting the `Sunset` line, and separately pointing `/stocks/*` at the wrong plugin:

```
E   KeyError: 'Sunset'
FAILED tests/test_deprecated_route_headers.py::test_a_deprecated_response_carries_the_headers
FAILED tests/test_deprecated_route_headers.py::test_a_route_without_a_successor_sends_no_link

E   AssertionError: assert 'muni' == 'stocks'
FAILED tests/test_deprecated_route_headers.py::test_each_deprecated_route_points_at_its_successor[/stocks/search-stocks]
```

The successor map is pinned by value (eleven live calls would mean eleven upstream APIs), and the two live tests use the one route that answers without an upstream call plus the local transit cache.

## 4. `refactor(api)`: Tier A rows A7 and A10 — seams nothing steers

**A7.** `_resolve_active_page_id`, `_resolve_next_check_seconds` and `_reinitialize_board_clients` had **zero** `patch("src.api_server.…")` sites; every other seam in the module has between 1 and 86. Their one consumer, `src/settings/routes.py`, now binds them from their canonical homes at module import — exactly how `src/schedules/routes.py` already binds the two resolvers and how `src/panels/routes.py` and `src/config_api/routes.py` already bind `reinitialize_board_clients`. `get_collection_service` stays a live `api_server` seam (7 patch sites) and is still what settings passes to the resolvers, so the resolution path is unchanged.

**A10.** Twelve re-exports removed. Two names the audit listed are **not** removed and the PR says why: `_setup_file_logging` and `mark_service_started` are called by this module's own lifespan and service lifecycle, so their `# noqa: F401 (re-export…)` comments went with the claim rather than the imports.

**Six of the twelve did have a consumer, and grep could not see it.** `tests/conftest.py`'s autouse `_display_runtime_follows_api_server_stubs` builds forwarders from a tuple of *strings*, so `src.display_runtime._get_first_board_dims` resolved `src.api_server._get_first_board_dims` at call time. Removing the re-export alone turned 96 debug tests into:

```
src/debug/routes.py:170: in debug_blank_board
    dims = runtime._get_first_board_dims()
tests/conftest.py:289: in forwarder
    return getattr(api_server, name)(*args, **kwargs)
E   AttributeError: module 'src.api_server' has no attribute '_get_first_board_dims'
```

Those six left the tuple with their re-exports, which is the correct half to cut: no test patches any of them at `src.api_server.<name>`, so forwarding them there steered nothing — it only kept six otherwise-unused re-exports alive. The remaining eight entries still work from both sides.

---

## Notes for the reviewer

- **Overlap with draft PR #1918.** That draft does change 3 against `main`, with `Sunset: Wed, 01 Sep 2027` described in its own body as a placeholder and no successor links. One of the two should close; this one targets `next` and carries the successor map.
- `src/settings/routes.py` and `tests/conftest.py` are touched only by change 4, three and one hunk respectively.
- `.github/workflows/ci.yml` is touched only by change 1 (the 503 case in the MCP sanity check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mYPdfxvAKCmztHasToHzH
