### PR TITLE
feat(web): move every superseded client call onto /v1

### DIFF
--- a/web/src/__tests__/active-page-display-note-array.test.tsx
+++ b/web/src/__tests__/active-page-display-note-array.test.tsx
@@ -108,7 +108,7 @@ function usePanelBoard({
   const puts: Array<{ page_id?: string | null; board_id?: string }> = [];
   server.use(
     http.get(`${API_BASE}/settings/board`, () => HttpResponse.json(BOARDS_WITH_PANEL)),
-    http.get(`${API_BASE}/pages`, () => HttpResponse.json({ pages, total: pages.length })),
+    http.get(`${API_BASE}/v1/pages`, () => HttpResponse.json({ pages, total: pages.length })),
     http.get(`${API_BASE}/settings/active-page`, () => HttpResponse.json({ page_id: activePageId })),
     http.get(`${API_BASE}/schedules/active/page`, () =>
       HttpResponse.json({ page_id: activePageId, source: "manual", schedule_enabled: false }),

--- a/web/src/__tests__/active-page-display.test.tsx
+++ b/web/src/__tests__/active-page-display.test.tsx
@@ -118,7 +118,7 @@ describe("ActivePageDisplay", () => {
       http.get(`${API_BASE}/settings/active-page`, () =>
         HttpResponse.json({ page_id: "collection:test-collection-id" }),
       ),
-      http.get(`${API_BASE}/collections`, () =>
+      http.get(`${API_BASE}/v1/collections`, () =>
         HttpResponse.json({
           collections: [
             {
@@ -154,7 +154,7 @@ describe("ActivePageDisplay", () => {
       http.get(`${API_BASE}/settings/active-page`, () =>
         HttpResponse.json({ page_id: "collection:test-collection-id", resolved_page_id: "page-1" }),
       ),
-      http.get(`${API_BASE}/collections`, () =>
+      http.get(`${API_BASE}/v1/collections`, () =>
         HttpResponse.json({
           collections: [
             {
@@ -394,7 +394,7 @@ describe("ActivePageDisplay", () => {
       http.get(`${API_BASE}/settings/active-page`, () =>
         HttpResponse.json({ page_id: "collection:test-collection-id" }),
       ),
-      http.get(`${API_BASE}/collections`, () =>
+      http.get(`${API_BASE}/v1/collections`, () =>
         HttpResponse.json({
           collections: [
             {

--- a/web/src/__tests__/api-auth.test.ts
+++ b/web/src/__tests__/api-auth.test.ts
@@ -169,14 +169,14 @@ describe("api auth helpers", () => {
     });
 
     it("redirects to /login on 401", async () => {
-      server.use(http.get("/api/status", () => HttpResponse.json({ detail: "Not authenticated" }, { status: 401 })));
+      server.use(http.get("/api/v1/status", () => HttpResponse.json({ detail: "Not authenticated" }, { status: 401 })));
       await expect(api.getStatus()).rejects.toThrow();
       expect(assignMock).toHaveBeenCalledWith(expect.stringMatching(/^\/login\?redirect=/));
     });
 
     it("redirects to /login on 409 with setup_required", async () => {
       server.use(
-        http.get("/api/status", () =>
+        http.get("/api/v1/status", () =>
           HttpResponse.json({ detail: "Setup required", setup_required: true, first_run: true }, { status: 409 }),
         ),
       );
@@ -188,7 +188,9 @@ describe("api auth helpers", () => {
     });
 
     it("does NOT redirect on 409 without setup_required", async () => {
-      server.use(http.get("/api/status", () => HttpResponse.json({ detail: "Some other conflict" }, { status: 409 })));
+      server.use(
+        http.get("/api/v1/status", () => HttpResponse.json({ detail: "Some other conflict" }, { status: 409 })),
+      );
       await expect(api.getStatus()).rejects.toThrow();
       await new Promise((r) => setTimeout(r, 0));
       expect(assignMock).not.toHaveBeenCalled();

--- a/web/src/__tests__/api-extended.test.ts
+++ b/web/src/__tests__/api-extended.test.ts
@@ -12,7 +12,7 @@ describe("API Extended Tests", () => {
     it("throws on non-ok response", async () => {
       server.use(
         http.get(
-          `${API_BASE}/status`,
+          `${API_BASE}/v1/status`,
           () => new HttpResponse(null, { status: 500, statusText: "Internal Server Error" }),
         ),
       );
@@ -73,18 +73,6 @@ describe("API Extended Tests", () => {
   });
 
   describe("Display endpoints", () => {
-    it("getDisplays returns display list", async () => {
-      const result = await api.getDisplays();
-      expect(result.displays).toBeDefined();
-      expect(result.total).toBeGreaterThan(0);
-    });
-
-    it("getDisplay returns formatted display", async () => {
-      const result = await api.getDisplay("weather");
-      expect(result.display_type).toBe("weather");
-      expect(result.lines).toBeDefined();
-    });
-
     it("getDisplayRaw returns raw data", async () => {
       const result = await api.getDisplayRaw("weather");
       expect(result.display_type).toBe("weather");
@@ -105,22 +93,6 @@ describe("API Extended Tests", () => {
 
       await api.getDisplaysRawBatch(["weather"], false);
       expect(capturedBody).toEqual({ display_types: ["weather"], enabled_only: false });
-    });
-
-    it("sendDisplay appends target query param", async () => {
-      let capturedUrl = "";
-      server.use(
-        http.post(`${API_BASE}/displays/:type/send`, ({ request }) => {
-          capturedUrl = request.url;
-          return HttpResponse.json({ status: "success", message: "sent" });
-        }),
-      );
-
-      await api.sendDisplay("weather", "board");
-      expect(capturedUrl).toContain("target=board");
-
-      await api.sendDisplay("weather");
-      expect(capturedUrl).not.toContain("target=");
     });
   });
 
@@ -170,7 +142,7 @@ describe("API Extended Tests", () => {
     it("updatePage sends correct body", async () => {
       let capturedBody: any;
       server.use(
-        http.put(`${API_BASE}/pages/:id`, async ({ request }) => {
+        http.put(`${API_BASE}/v1/pages/:id`, async ({ request }) => {
           capturedBody = await request.json();
           return HttpResponse.json({ page: { ...capturedBody, id: "page-1" }, incompatible_references: [] });
         }),
@@ -203,28 +175,6 @@ describe("API Extended Tests", () => {
 
       await api.previewPagesBatch(["page-1", "page-2"]);
       expect(capturedBody).toEqual({ page_ids: ["page-1", "page-2"] });
-    });
-
-    it("sendPage appends target query param", async () => {
-      let capturedUrl = "";
-      server.use(
-        http.post(`${API_BASE}/pages/:id/send`, ({ request }) => {
-          capturedUrl = request.url;
-          return HttpResponse.json({
-            page_id: "page-1",
-            message: "sent",
-            sent_to_board: true,
-            paused: false,
-            target: "both",
-          });
-        }),
-      );
-
-      await api.sendPage("page-1", "both");
-      expect(capturedUrl).toContain("target=both");
-
-      await api.sendPage("page-1");
-      expect(capturedUrl).not.toContain("target=");
     });
 
     it("getCurrentDisplay returns current board display", async () => {
@@ -309,7 +259,7 @@ describe("API Extended Tests", () => {
   describe("Schedule endpoints", () => {
     beforeEach(() => {
       server.use(
-        http.get(`${API_BASE}/schedules`, ({ request }) => {
+        http.get(`${API_BASE}/v1/schedules`, ({ request }) => {
           const url = new URL(request.url);
           const boardId = url.searchParams.get("board_id");
           return HttpResponse.json({
@@ -320,7 +270,7 @@ describe("API Extended Tests", () => {
             ...(boardId && { board_id: boardId }),
           });
         }),
-        http.post(`${API_BASE}/schedules`, async ({ request }) => {
+        http.post(`${API_BASE}/v1/schedules`, async ({ request }) => {
           const body = (await request.json()) as any;
           return HttpResponse.json({
             id: "sched-1",
@@ -342,32 +292,11 @@ describe("API Extended Tests", () => {
           const body = (await request.json()) as any;
           return HttpResponse.json({ valid: true, overlaps: [], gaps: [], ...body });
         }),
-        http.get(`${API_BASE}/schedules/default-page`, () => HttpResponse.json({ default_page_id: null })),
-        http.put(`${API_BASE}/schedules/default-page`, async ({ request }) => {
-          const body = (await request.json()) as any;
-          return HttpResponse.json({ status: "success", default_page_id: body.page_id });
-        }),
-        http.get(`${API_BASE}/schedules/enabled`, () => HttpResponse.json({ enabled: true })),
-        http.put(`${API_BASE}/schedules/enabled`, async ({ request }) => {
-          const body = (await request.json()) as any;
-          return HttpResponse.json({ status: "success", enabled: body.enabled, message: "ok" });
-        }),
-        http.get(`${API_BASE}/schedules/:id`, ({ params }) =>
-          HttpResponse.json({
-            id: params.id,
-            page_id: "page-1",
-            start_time: "09:00",
-            end_time: "17:00",
-            day_pattern: "all",
-            enabled: true,
-            created_at: new Date().toISOString(),
-          }),
-        ),
-        http.put(`${API_BASE}/schedules/:id`, async ({ request, params }) => {
+        http.put(`${API_BASE}/v1/schedules/:id`, async ({ request, params }) => {
           const body = (await request.json()) as any;
           return HttpResponse.json({ id: params.id, ...body });
         }),
-        http.delete(`${API_BASE}/schedules/:id`, ({ params }) => HttpResponse.json({ id: params.id })),
+        http.delete(`${API_BASE}/v1/schedules/:id`, ({ params }) => HttpResponse.json({ id: params.id })),
       );
     });
 
@@ -391,11 +320,6 @@ describe("API Extended Tests", () => {
       });
       expect(result.page_id).toBe("page-1");
       expect(result.day_pattern).toBe("weekdays");
-    });
-
-    it("getSchedule returns single entry", async () => {
-      const result = await api.getSchedule("sched-1");
-      expect(result.id).toBe("sched-1");
     });
 
     it("updateSchedule sends partial update", async () => {
@@ -436,49 +360,53 @@ describe("API Extended Tests", () => {
       expect(capturedBody).toEqual({});
     });
 
-    it("getDefaultPage returns default_page_id", async () => {
-      const result = await api.getDefaultPage();
-      expect(result).toHaveProperty("default_page_id");
-    });
-
-    it("setDefaultPage sends page_id and optional board_id", async () => {
+    // The schedule's fallback page is a per-board setting, so v1 addresses it
+    // on the board: `PUT /schedules/default-page {page_id, board_id?}` became
+    // `PATCH /v1/boards/{board} {default_page_id}`. An omitted board_id used
+    // to mean "the primary board"; the path segment `primary` says the same.
+    it("setDefaultPage patches the board it targets", async () => {
       let capturedBody: any;
+      let capturedUrl = "";
       server.use(
-        http.put(`${API_BASE}/schedules/default-page`, async ({ request }) => {
+        http.patch(`${API_BASE}/v1/boards/:board`, async ({ request }) => {
+          capturedUrl = request.url;
           capturedBody = await request.json();
-          return HttpResponse.json({ default_page_id: capturedBody.page_id });
+          return HttpResponse.json({ default_page_id: capturedBody.default_page_id });
         }),
       );
 
       await api.setDefaultPage("page-1");
-      expect(capturedBody).toEqual({ page_id: "page-1" });
+      expect(capturedUrl).toContain("/v1/boards/primary");
+      expect(capturedBody).toEqual({ default_page_id: "page-1" });
 
       await api.setDefaultPage("page-1", "board-1");
-      expect(capturedBody).toEqual({ page_id: "page-1", board_id: "board-1" });
+      expect(capturedUrl).toContain("/v1/boards/board-1");
+      expect(capturedBody).toEqual({ default_page_id: "page-1" });
 
       await api.setDefaultPage(null);
-      expect(capturedBody).toEqual({ page_id: null });
+      expect(capturedBody).toEqual({ default_page_id: null });
     });
 
-    it("getScheduleEnabled returns enabled state", async () => {
-      const result = await api.getScheduleEnabled();
-      expect(result.enabled).toBe(true);
-    });
-
-    it("setScheduleEnabled sends enabled and optional board_id", async () => {
+    // Same move: `PUT /schedules/enabled {enabled, board_id?}` became
+    // `PATCH /v1/boards/{board} {schedule_enabled}`.
+    it("setScheduleEnabled patches the board it targets", async () => {
       let capturedBody: any;
+      let capturedUrl = "";
       server.use(
-        http.put(`${API_BASE}/schedules/enabled`, async ({ request }) => {
+        http.patch(`${API_BASE}/v1/boards/:board`, async ({ request }) => {
+          capturedUrl = request.url;
           capturedBody = await request.json();
-          return HttpResponse.json({ enabled: capturedBody.enabled });
+          return HttpResponse.json({ schedule_enabled: capturedBody.schedule_enabled });
         }),
       );
 
       await api.setScheduleEnabled(false);
-      expect(capturedBody).toEqual({ enabled: false });
+      expect(capturedUrl).toContain("/v1/boards/primary");
+      expect(capturedBody).toEqual({ schedule_enabled: false });
 
       await api.setScheduleEnabled(true, "board-1");
-      expect(capturedBody).toEqual({ enabled: true, board_id: "board-1" });
+      expect(capturedUrl).toContain("/v1/boards/board-1");
+      expect(capturedBody).toEqual({ schedule_enabled: true });
     });
   });
 
@@ -879,46 +807,46 @@ describe("API Extended Tests", () => {
       expect(result.id).toBe("weather");
     });
 
-    it("updatePluginConfig sends config body", async () => {
+    // `PUT /plugins/{id}/config`, `POST .../enable` and `POST .../disable`
+    // are one `PATCH /v1/plugins/{id}`, which answers with the plugin's
+    // detail rather than `{plugin_id, config}` / `{plugin_id, enabled}`.
+    it("updatePluginConfig patches the plugin with a config body", async () => {
       let capturedBody: any;
       server.use(
-        http.put(`${API_BASE}/plugins/:pluginId/config`, async ({ request }) => {
+        http.patch(`${API_BASE}/v1/plugins/:pluginId`, async ({ request, params }) => {
           capturedBody = await request.json();
-          return HttpResponse.json({ plugin_id: "test", config: {} });
+          return HttpResponse.json({ id: params.pluginId, config: capturedBody.config });
         }),
       );
-      await api.updatePluginConfig("test", { key: "value" });
+      const result = await api.updatePluginConfig("test", { key: "value" });
       expect(capturedBody).toEqual({ config: { key: "value" } });
+      expect(result.config).toEqual({ key: "value" });
     });
 
-    it("enablePlugin sends POST", async () => {
+    it("enablePlugin patches the plugin with enabled: true", async () => {
+      let capturedBody: any;
       server.use(
-        http.post(`${API_BASE}/plugins/:pluginId/enable`, () =>
-          HttpResponse.json({ plugin_id: "test", enabled: true }),
-        ),
+        http.patch(`${API_BASE}/v1/plugins/:pluginId`, async ({ request, params }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({ id: params.pluginId, enabled: capturedBody.enabled });
+        }),
       );
       const result = await api.enablePlugin("test");
+      expect(capturedBody).toEqual({ enabled: true });
       expect(result.enabled).toBe(true);
     });
 
-    it("disablePlugin sends POST", async () => {
+    it("disablePlugin patches the plugin with enabled: false", async () => {
+      let capturedBody: any;
       server.use(
-        http.post(`${API_BASE}/plugins/:pluginId/disable`, () =>
-          HttpResponse.json({ plugin_id: "test", enabled: false }),
-        ),
+        http.patch(`${API_BASE}/v1/plugins/:pluginId`, async ({ request, params }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({ id: params.pluginId, enabled: capturedBody.enabled });
+        }),
       );
       const result = await api.disablePlugin("test");
+      expect(capturedBody).toEqual({ enabled: false });
       expect(result.enabled).toBe(false);
-    });
-
-    it("getPluginData returns data", async () => {
-      server.use(
-        http.get(`${API_BASE}/plugins/:pluginId/data`, () =>
-          HttpResponse.json({ plugin_id: "test", available: true, data: { foo: "bar" } }),
-        ),
-      );
-      const result = await api.getPluginData("test");
-      expect(result.available).toBe(true);
     });
 
     it("getPluginVariables returns variables", async () => {
@@ -929,16 +857,6 @@ describe("API Extended Tests", () => {
       );
       const result = await api.getPluginVariables("test");
       expect(result.plugin_id).toBe("test");
-    });
-
-    it("getAllPluginVariables returns all variables", async () => {
-      server.use(
-        http.get(`${API_BASE}/plugins/variables/all`, () =>
-          HttpResponse.json({ variables: {}, max_lengths: {}, plugin_system_enabled: true }),
-        ),
-      );
-      const result = await api.getAllPluginVariables();
-      expect(result.plugin_system_enabled).toBe(true);
     });
 
     it("getPluginErrors returns errors", async () => {
@@ -1198,33 +1116,6 @@ describe("Per-board boardId params (issue #1244)", () => {
 
     await api.setActivePage("page-1", "b2");
     expect(capturedBody).toEqual({ page_id: "page-1", board_id: "b2" });
-  });
-
-  it("sendPage only appends board_id for a non-empty string", async () => {
-    let capturedUrl = "";
-    server.use(
-      http.post(`${API_BASE}/pages/:id/send`, ({ request }) => {
-        capturedUrl = request.url;
-        return HttpResponse.json({
-          page_id: "page-1",
-          message: "sent",
-          sent_to_board: true,
-          paused: false,
-          target: "board",
-        });
-      }),
-    );
-    await api.sendPage("page-1", "board", "b2");
-    expect(capturedUrl).toContain("board_id=b2");
-
-    await (api.sendPage as unknown as (pageId: string, target?: string, arg?: unknown) => Promise<unknown>)(
-      "page-1",
-      "board",
-      {
-        not: "a-board",
-      },
-    );
-    expect(capturedUrl).not.toContain("board_id");
   });
 
   it("getBoardCurrentMessage only appends board_id for a non-empty string", async () => {

--- a/web/src/__tests__/api.test.ts
+++ b/web/src/__tests__/api.test.ts
@@ -99,14 +99,6 @@ describe("API Contract Tests", () => {
       expect(Array.isArray(result.lines)).toBe(true);
       expect(result.display_type).toBeDefined();
     });
-
-    it("sendPage returns send result", async () => {
-      const result = await api.sendPage("page-1");
-
-      // The {"status": "success"} key is gone; the 200 carries that.
-      expect(result.page_id).toBe("page-1");
-      expect(typeof result.sent_to_board).toBe("boolean");
-    });
   });
 
   describe("Settings API", () => {
@@ -198,45 +190,12 @@ describe("API Contract Tests", () => {
   });
 
   describe("Display API", () => {
-    it("getDisplays returns display list with availability", async () => {
-      const result = await api.getDisplays();
-
-      expect(result.displays).toBeDefined();
-      expect(Array.isArray(result.displays)).toBe(true);
-      expect(typeof result.total).toBe("number");
-      expect(typeof result.available_count).toBe("number");
-
-      // Check display structure
-      if (result.displays.length > 0) {
-        const display = result.displays[0];
-        expect(display.type).toBeDefined();
-        expect(typeof display.available).toBe("boolean");
-        expect(display.description).toBeDefined();
-      }
-    });
-
-    it("getDisplay returns formatted message", async () => {
-      const result = await api.getDisplay("weather");
-
-      expect(result.display_type).toBe("weather");
-      expect(result.message).toBeDefined();
-      expect(Array.isArray(result.lines)).toBe(true);
-      expect(typeof result.line_count).toBe("number");
-      expect(typeof result.available).toBe("boolean");
-    });
-
     it("getDisplayRaw returns raw data", async () => {
       const result = await api.getDisplayRaw("weather");
 
       expect(result.display_type).toBe("weather");
       expect(result.data).toBeDefined();
       expect(typeof result.available).toBe("boolean");
-    });
-
-    it("sendDisplay returns send result", async () => {
-      const result = await api.sendDisplay("weather", "board");
-
-      expect(result.status).toBe("success");
     });
   });
 });

--- a/web/src/__tests__/board-init-error-banner.test.tsx
+++ b/web/src/__tests__/board-init-error-banner.test.tsx
@@ -43,7 +43,7 @@ function setupHandlers({ boardsStatus }: { boardsStatus?: Record<string, unknown
         devices: ["flagship", "note"],
       }),
     ),
-    http.get(`${API_BASE}/status`, () =>
+    http.get(`${API_BASE}/v1/status`, () =>
       HttpResponse.json({
         running: true,
         initialized: true,

--- a/web/src/__tests__/components.test.tsx
+++ b/web/src/__tests__/components.test.tsx
@@ -42,7 +42,7 @@ describe("ServiceControls", () => {
 
   it("shows Stopped badge when status.running is false", async () => {
     server.use(
-      http.get(`${API_BASE}/status`, () =>
+      http.get(`${API_BASE}/v1/status`, () =>
         HttpResponse.json({
           running: false,
           initialized: true,

--- a/web/src/__tests__/compose-dialog.test.tsx
+++ b/web/src/__tests__/compose-dialog.test.tsx
@@ -136,7 +136,7 @@ describe("ComposePageDialog", () => {
       http.post(`${API_BASE}/settings/temporary-override`, () =>
         HttpResponse.json({ active: true, template: ["HI"], device_type: "flagship" }),
       ),
-      http.post(`${API_BASE}/pages`, () => {
+      http.post(`${API_BASE}/v1/pages`, () => {
         pageCreated = true;
         return HttpResponse.json({ id: "p", name: "x" }, { status: 201 });
       }),
@@ -155,7 +155,7 @@ describe("ComposePageDialog", () => {
     let capturedPage: Record<string, unknown> | null = null;
     let overrideSent = false;
     server.use(
-      http.post(`${API_BASE}/pages`, async ({ request }) => {
+      http.post(`${API_BASE}/v1/pages`, async ({ request }) => {
         capturedPage = (await request.json()) as Record<string, unknown>;
         return HttpResponse.json({ id: "p1", name: "Saved" }, { status: 201 });
       }),

--- a/web/src/__tests__/display-settings-init-error.test.tsx
+++ b/web/src/__tests__/display-settings-init-error.test.tsx
@@ -38,7 +38,7 @@ function setupHandlers({ error }: { error?: string | null } = {}) {
         devices: ["flagship"],
       }),
     ),
-    http.get(`${API_BASE}/status`, () =>
+    http.get(`${API_BASE}/v1/status`, () =>
       HttpResponse.json({
         running: true,
         initialized: true,

--- a/web/src/__tests__/general-settings-silence-interaction.test.tsx
+++ b/web/src/__tests__/general-settings-silence-interaction.test.tsx
@@ -133,7 +133,7 @@ describe("GeneralSettings - silence interaction handlers", () => {
   it("renders available pages in page mode selector", async () => {
     server.use(
       http.get(`${API_BASE}/settings/all`, () => HttpResponse.json(allSettings({ mode: "page" }))),
-      http.get(`${API_BASE}/pages`, () => HttpResponse.json(mockPages)),
+      http.get(`${API_BASE}/v1/pages`, () => HttpResponse.json(mockPages)),
     );
 
     const user = userEvent.setup();

--- a/web/src/__tests__/mocks/handlers.ts
+++ b/web/src/__tests__/mocks/handlers.ts
@@ -4,9 +4,7 @@ import type {
   ConfigSummary,
   CurrentDisplayResponse,
   DisplayRawResponse,
-  DisplayResponse,
   DisplaySettings,
-  DisplaysResponse,
   GeneralConfig,
   OutputSettings,
   Page,
@@ -51,27 +49,6 @@ export const mockConfig: ConfigSummary = {
   guest_wifi_enabled: false,
   star_trek_quotes_enabled: true,
   rotation_enabled: true,
-};
-
-export const mockDisplays: DisplaysResponse = {
-  displays: [
-    { type: "weather", available: true, description: "Current weather conditions", source: "plugin" },
-    { type: "datetime", available: true, description: "Current date and time", source: "plugin" },
-    { type: "weather_datetime", available: true, description: "Combined weather and datetime", source: "plugin" },
-    { type: "home_assistant", available: false, description: "Home Assistant status", source: "plugin" },
-    { type: "star_trek", available: true, description: "Star Trek quotes", source: "plugin" },
-    { type: "guest_wifi", available: false, description: "Guest WiFi credentials", source: "plugin" },
-  ],
-  total: 7,
-  available_count: 5,
-};
-
-export const mockWeatherDisplay: DisplayResponse = {
-  display_type: "weather",
-  message: "San Francisco: * Sunny\nTemp: 72°F",
-  lines: ["San Francisco: * Sunny", "Temp: 72°F"],
-  line_count: 2,
-  available: true,
 };
 
 export const mockWeatherRaw: DisplayRawResponse = {
@@ -316,9 +293,39 @@ const inactiveTemporaryOverride = {
 };
 
 // Handlers with request validation
+/** The `PluginDetail` body `GET`/`PATCH /v1/plugins/{id}` both answer with. */
+function pluginDetailFor(pluginId: string) {
+  if (pluginId === "silence_schedule") {
+    return mockSilenceSchedulePlugin;
+  }
+  return {
+    id: pluginId,
+    name: pluginId,
+    version: "1.0.0",
+    description: "",
+    author: "Unknown",
+    icon: "puzzle",
+    category: "utility",
+    plugin_type: "data",
+    enabled: false,
+    config: {},
+    env_overridden_keys: [],
+    settings_schema: {},
+    variables: {},
+    max_lengths: {},
+    env_vars: [],
+    documentation: "",
+    has_demo: false,
+    demo_page_id: null,
+    instance_label: null,
+    base_plugin_id: pluginId,
+    instances: [],
+  };
+}
+
 export const handlers = [
   // Core status endpoints
-  http.get(`${API_BASE}/status`, () => {
+  http.get(`${API_BASE}/v1/status`, () => {
     return HttpResponse.json(mockStatus);
   }),
 
@@ -356,25 +363,6 @@ export const handlers = [
   }),
 
   // Display endpoints
-  http.get(`${API_BASE}/displays`, () => {
-    return HttpResponse.json(mockDisplays);
-  }),
-
-  http.get(`${API_BASE}/displays/:type`, ({ params }) => {
-    const { type } = params;
-    if (type === "weather") {
-      return HttpResponse.json(mockWeatherDisplay);
-    }
-    const response: DisplayResponse = {
-      display_type: String(type),
-      message: `${type} display`,
-      lines: [`${type} display`],
-      line_count: 1,
-      available: true,
-    };
-    return HttpResponse.json(response);
-  }),
-
   http.post(`${API_BASE}/displays/raw/batch`, async ({ request }) => {
     const body = (await request.json()) as { display_types?: string[] };
     const displayTypes = body.display_types || [];
@@ -404,18 +392,6 @@ export const handlers = [
       error: null,
     };
     return HttpResponse.json(response);
-  }),
-
-  http.post(`${API_BASE}/displays/:type/send`, ({ params }) => {
-    const { type } = params;
-    return HttpResponse.json({
-      status: "success",
-      display_type: type,
-      message: `${type} sent`,
-      sent_to_board: true,
-      paused: false,
-      target: "board",
-    });
   }),
 
   // Settings endpoints
@@ -473,7 +449,7 @@ export const handlers = [
   }),
 
   // Pages endpoints
-  http.get(`${API_BASE}/pages`, () => {
+  http.get(`${API_BASE}/v1/pages`, () => {
     return HttpResponse.json(mockPages);
   }),
 
@@ -493,7 +469,7 @@ export const handlers = [
     });
   }),
 
-  http.get(`${API_BASE}/pages/:id`, ({ params }) => {
+  http.get(`${API_BASE}/v1/pages/:id`, ({ params }) => {
     const { id } = params;
     if (id === "page-1") {
       return HttpResponse.json(mockPage);
@@ -504,7 +480,7 @@ export const handlers = [
     return HttpResponse.json(mockPage);
   }),
 
-  http.post(`${API_BASE}/pages`, async ({ request }) => {
+  http.post(`${API_BASE}/v1/pages`, async ({ request }) => {
     const body = (await request.json()) as PageCreate;
     requestStore.lastPageCreate = body;
 
@@ -523,7 +499,7 @@ export const handlers = [
     return HttpResponse.json(newPage, { status: 201 });
   }),
 
-  http.put(`${API_BASE}/pages/:id`, async ({ request, params }) => {
+  http.put(`${API_BASE}/v1/pages/:id`, async ({ request, params }) => {
     const body = (await request.json()) as Partial<Page>;
     const { id } = params;
     const updatedPage: Page = {
@@ -535,7 +511,7 @@ export const handlers = [
     return HttpResponse.json({ page: updatedPage, incompatible_references: [] });
   }),
 
-  http.delete(`${API_BASE}/pages/:id`, ({ params }) => {
+  http.delete(`${API_BASE}/v1/pages/:id`, ({ params }) => {
     return HttpResponse.json({
       id: params.id,
       message: "Page deleted",
@@ -675,19 +651,8 @@ export const handlers = [
     });
   }),
 
-  http.post(`${API_BASE}/pages/:id/send`, ({ params }) => {
-    const { id } = params;
-    return HttpResponse.json({
-      page_id: id,
-      message: "Page sent",
-      sent_to_board: true,
-      paused: false,
-      target: "board",
-    });
-  }),
-
   // Template endpoints
-  http.get(`${API_BASE}/templates/variables`, () => {
+  http.get(`${API_BASE}/v1/variables`, () => {
     return HttpResponse.json(mockTemplateVariables);
   }),
 
@@ -755,34 +720,20 @@ export const handlers = [
   }),
 
   // Plugin config endpoints
-  http.get(`${API_BASE}/plugins/:pluginId`, ({ params }) => {
-    const { pluginId } = params;
-    if (pluginId === "silence_schedule") {
-      return HttpResponse.json(mockSilenceSchedulePlugin);
-    }
-    // Return generic plugin response for other plugins
+  http.get(`${API_BASE}/v1/plugins/:pluginId`, ({ params }) => {
+    return HttpResponse.json(pluginDetailFor(String(params.pluginId)));
+  }),
+
+  // `PATCH /v1/plugins/{id}` replaced PUT /plugins/{id}/config, POST
+  // .../enable and POST .../disable, and answers with the plugin's detail
+  // instead of `{plugin_id, config}` / `{plugin_id, enabled}`.
+  http.patch(`${API_BASE}/v1/plugins/:pluginId`, async ({ request, params }) => {
+    const body = (await request.json()) as { config?: Record<string, unknown>; enabled?: boolean };
+    const detail = pluginDetailFor(String(params.pluginId));
     return HttpResponse.json({
-      id: pluginId,
-      name: String(pluginId),
-      version: "1.0.0",
-      description: "",
-      author: "Unknown",
-      icon: "puzzle",
-      category: "utility",
-      plugin_type: "data",
-      enabled: false,
-      config: {},
-      env_overridden_keys: [],
-      settings_schema: {},
-      variables: {},
-      max_lengths: {},
-      env_vars: [],
-      documentation: "",
-      has_demo: false,
-      demo_page_id: null,
-      instance_label: null,
-      base_plugin_id: String(pluginId),
-      instances: [],
+      ...detail,
+      ...(body.config !== undefined && { config: body.config }),
+      ...(body.enabled !== undefined && { enabled: body.enabled }),
     });
   }),
 
@@ -825,24 +776,6 @@ export const handlers = [
       settings_schema: {},
       max_lengths: {},
       variables: { simple: [] },
-    });
-  }),
-
-  http.post(`${API_BASE}/plugins/:pluginId/config`, async ({ request, params }) => {
-    const { pluginId } = params;
-    const body = (await request.json()) as { config: Record<string, unknown> };
-    return HttpResponse.json({
-      plugin_id: pluginId,
-      config: body.config,
-    });
-  }),
-
-  http.put(`${API_BASE}/plugins/:pluginId/config`, async ({ request, params }) => {
-    const { pluginId } = params;
-    const body = (await request.json()) as { config: Record<string, unknown> };
-    return HttpResponse.json({
-      plugin_id: pluginId,
-      config: body.config,
     });
   }),
 
@@ -902,7 +835,7 @@ export const handlers = [
   }),
 
   // Collection endpoints
-  http.get(`${API_BASE}/collections`, () => {
+  http.get(`${API_BASE}/v1/collections`, () => {
     return HttpResponse.json({
       collections: [],
       total: 0,
@@ -910,7 +843,7 @@ export const handlers = [
   }),
 
   // Schedule endpoints (for active-page-display)
-  http.get(`${API_BASE}/schedules`, ({ request }) => {
+  http.get(`${API_BASE}/v1/schedules`, ({ request }) => {
     const url = new URL(request.url);
     const boardId = url.searchParams.get("board_id");
     return HttpResponse.json({
@@ -1180,6 +1113,38 @@ export const handlers = [
   }),
 
   // Board settings endpoints
+  // `PATCH /v1/boards/{board}` — where pausing, schedule mode and the
+  // schedule's fallback page moved (was POST /settings/board/{id}/pause,
+  // PUT /schedules/enabled, PUT /schedules/default-page). `primary` is the
+  // alias for "the board an id-less internal call meant".
+  http.patch(`${API_BASE}/v1/boards/:board`, async ({ request, params }) => {
+    const body = (await request.json()) as {
+      paused?: boolean;
+      schedule_enabled?: boolean;
+      default_page_id?: string | null;
+      name?: string;
+    };
+    return HttpResponse.json({
+      id: String(params.board),
+      name: body.name ?? String(params.board),
+      device_type: "flagship",
+      rows: 6,
+      cols: 22,
+      is_primary: true,
+      paused: body.paused ?? false,
+      schedule_enabled: body.schedule_enabled ?? false,
+      characters: null,
+      text: null,
+      read_at: null,
+      active_page_id: null,
+      scheduled_page_id: null,
+      resolved_page_id: null,
+      source: "none",
+      default_page_id: body.default_page_id ?? null,
+      override_expires_at: null,
+    });
+  }),
+
   http.get(`${API_BASE}/settings/board`, () => {
     return HttpResponse.json({
       board_type: "black",

--- a/web/src/__tests__/page-builder-new-page-invalidation.test.tsx
+++ b/web/src/__tests__/page-builder-new-page-invalidation.test.tsx
@@ -53,7 +53,7 @@ describe("PageBuilder — saving a new page", () => {
     vi.clearAllMocks();
     localStorage.clear();
     server.use(
-      http.post(`${API_BASE}/pages`, async () => {
+      http.post(`${API_BASE}/v1/pages`, async () => {
         // 201 + the bare page since the Phase 2 conventions pass. This test is
         // the #1586 regression guard: the id the builder invalidates on must be
         // the one the create response carried.

--- a/web/src/__tests__/page-builder-transition-picker.test.tsx
+++ b/web/src/__tests__/page-builder-transition-picker.test.tsx
@@ -54,7 +54,7 @@ function TestWrapper({ children }: { children: React.ReactNode }) {
 /** Serve GET /pages/page-1 with the given saved override. */
 function servePageWithTransition(transitionStrategy: string | null) {
   server.use(
-    http.get(`${API_BASE}/pages/page-1`, () =>
+    http.get(`${API_BASE}/v1/pages/page-1`, () =>
       HttpResponse.json({
         id: "page-1",
         name: "Weather Page",
@@ -73,7 +73,7 @@ function servePageWithTransition(transitionStrategy: string | null) {
 function captureUpdate(): { body: Record<string, unknown> | null } {
   const captured: { body: Record<string, unknown> | null } = { body: null };
   server.use(
-    http.put(`${API_BASE}/pages/page-1`, async ({ request }) => {
+    http.put(`${API_BASE}/v1/pages/page-1`, async ({ request }) => {
       captured.body = (await request.json()) as Record<string, unknown>;
       return HttpResponse.json({
         page: { id: "page-1", name: "Weather Page", type: "template", device_type: "flagship" },

--- a/web/src/__tests__/page-builder.test.tsx
+++ b/web/src/__tests__/page-builder.test.tsx
@@ -165,7 +165,7 @@ describe("PageBuilder — note-array dimensions", () => {
     // Editing a 2×2 note array page (persisted notes_wide/notes_tall) →
     // 2*15 = 30 cols × 2*3 = 6 rows → "6 × 30".
     server.use(
-      http.get(`${API_BASE}/pages/:id`, () => {
+      http.get(`${API_BASE}/v1/pages/:id`, () => {
         return HttpResponse.json({
           id: "na-page",
           name: "My Note Array Page",

--- a/web/src/__tests__/pages-index-device-tabs.test.tsx
+++ b/web/src/__tests__/pages-index-device-tabs.test.tsx
@@ -61,7 +61,7 @@ function mockBoardSettings(devices: TestDevice[]) {
 
 function mockPages(pages: { id: string; name: string; device_type: TestDevice }[]) {
   server.use(
-    http.get(`${API_BASE}/pages`, () =>
+    http.get(`${API_BASE}/v1/pages`, () =>
       HttpResponse.json({
         pages: pages.map((p) => ({
           ...p,
@@ -78,7 +78,7 @@ function mockPages(pages: { id: string; name: string; device_type: TestDevice }[
   // the component finishes loading.
   server.use(http.post(`${API_BASE}/pages/preview-batch`, () => HttpResponse.json({ previews: {} })));
   // Collections — empty.
-  server.use(http.get(`${API_BASE}/collections`, () => HttpResponse.json({ collections: [] })));
+  server.use(http.get(`${API_BASE}/v1/collections`, () => HttpResponse.json({ collections: [] })));
 }
 
 describe("PagesPage device-type tabs", () => {

--- a/web/src/__tests__/silence-imminent-banner.test.tsx
+++ b/web/src/__tests__/silence-imminent-banner.test.tsx
@@ -53,7 +53,7 @@ function setupHandlers(opts: {
       }),
     ),
     http.get(`${API_BASE}/settings/active-page`, () => HttpResponse.json({ page_id: opts.manualPageId ?? null })),
-    http.get(`${API_BASE}/pages`, () =>
+    http.get(`${API_BASE}/v1/pages`, () =>
       HttpResponse.json({
         pages: opts.pages ?? [{ id: "page-quiet", name: "Quiet" }],
         total: (opts.pages ?? [{ id: "page-quiet", name: "Quiet" }]).length,

--- a/web/src/__tests__/silence-schedule-extended.test.tsx
+++ b/web/src/__tests__/silence-schedule-extended.test.tsx
@@ -78,7 +78,7 @@ describe("SilenceSchedule — indicator position handler", () => {
   beforeEach(() => {
     server.use(
       http.get(`${API_BASE}/settings/all`, () => HttpResponse.json(allSettings({ mode: "indicator" }))),
-      http.get(`${API_BASE}/pages`, () => HttpResponse.json({ pages: mockPages })),
+      http.get(`${API_BASE}/v1/pages`, () => HttpResponse.json({ pages: mockPages })),
     );
   });
   afterEach(() => server.resetHandlers());

--- a/web/src/__tests__/silence-schedule-per-board.test.tsx
+++ b/web/src/__tests__/silence-schedule-per-board.test.tsx
@@ -89,7 +89,7 @@ function stub({ boards = [FLAGSHIP], silence = {} as Record<string, unknown>, on
     http.get(`${API_BASE}/settings/board`, () =>
       HttpResponse.json({ board_type: "black", boards, devices: ["flagship"] }),
     ),
-    http.get(`${API_BASE}/pages`, () => HttpResponse.json({ pages: PAGES, total: PAGES.length })),
+    http.get(`${API_BASE}/v1/pages`, () => HttpResponse.json({ pages: PAGES, total: PAGES.length })),
     http.put(`${API_BASE}/settings/silence-schedule`, async ({ request }) => {
       const body = await request.json();
       onPut(body);

--- a/web/src/__tests__/template-editor-toolbar-home-assistant.test.tsx
+++ b/web/src/__tests__/template-editor-toolbar-home-assistant.test.tsx
@@ -31,10 +31,10 @@ const sensorTemperature: HomeAssistantEntity = {
   friendly_name: "Living Room Temperature",
 };
 
-/** `/templates/variables` including a `home_assistant` namespace. */
+/** `GET /v1/variables` including a `home_assistant` namespace. */
 function useHomeAssistantVariables() {
   server.use(
-    http.get(`${API_BASE}/templates/variables`, () =>
+    http.get(`${API_BASE}/v1/variables`, () =>
       HttpResponse.json({
         ...mockTemplateVariables,
         variables: { ...mockTemplateVariables.variables, home_assistant: ["sensor_temperature.state"] },
@@ -104,7 +104,7 @@ describe("TemplateEditorToolbar Home Assistant entity picker", () => {
   });
 
   it("does not render the Home Assistant entity button when home_assistant is absent", async () => {
-    // The default `/templates/variables` mock only exposes weather + datetime.
+    // The default `GET /v1/variables` mock only exposes weather + datetime.
     renderToolbar();
 
     // Wait for the toolbar to have consumed the variables response.

--- a/web/src/__tests__/transitions-lab-defaults.test.tsx
+++ b/web/src/__tests__/transitions-lab-defaults.test.tsx
@@ -49,7 +49,7 @@ function mockLab() {
       HttpResponse.json({ settings: { transition_plugins_enabled: true }, available: [] }),
     ),
     http.get(`${API_BASE}/transitions/plugins`, () => HttpResponse.json({ plugins: [PLUGIN] })),
-    http.get(`${API_BASE}/pages`, () => HttpResponse.json({ pages: PAGES })),
+    http.get(`${API_BASE}/v1/pages`, () => HttpResponse.json({ pages: PAGES })),
     http.post(`${API_BASE}/transitions/preview`, () =>
       HttpResponse.json({ frames: FRAMES, frame_count: FRAMES.length, capped: false }),
     ),

--- a/web/src/lib/api/boards.ts
+++ b/web/src/lib/api/boards.ts
@@ -207,6 +207,47 @@ export interface BoardInstance {
   tiles?: NoteArrayTile[];
 }
 
+/**
+ * `GET | PATCH /v1/boards/{board}` — mirrors `BoardDetail` in src/v1/models.py.
+ *
+ * A deliberate projection of a board plus what it is doing right now. It is
+ * NOT a replacement for `BoardInstance` (`GET /settings/board`): v1 drops the
+ * connection credentials, per-tile wiring, board colour and code-62 glyph on
+ * purpose, so anything configuring a board still reads the settings shape.
+ */
+export interface BoardDetail {
+  id: string;
+  name: string;
+  device_type: DeviceType;
+  rows: number;
+  cols: number;
+  is_primary: boolean;
+  paused: boolean;
+  schedule_enabled: boolean;
+  characters: number[][] | null;
+  text: string | null;
+  read_at: string | null;
+  active_page_id: string | null;
+  scheduled_page_id: string | null;
+  resolved_page_id: string | null;
+  source: "manual" | "schedule" | "none";
+  default_page_id: string | null;
+  override_expires_at: string | null;
+}
+
+/**
+ * The `{board}` path segment of a v1 board route.
+ *
+ * v1 accepts the literal `primary` in place of an id, which is how an
+ * id-less internal call ("no board_id" = the default board) is expressed:
+ * `SettingsService.get_primary_board_id()` is the same resolution both sides
+ * use. Non-empty string only — these wrappers get handed to TanStack Query
+ * and event handlers as bare references (issue #1244).
+ */
+export function boardPathSegment(boardId?: string | null): string {
+  return typeof boardId === "string" && boardId ? encodeURIComponent(boardId) : "primary";
+}
+
 export interface BoardSettings {
   board_type: "black" | "white" | null;
   boards: BoardInstance[];
@@ -323,9 +364,13 @@ export const boardsApi = {
     fetchApi<BoardSettings>(`/settings/board/${boardId}`, {
       method: "DELETE",
     }),
+  // Pausing moved to `PATCH /v1/boards/{board}` (issue #1930), which calls the
+  // same `SettingsService.set_paused`. The response is the v1 BoardDetail
+  // rather than `{ board_id, paused, board_settings }` — no caller read those
+  // fields; the one consumer invalidates its queries instead.
   setBoardPaused: (boardId: string, paused: boolean) =>
-    fetchApi<{ board_id: string; paused: boolean; board_settings: BoardSettings }>(`/settings/board/${boardId}/pause`, {
-      method: "POST",
+    fetchApi<BoardDetail>(`/v1/boards/${boardPathSegment(boardId)}`, {
+      method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ paused }),
     }),

--- a/web/src/lib/api/collections.ts
+++ b/web/src/lib/api/collections.ts
@@ -74,26 +74,28 @@ export interface CollectionDeleteResponse {
 // Create / update / delete return bare bodies, not `{status, collection}`
 // envelopes — see docs/internal/reference/API_CONVENTIONS.md. Create answers
 // 201; `fetchApi` already treats any 2xx as success.
+//
+// All of these are on /v1 (issue #1930): `/v1/collections*` delegates to the
+// same handlers `/collections*` does, so the models and status codes are
+// identical and only the path moved.
 export const collectionsApi = {
   // Collection endpoints
-  getCollections: () => fetchApi<CollectionsResponse>("/collections"),
+  getCollections: () => fetchApi<CollectionsResponse>("/v1/collections"),
 
   createCollection: (data: CollectionCreate) =>
-    fetchApi<Collection>("/collections", {
+    fetchApi<Collection>("/v1/collections", {
       method: "POST",
       body: JSON.stringify(data),
     }),
 
-  getCollection: (collectionId: string) => fetchApi<Collection>(`/collections/${collectionId}`),
-
   updateCollection: (collectionId: string, data: CollectionUpdate) =>
-    fetchApi<Collection>(`/collections/${collectionId}`, {
+    fetchApi<Collection>(`/v1/collections/${collectionId}`, {
       method: "PUT",
       body: JSON.stringify(data),
     }),
 
   deleteCollection: (collectionId: string) =>
-    fetchApi<CollectionDeleteResponse>(`/collections/${collectionId}`, {
+    fetchApi<CollectionDeleteResponse>(`/v1/collections/${collectionId}`, {
       method: "DELETE",
     }),
 };

--- a/web/src/lib/api/misc.ts
+++ b/web/src/lib/api/misc.ts
@@ -12,45 +12,11 @@ export interface PreviewResponse {
   preview: boolean;
 }
 
-// Display types
-export interface DisplayInfo {
-  type: string;
-  available: boolean;
-  description: string;
-  /** Always "plugin"; kept for clients that predate the plugin system. */
-  source: string;
-}
-
-export interface DisplaysResponse {
-  displays: DisplayInfo[];
-  total: number;
-  available_count: number;
-}
-
-export interface DisplayResponse {
-  display_type: string;
-  message: string;
-  lines: string[];
-  line_count: number;
-  available: boolean;
-}
-
 export interface DisplayRawResponse {
   display_type: string;
   data: Record<string, unknown> | null;
   available: boolean;
   error: string | null;
-}
-
-/** POST /displays/{type}/send — mirrors src/displays/models.py. */
-export interface DisplaySendResponse {
-  status: string;
-  display_type: string;
-  message: string;
-  sent_to_board: boolean;
-  /** True when the send was skipped because the target board is paused. */
-  paused: boolean;
-  target: string;
 }
 
 export interface DisplayRawBatchResponse {
@@ -112,8 +78,6 @@ export interface StockSymbolValidation {
 
 export const miscApi = {
   // Display endpoints
-  getDisplays: () => fetchApi<DisplaysResponse>("/displays"),
-  getDisplay: (type: string) => fetchApi<DisplayResponse>(`/displays/${type}`),
   getDisplayRaw: (type: string) => fetchApi<DisplayRawResponse>(`/displays/${type}/raw`),
   getDisplaysRawBatch: (displayTypes: string[], enabledOnly?: boolean) =>
     fetchApi<DisplayRawBatchResponse>("/displays/raw/batch", {
@@ -123,10 +87,6 @@ export const miscApi = {
         enabled_only: enabledOnly ?? true,
       }),
     }),
-  sendDisplay: (type: string, target?: "ui" | "board" | "both") => {
-    const params = target ? `?target=${target}` : "";
-    return fetchApi<DisplaySendResponse>(`/displays/${type}/send${params}`, { method: "POST" });
-  },
   // Bay Wheels station search endpoints
   listBayWheelsStations: () => fetchApi<{ stations: BayWheelsStation[]; total: number }>("/baywheels/stations"),
   findNearbyBayWheelsStations: (lat: number, lng: number, radius?: number, limit?: number) => {

--- a/web/src/lib/api/pages.ts
+++ b/web/src/lib/api/pages.ts
@@ -167,16 +167,6 @@ export interface PagePreviewBatchResponse {
   successful: number;
 }
 
-export interface PageSendResponse {
-  page_id: string;
-  message: string;
-  sent_to_board: boolean;
-  /** True when the send was skipped because the target board is paused. */
-  paused: boolean;
-  target: string;
-  board_id?: string | null;
-}
-
 export interface CurrentDisplayResponse {
   page_id: string;
   page_name: string;
@@ -205,36 +195,30 @@ export const pagesApi = {
         ...(typeof boardId === "string" && boardId && { board_id: boardId }),
       }),
     }),
-  // Pages endpoints
-  getPages: () => fetchApi<PagesResponse>("/pages"),
+  // Pages CRUD lives on /v1 (issue #1930). `/v1/pages*` delegates to the very
+  // same handlers `/pages*` does — same models, same 404 wording — so this is
+  // a path change with no response-shape change.
+  getPages: () => fetchApi<PagesResponse>("/v1/pages"),
   getCurrentDisplay: () => fetchApi<CurrentDisplayResponse>("/pages/current-display"),
-  getPage: (pageId: string) => fetchApi<Page>(`/pages/${pageId}`),
+  getPage: (pageId: string) => fetchApi<Page>(`/v1/pages/${pageId}`),
   /** 201 with the created page itself — no envelope. */
   createPage: (page: PageCreate) =>
-    fetchApi<Page>("/pages", {
+    fetchApi<Page>("/v1/pages", {
       method: "POST",
       body: JSON.stringify(page),
     }),
   updatePage: (pageId: string, page: PageUpdate) =>
-    fetchApi<PageUpdateResponse>(`/pages/${pageId}`, {
+    fetchApi<PageUpdateResponse>(`/v1/pages/${pageId}`, {
       method: "PUT",
       body: JSON.stringify(page),
     }),
-  deletePage: (pageId: string) => fetchApi<PageDeleteResponse>(`/pages/${pageId}`, { method: "DELETE" }),
+  deletePage: (pageId: string) => fetchApi<PageDeleteResponse>(`/v1/pages/${pageId}`, { method: "DELETE" }),
   previewPage: (pageId: string) => fetchApi<PagePreviewResponse>(`/pages/${pageId}/preview`, { method: "POST" }),
   previewPagesBatch: (pageIds: string[]) =>
     fetchApi<PagePreviewBatchResponse>("/pages/preview/batch", {
       method: "POST",
       body: JSON.stringify({ page_ids: pageIds }),
     }),
-  sendPage: (pageId: string, target?: "ui" | "board" | "both", boardId?: string) => {
-    const query = new URLSearchParams();
-    if (target) query.set("target", target);
-    // Non-empty string only — see the getActivePage note (issue #1244).
-    if (typeof boardId === "string" && boardId) query.set("board_id", boardId);
-    const qs = query.toString();
-    return fetchApi<PageSendResponse>(`/pages/${pageId}/send${qs ? `?${qs}` : ""}`, { method: "POST" });
-  },
   getPageShareString: (pageId: string) => fetchApi<{ share_string: string }>(`/pages/${pageId}/share`),
   /** 201 with the created page itself — no envelope, same as createPage. */
   importPage: (shareString: string) =>

--- a/web/src/lib/api/plugins.ts
+++ b/web/src/lib/api/plugins.ts
@@ -212,37 +212,11 @@ export interface PluginDemoPageCreateResponse {
   page: Page;
 }
 
-export interface PluginConfigUpdateResponse {
-  plugin_id: string;
-  /** The stored configuration, re-masked. Never echoes a real secret back. */
-  config: Record<string, unknown>;
-}
-
-export interface PluginEnableResponse {
-  plugin_id: string;
-  enabled: boolean;
-}
-
-export interface PluginDataResponse {
-  plugin_id: string;
-  available: boolean;
-  data: Record<string, unknown> | null;
-  /** The plugin's rendered board lines. (Was mistyped as `formatted`.) */
-  formatted_lines: string[] | null;
-  error: string | null;
-}
-
 export interface PluginVariablesResponse {
   plugin_id: string;
   variables: Record<string, unknown>;
   max_lengths: Record<string, number>;
   color_rules_schema: Record<string, unknown>;
-}
-
-export interface AllPluginVariablesResponse {
-  variables: Record<string, string[]>;
-  max_lengths: Record<string, number>;
-  plugin_system_enabled: boolean;
 }
 
 /** One plugin's standing with the data-fetch circuit breaker. */
@@ -264,24 +238,32 @@ export const pluginsApi = {
   // Plugin system endpoints
   listPlugins: () => fetchApi<PluginsListResponse>("/plugins"),
 
-  getPlugin: (pluginId: string) => fetchApi<PluginDetailResponse>(`/plugins/${pluginId}`),
+  // `GET /v1/plugins/{id}` is `GET /plugins/{id}`'s own handler behind a new
+  // path — same PluginDetail model, same masking of stored secrets.
+  getPlugin: (pluginId: string) => fetchApi<PluginDetailResponse>(`/v1/plugins/${pluginId}`),
 
   getPluginManifest: (pluginId: string) => fetchApi<PluginManifest>(`/plugins/${pluginId}/manifest`),
 
+  // `PUT /plugins/{id}/config`, `POST .../enable` and `POST .../disable` are
+  // one `PATCH /v1/plugins/{id}` (issue #1930). v1 dispatches to those three
+  // handlers unchanged and answers with the plugin's full detail instead of
+  // `{plugin_id, config}` / `{plugin_id, enabled}`; no caller read either.
   updatePluginConfig: (pluginId: string, config: Record<string, unknown>) =>
-    fetchApi<PluginConfigUpdateResponse>(`/plugins/${pluginId}/config`, {
-      method: "PUT",
+    fetchApi<PluginDetailResponse>(`/v1/plugins/${pluginId}`, {
+      method: "PATCH",
       body: JSON.stringify({ config }),
     }),
 
   enablePlugin: (pluginId: string) =>
-    fetchApi<PluginEnableResponse>(`/plugins/${pluginId}/enable`, {
-      method: "POST",
+    fetchApi<PluginDetailResponse>(`/v1/plugins/${pluginId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ enabled: true }),
     }),
 
   disablePlugin: (pluginId: string) =>
-    fetchApi<PluginEnableResponse>(`/plugins/${pluginId}/disable`, {
-      method: "POST",
+    fetchApi<PluginDetailResponse>(`/v1/plugins/${pluginId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ enabled: false }),
     }),
 
   /**
@@ -295,8 +277,6 @@ export const pluginsApi = {
       body: JSON.stringify(request),
     }),
 
-  getPluginData: (pluginId: string) => fetchApi<PluginDataResponse>(`/plugins/${pluginId}/data`),
-
   getPluginVariables: (pluginId: string) => fetchApi<PluginVariablesResponse>(`/plugins/${pluginId}/variables`),
 
   getPluginDemoPage: (pluginId: string) => fetchApi<PluginDemoPageResponse>(`/plugins/${pluginId}/demo-page`),
@@ -305,8 +285,6 @@ export const pluginsApi = {
     fetchApi<PluginDemoPageCreateResponse>(`/plugins/${pluginId}/demo-page`, {
       method: "POST",
     }),
-
-  getAllPluginVariables: () => fetchApi<AllPluginVariablesResponse>("/plugins/variables/all"),
 
   getPluginErrors: () => fetchApi<PluginErrorsResponse>("/plugins/errors"),
 

--- a/web/src/lib/api/schedules.ts
+++ b/web/src/lib/api/schedules.ts
@@ -1,6 +1,7 @@
 // Schedules domain: schedule CRUD/validation, default page,
 // temporary overrides, and the silence (quiet hours) feature.
 
+import { type BoardDetail, boardPathSegment } from "./boards";
 import { fetchApi } from "./core";
 import type { LineMetadata } from "./shared";
 
@@ -176,14 +177,6 @@ export interface ActiveScheduleResponse {
   temporary_override: TemporaryOverrideStatus;
 }
 
-export interface ScheduleEnabledResponse {
-  enabled: boolean;
-}
-
-export interface DefaultPageResponse {
-  default_page_id: string | null;
-}
-
 /**
  * What POST/PUT /schedules answer with: the schedule, plus the non-fatal
  * page<->board size mismatches of issue #1245. `warnings` is always present
@@ -233,26 +226,26 @@ export const schedulesApi = {
     fetchApi<{ revert_mode: string | null }>("/settings/temporary-override", {
       method: "DELETE",
     }),
-  // Schedule endpoints (optional boardId for per-board schedules)
+  // Schedule CRUD lives on /v1 (issue #1930): `/v1/schedules*` delegates to the
+  // same handlers `/schedules*` does — including the sun-time enrichment and
+  // the #1245 size warnings — so only the path moved.
   getSchedules: (boardId?: string) =>
-    fetchApi<SchedulesResponse>(boardId ? `/schedules?board_id=${encodeURIComponent(boardId)}` : "/schedules"),
+    fetchApi<SchedulesResponse>(boardId ? `/v1/schedules?board_id=${encodeURIComponent(boardId)}` : "/v1/schedules"),
 
   createSchedule: (data: ScheduleCreate) =>
-    fetchApi<ScheduleWriteResponse>("/schedules", {
+    fetchApi<ScheduleWriteResponse>("/v1/schedules", {
       method: "POST",
       body: JSON.stringify(data),
     }),
 
-  getSchedule: (scheduleId: string) => fetchApi<ScheduleEntry>(`/schedules/${scheduleId}`),
-
   updateSchedule: (scheduleId: string, data: ScheduleUpdate) =>
-    fetchApi<ScheduleWriteResponse>(`/schedules/${scheduleId}`, {
+    fetchApi<ScheduleWriteResponse>(`/v1/schedules/${scheduleId}`, {
       method: "PUT",
       body: JSON.stringify(data),
     }),
 
   deleteSchedule: (scheduleId: string) =>
-    fetchApi<ScheduleDeleteResponse>(`/schedules/${scheduleId}`, {
+    fetchApi<ScheduleDeleteResponse>(`/v1/schedules/${scheduleId}`, {
       method: "DELETE",
     }),
 
@@ -267,26 +260,22 @@ export const schedulesApi = {
       body: JSON.stringify(boardId != null ? { board_id: boardId } : {}),
     }),
 
-  getDefaultPage: (boardId?: string) =>
-    fetchApi<DefaultPageResponse>(
-      boardId ? `/schedules/default-page?board_id=${encodeURIComponent(boardId)}` : "/schedules/default-page",
-    ),
-
+  // Both of these are per-board settings, so v1 puts them on the board rather
+  // than on /schedules: `PATCH /v1/boards/{board}` calls the same
+  // `ScheduleService.set_default_page` / `SettingsService.set_schedule_enabled`
+  // (and the same page-exists 404) that the /schedules setters did. The
+  // response widens from `{default_page_id}` / `{enabled}` to the whole
+  // BoardDetail; no caller read the old body.
   setDefaultPage: (pageId: string | null, boardId?: string) =>
-    fetchApi<DefaultPageResponse>("/schedules/default-page", {
-      method: "PUT",
-      body: JSON.stringify({ page_id: pageId, ...(boardId != null && { board_id: boardId }) }),
+    fetchApi<BoardDetail>(`/v1/boards/${boardPathSegment(boardId)}`, {
+      method: "PATCH",
+      body: JSON.stringify({ default_page_id: pageId }),
     }),
 
-  getScheduleEnabled: (boardId?: string) =>
-    fetchApi<ScheduleEnabledResponse>(
-      boardId ? `/schedules/enabled?board_id=${encodeURIComponent(boardId)}` : "/schedules/enabled",
-    ),
-
   setScheduleEnabled: (enabled: boolean, boardId?: string) =>
-    fetchApi<ScheduleEnabledResponse>("/schedules/enabled", {
-      method: "PUT",
-      body: JSON.stringify({ enabled, ...(boardId != null && { board_id: boardId }) }),
+    fetchApi<BoardDetail>(`/v1/boards/${boardPathSegment(boardId)}`, {
+      method: "PATCH",
+      body: JSON.stringify({ schedule_enabled: enabled }),
     }),
   // Silence mode status (optional boardId reads that board's window).
   // boardId is only honored when it's a non-empty string: this wrapper is

--- a/web/src/lib/api/system.ts
+++ b/web/src/lib/api/system.ts
@@ -238,7 +238,8 @@ export interface WifiConnectResponse {
 
 export const systemApi = {
   // Queries (read-only)
-  getStatus: () => fetchApi<StatusResponse>("/status"),
+  // `GET /v1/status` is `GET /status`'s own handler behind a new path.
+  getStatus: () => fetchApi<StatusResponse>("/v1/status"),
   getConfig: () => fetchApi<ConfigSummary>("/config"),
   // Mutations (actions)
   startService: () => fetchApi<ServiceStateResponse>("/start", { method: "POST" }),

--- a/web/src/lib/api/templates.ts
+++ b/web/src/lib/api/templates.ts
@@ -83,8 +83,13 @@ export interface TemplateRenderLiveResponse {
 
 export const templatesApi = {
   // Templates endpoints
-  getTemplateVariables: () => fetchApi<TemplateVariables>("/templates/variables"),
-  getFormulaFunctions: () => fetchApi<FormulaFunctionsResponse>("/templates/formula-functions"),
+  // `GET /v1/variables` is the merge of `GET /templates/variables` and
+  // `GET /plugins/variables/all` (issue #1930). Both sides read the same
+  // `registry.get_all_variables()` — `TemplateEngine.get_available_variables`
+  // forwards to it — so the merge adds nothing to `variables`/`max_lengths`
+  // and the payload here is a strict superset of the old one.
+  getTemplateVariables: () => fetchApi<TemplateVariables>("/v1/variables"),
+  getFormulaFunctions: () => fetchApi<FormulaFunctionsResponse>("/v1/functions"),
   validateTemplate: (template: string | string[]) =>
     fetchApi<TemplateValidationResponse>("/templates/validate", {
       method: "POST",

--- a/web/tests/helpers.ts
+++ b/web/tests/helpers.ts
@@ -250,7 +250,7 @@ let _cachedSessionCookie: string | null = null;
  * pending state to let the real request finish.
  *
  * @example
- *   const release = await slowRoute(page, "**\/api\/pages", ["GET"]);
+ *   const release = await slowRoute(page, "**\/api\/v1\/pages", ["GET"]);
  *   await page.goto("/pages");
  *   await expect(skeleton).toBeVisible();
  *   release();

--- a/web/tests/helpers.ts
+++ b/web/tests/helpers.ts
@@ -360,6 +360,13 @@ export async function waitForApi(timeoutMs = 15_000) {
 }
 
 // ---------------------------------------------------------------------------
+// These fixtures set up the fleet through the same /v1 surface the app now
+// uses (issue #1930). /v1 pages, schedules and collections delegate to the
+// internal domain handlers, so the bodies read here are unchanged; the two
+// that did change shape are noted at their call sites.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
 // CRUD helpers – keep tests focused on assertions, not setup boilerplate
 // ---------------------------------------------------------------------------
 
@@ -373,7 +380,7 @@ export async function createPage(
   if (deviceType !== "flagship") {
     body.device_type = deviceType;
   }
-  const res = await fetch(`${API_URL}/pages`, {
+  const res = await fetch(`${API_URL}/v1/pages`, {
     method: "POST",
     headers: { "Content-Type": "application/json", ...authHeaders() },
     body: JSON.stringify(body),
@@ -390,7 +397,7 @@ export async function createNotePage(name: string, template: string[] = ["NOTE T
 
 /** Delete a page via the API. */
 export async function deletePage(id: string): Promise<void> {
-  const res = await fetch(`${API_URL}/pages/${id}`, {
+  const res = await fetch(`${API_URL}/v1/pages/${id}`, {
     method: "DELETE",
     headers: authHeaders(),
   });
@@ -403,7 +410,7 @@ export async function createCollection(
   pageIds: string[],
   intervalSeconds = 30,
 ): Promise<{ id: string; name: string; page_ids: string[]; time: { interval_seconds: number } }> {
-  const res = await fetch(`${API_URL}/collections`, {
+  const res = await fetch(`${API_URL}/v1/collections`, {
     method: "POST",
     headers: { "Content-Type": "application/json", ...authHeaders() },
     body: JSON.stringify({
@@ -422,11 +429,11 @@ export async function createCollection(
 
 /** Delete every collection via the API. */
 export async function deleteAllCollections(): Promise<void> {
-  const res = await fetch(`${API_URL}/collections`, { headers: authHeaders() });
+  const res = await fetch(`${API_URL}/v1/collections`, { headers: authHeaders() });
   if (!res.ok) return;
   const data = await res.json();
   for (const c of data.collections || []) {
-    await fetch(`${API_URL}/collections/${c.id}`, {
+    await fetch(`${API_URL}/v1/collections/${c.id}`, {
       method: "DELETE",
       headers: authHeaders(),
     });
@@ -486,12 +493,12 @@ export async function configureMockCloud(notesWide: number, notesTall: number): 
  * would keep the Note tab alive (issue #943 semantics).
  */
 export async function deletePagesByDevice(deviceType: string): Promise<void> {
-  const res = await fetch(`${API_URL}/pages`, { headers: authHeaders() });
+  const res = await fetch(`${API_URL}/v1/pages`, { headers: authHeaders() });
   if (!res.ok) return;
   const data = await res.json();
   for (const p of data.pages) {
     if (p.device_type === deviceType) {
-      await fetch(`${API_URL}/pages/${p.id}`, {
+      await fetch(`${API_URL}/v1/pages/${p.id}`, {
         method: "DELETE",
         headers: authHeaders(),
       });
@@ -501,11 +508,11 @@ export async function deletePagesByDevice(deviceType: string): Promise<void> {
 
 /** Delete every page via the API. */
 export async function deleteAllPages(): Promise<void> {
-  const res = await fetch(`${API_URL}/pages`, { headers: authHeaders() });
+  const res = await fetch(`${API_URL}/v1/pages`, { headers: authHeaders() });
   if (!res.ok) return;
   const data = await res.json();
   for (const p of data.pages) {
-    await fetch(`${API_URL}/pages/${p.id}`, {
+    await fetch(`${API_URL}/v1/pages/${p.id}`, {
       method: "DELETE",
       headers: authHeaders(),
     });
@@ -529,7 +536,7 @@ export async function createSchedule(
   };
   if (boardId != null && boardId !== "") body.board_id = boardId;
   if (opts.enabled === false) body.enabled = false;
-  const res = await fetch(`${API_URL}/schedules`, {
+  const res = await fetch(`${API_URL}/v1/schedules`, {
     method: "POST",
     headers: { "Content-Type": "application/json", ...authHeaders() },
     body: JSON.stringify(body),
@@ -541,7 +548,7 @@ export async function createSchedule(
 
 /** Delete a schedule via the API. */
 export async function deleteSchedule(id: string): Promise<void> {
-  const res = await fetch(`${API_URL}/schedules/${id}`, {
+  const res = await fetch(`${API_URL}/v1/schedules/${id}`, {
     method: "DELETE",
     headers: authHeaders(),
   });
@@ -550,11 +557,11 @@ export async function deleteSchedule(id: string): Promise<void> {
 
 /** Delete every schedule via the API (across all boards). */
 export async function deleteAllSchedules(): Promise<void> {
-  const res = await fetch(`${API_URL}/schedules?board_id=*`, { headers: authHeaders() });
+  const res = await fetch(`${API_URL}/v1/schedules?board_id=*`, { headers: authHeaders() });
   if (!res.ok) return;
   const data = await res.json();
   for (const s of data.schedules) {
-    await fetch(`${API_URL}/schedules/${s.id}`, {
+    await fetch(`${API_URL}/v1/schedules/${s.id}`, {
       method: "DELETE",
       headers: authHeaders(),
     });
@@ -569,38 +576,44 @@ export async function deleteAllSchedules(): Promise<void> {
  * whenever the active page is null *in manual mode*, so a test that needs a
  * genuinely empty active display should enable schedule mode with no matching
  * schedules rather than race the loop's ~15s tick.
+ *
+ * Schedule mode is a per-board setting, so v1 addresses it on the board:
+ * `PUT /schedules/enabled {enabled}` with no board_id meant "the primary
+ * board", which is exactly what the `primary` path segment resolves to.
  */
 export async function setScheduleEnabled(enabled: boolean): Promise<void> {
-  const res = await fetch(`${API_URL}/schedules/enabled`, {
-    method: "PUT",
+  const res = await fetch(`${API_URL}/v1/boards/primary`, {
+    method: "PATCH",
     headers: { "Content-Type": "application/json", ...authHeaders() },
-    body: JSON.stringify({ enabled }),
+    body: JSON.stringify({ schedule_enabled: enabled }),
   });
   if (!res.ok) throw new Error(`setScheduleEnabled(${enabled}) failed: ${res.status}`);
 }
 
-/** Enable a plugin via the API. */
+/** Enable a plugin via the API. `PATCH /v1/plugins/{id}` replaced POST .../enable. */
 export async function enablePlugin(id: string): Promise<void> {
-  const res = await fetch(`${API_URL}/plugins/${id}/enable`, {
-    method: "POST",
-    headers: authHeaders(),
+  const res = await fetch(`${API_URL}/v1/plugins/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify({ enabled: true }),
   });
   if (!res.ok) throw new Error(`enablePlugin failed: ${res.status}`);
 }
 
-/** Disable a plugin via the API. */
+/** Disable a plugin via the API. `PATCH /v1/plugins/{id}` replaced POST .../disable. */
 export async function disablePlugin(id: string): Promise<void> {
-  const res = await fetch(`${API_URL}/plugins/${id}/disable`, {
-    method: "POST",
-    headers: authHeaders(),
+  const res = await fetch(`${API_URL}/v1/plugins/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify({ enabled: false }),
   });
   if (!res.ok) throw new Error(`disablePlugin failed: ${res.status}`);
 }
 
-/** Update plugin configuration via the API. */
+/** Update plugin configuration. `PATCH /v1/plugins/{id}` replaced PUT .../config. */
 export async function updatePluginConfig(id: string, config: Record<string, unknown>): Promise<void> {
-  const res = await fetch(`${API_URL}/plugins/${id}/config`, {
-    method: "PUT",
+  const res = await fetch(`${API_URL}/v1/plugins/${id}`, {
+    method: "PATCH",
     headers: { "Content-Type": "application/json", ...authHeaders() },
     body: JSON.stringify({ config }),
   });

--- a/web/tests/multi-board-schedule.spec.ts
+++ b/web/tests/multi-board-schedule.spec.ts
@@ -65,10 +65,15 @@ test.describe("Multi-Board and Schedule", () => {
 
     const switchEl = page.locator("section, div").filter({ hasText: "Schedule Mode" }).getByRole("switch").first();
     if (await switchEl.isVisible({ timeout: 5_000 }).catch(() => false)) {
-      const apiResponse = page.waitForResponse((r) => r.url().includes("/schedules/enabled") && r.status() === 200);
+      // `PUT /schedules/enabled` is now `PATCH /v1/boards/{board}`.
+      const apiResponse = page.waitForResponse(
+        (r) => r.url().includes("/api/v1/boards/") && r.request().method() === "PATCH" && r.status() === 200,
+      );
       await switchEl.click();
       await apiResponse;
-      const revertResponse = page.waitForResponse((r) => r.url().includes("/schedules/enabled") && r.status() === 200);
+      const revertResponse = page.waitForResponse(
+        (r) => r.url().includes("/api/v1/boards/") && r.request().method() === "PATCH" && r.status() === 200,
+      );
       await switchEl.click();
       await revertResponse;
     }

--- a/web/tests/regression/collections.spec.ts
+++ b/web/tests/regression/collections.spec.ts
@@ -133,7 +133,7 @@ test.describe("regression: collections.list", () => {
     const gate = new Promise<void>((resolve) => {
       release = resolve;
     });
-    await page.route("**/api/collections", async (route) => {
+    await page.route("**/api/v1/collections", async (route) => {
       if (route.request().method() !== "GET") return route.fallback();
       await gate;
       return route.continue();
@@ -311,7 +311,7 @@ test.describe("regression: collections.form", () => {
     const gate = new Promise<void>((resolve) => {
       release = resolve;
     });
-    await page.route("**/api/collections", async (route) => {
+    await page.route("**/api/v1/collections", async (route) => {
       if (route.request().method() !== "POST") return route.continue();
       await gate;
       return route.continue();
@@ -354,7 +354,7 @@ test.describe("regression: collections.form", () => {
     const pageName = `E2E Page ${Date.now()}`;
     await createPage(pageName);
 
-    await page.route("**/api/collections", async (route) => {
+    await page.route("**/api/v1/collections", async (route) => {
       if (route.request().method() !== "POST") return route.continue();
       await route.fulfill({
         status: 500,
@@ -404,7 +404,7 @@ test.describe("regression: collections.form", () => {
     const gate = new Promise<void>((resolve) => {
       release = resolve;
     });
-    await page.route(`**/api/collections/${collection.id}`, async (route) => {
+    await page.route(`**/api/v1/collections/${collection.id}`, async (route) => {
       if (route.request().method() !== "PUT") return route.continue();
       await gate;
       return route.continue();
@@ -443,7 +443,7 @@ test.describe("regression: collections.form", () => {
     const name = `E2E Update Error ${Date.now()}`;
     const collection = await createCollectionApi(name, [pageId], 30);
 
-    await page.route(`**/api/collections/${collection.id}`, async (route) => {
+    await page.route(`**/api/v1/collections/${collection.id}`, async (route) => {
       if (route.request().method() !== "PUT") return route.continue();
       await route.fulfill({
         status: 500,

--- a/web/tests/regression/integrations-installed.spec.ts
+++ b/web/tests/regression/integrations-installed.spec.ts
@@ -316,7 +316,11 @@ test.describe("regression: integrations.installed", () => {
     try {
       // Stall + 500 the disable call so we can observe the optimistic flip
       // and the rollback when the mutation eventually fails.
-      await page.route(`**/api/plugins/${STABLE_PLUGIN_ID}/disable`, async (route) => {
+      // `POST /plugins/{id}/disable` is now `PATCH /v1/plugins/{id}
+      // {enabled: false}`. The body guard keeps this matching only the
+      // disable half, as the /disable path did.
+      await page.route(`**/api/v1/plugins/${STABLE_PLUGIN_ID}`, async (route) => {
+        if (route.request().postDataJSON()?.enabled !== false) return route.continue();
         await new Promise((r) => setTimeout(r, 1200));
         await route.fulfill({
           status: 500,
@@ -355,7 +359,9 @@ test.describe("regression: integrations.installed", () => {
     if (!initiallyEnabled) await enablePlugin(STABLE_PLUGIN_ID);
 
     try {
-      await page.route(`**/api/plugins/${STABLE_PLUGIN_ID}/disable`, async (route) => {
+      // See toggle-pending: disable is now `PATCH /v1/plugins/{id} {enabled: false}`.
+      await page.route(`**/api/v1/plugins/${STABLE_PLUGIN_ID}`, async (route) => {
+        if (route.request().postDataJSON()?.enabled !== false) return route.continue();
         await route.fulfill({
           status: 500,
           body: JSON.stringify({ detail: "toggle failed" }),

--- a/web/tests/regression/integrations-marketplace-detail.spec.ts
+++ b/web/tests/regression/integrations-marketplace-detail.spec.ts
@@ -117,7 +117,7 @@ test.describe("regression: integrations.detail", () => {
   /** UX node: integrations.detail.loading */
   test("integrations.detail.loading — pending detail query keeps body mounted", async ({ page }) => {
     let release: () => void = () => {};
-    await page.route("**/api/plugins/date_time", async (route) => {
+    await page.route("**/api/v1/plugins/date_time", async (route) => {
       if (route.request().method() === "GET") {
         await new Promise<void>((r) => {
           release = r;

--- a/web/tests/regression/integrations-plugin-config.spec.ts
+++ b/web/tests/regression/integrations-plugin-config.spec.ts
@@ -111,8 +111,11 @@ test.describe("regression: integrations.plugin (config sheet + lifecycle)", () =
     await page.goto("/integrations");
     await expect(page.getByRole("heading", { name: /integrations/i })).toBeVisible({ timeout: 15_000 });
 
-    // Throttle the plugin details endpoint so the loading state is observable
-    await page.route(`**/api/plugins/${TEST_PLUGIN_ID}`, async (route) => {
+    // Throttle the plugin details endpoint so the loading state is observable.
+    // `GET /v1/plugins/{id}` shares its URL with the write PATCH, so guard on
+    // the method to keep this the read-only throttle it always was.
+    await page.route(`**/api/v1/plugins/${TEST_PLUGIN_ID}`, async (route) => {
+      if (route.request().method() !== "GET") return route.continue();
       await new Promise((r) => setTimeout(r, 1500));
       await route.continue();
     });
@@ -144,8 +147,11 @@ test.describe("regression: integrations.plugin (config sheet + lifecycle)", () =
     await page.goto("/integrations");
     await expect(page.getByRole("heading", { name: /integrations/i })).toBeVisible({ timeout: 15_000 });
 
-    // Intercept plugin details and return a payload with no settings_schema and no variables
-    await page.route(`**/api/plugins/${TEST_PLUGIN_ID}`, async (route) => {
+    // Intercept plugin details and return a payload with no settings_schema and
+    // no variables. Method-guarded: `GET /v1/plugins/{id}` now shares its URL
+    // with the write PATCH.
+    await page.route(`**/api/v1/plugins/${TEST_PLUGIN_ID}`, async (route) => {
+      if (route.request().method() !== "GET") return route.continue();
       const response = await route.fetch();
       const data = await response.json();
       // Wipe everything that would render config UI
@@ -182,9 +188,12 @@ test.describe("regression: integrations.plugin (config sheet + lifecycle)", () =
     await expect(saveBtn).toBeVisible({ timeout: 15_000 });
     await expect(saveBtn).toBeEnabled({ timeout: 15_000 });
 
-    // Throttle PUT /plugins/{id}/config to make Saving... observable
-    await page.route(`**/api/plugins/${TEST_PLUGIN_ID}/config`, async (route) => {
-      if (route.request().method() === "PUT") {
+    // Throttle the config write to make Saving... observable. `PUT
+    // /plugins/{id}/config` is now `PATCH /v1/plugins/{id} {config}`, which
+    // shares its URL with the detail GET and the enable/disable PATCH — hence
+    // the method + body-key guard.
+    await page.route(`**/api/v1/plugins/${TEST_PLUGIN_ID}`, async (route) => {
+      if (route.request().method() === "PATCH" && "config" in (route.request().postDataJSON() ?? {})) {
         await new Promise((r) => setTimeout(r, 1200));
       }
       await route.continue();

--- a/web/tests/regression/pages-edit.spec.ts
+++ b/web/tests/regression/pages-edit.spec.ts
@@ -99,7 +99,7 @@ test.describe("regression: pages.edit", () => {
   test("pages.edit.saving — Save click shows pending state", async ({ page }) => {
     const id = await createPage("Saving Test", ["A", "", "", "", "", ""]);
     let release: () => void = () => {};
-    await page.route(`**/api/pages/${id}`, async (route) => {
+    await page.route(`**/api/v1/pages/${id}`, async (route) => {
       if (route.request().method() === "PUT") {
         await new Promise<void>((r) => {
           release = r;
@@ -119,7 +119,7 @@ test.describe("regression: pages.edit", () => {
   /** UX node: pages.edit.save-error */
   test("pages.edit.save-error — failed save surfaces toast and keeps dirty state", async ({ page }) => {
     const id = await createPage("Save Err", ["A", "", "", "", "", ""]);
-    await page.route(`**/api/pages/${id}`, (route) => {
+    await page.route(`**/api/v1/pages/${id}`, (route) => {
       if (route.request().method() === "PUT") {
         return route.fulfill({ status: 500, body: '{"detail":"boom"}' });
       }
@@ -167,7 +167,7 @@ test.describe("regression: pages.edit", () => {
   /** UX node: pages.edit.delete-error */
   test("pages.edit.delete-error — failed delete surfaces toast and keeps editor", async ({ page }) => {
     const id = await createPage("Delete Err", ["A", "", "", "", "", ""]);
-    await page.route(`**/api/pages/${id}`, (route) => {
+    await page.route(`**/api/v1/pages/${id}`, (route) => {
       if (route.request().method() === "DELETE") {
         return route.fulfill({ status: 500, body: '{"detail":"boom"}' });
       }
@@ -195,7 +195,7 @@ test.describe("regression: pages.edit", () => {
   test("pages.edit.loading — page query in-flight shows skeleton", async ({ page }) => {
     const id = await createPage("Loading Test", ["A", "", "", "", "", ""]);
     let release: () => void = () => {};
-    await page.route(`**/api/pages/${id}`, async (route) => {
+    await page.route(`**/api/v1/pages/${id}`, async (route) => {
       if (route.request().method() === "GET") {
         await new Promise<void>((r) => {
           release = r;

--- a/web/tests/regression/pages-list.spec.ts
+++ b/web/tests/regression/pages-list.spec.ts
@@ -64,7 +64,7 @@ test.describe("regression: pages.list", () => {
   test("pages.list.empty — empty pages payload renders the list surface", async ({ page }) => {
     // Mock /pages to empty so the empty state is observed without flake from
     // stray pages left by other parallel workers.
-    await page.route("**/api/pages", (route) => {
+    await page.route("**/api/v1/pages", (route) => {
       if (route.request().method() !== "GET") return route.continue();
       return route.fulfill({
         status: 200,
@@ -83,7 +83,7 @@ test.describe("regression: pages.list", () => {
     page,
   }) => {
     let release: () => void = () => {};
-    await page.route("**/api/pages", async (route) => {
+    await page.route("**/api/v1/pages", async (route) => {
       if (route.request().method() === "GET") {
         await new Promise<void>((r) => {
           release = r;
@@ -104,7 +104,7 @@ test.describe("regression: pages.list", () => {
       localStorage.setItem("fiestaboard_pages_view_mode", "grid");
     });
     let release: () => void = () => {};
-    await page.route("**/api/pages", async (route) => {
+    await page.route("**/api/v1/pages", async (route) => {
       if (route.request().method() === "GET") {
         await new Promise<void>((r) => {
           release = r;
@@ -124,7 +124,7 @@ test.describe("regression: pages.list", () => {
       localStorage.setItem("fiestaboard_pages_view_mode", "list");
     });
     let release: () => void = () => {};
-    await page.route("**/api/pages", async (route) => {
+    await page.route("**/api/v1/pages", async (route) => {
       if (route.request().method() === "GET") {
         await new Promise<void>((r) => {
           release = r;

--- a/web/tests/regression/schedule-calendar.spec.ts
+++ b/web/tests/regression/schedule-calendar.spec.ts
@@ -173,7 +173,7 @@ test.describe("regression: schedule.calendar", () => {
       localStorage.setItem("schedule-view-mode", "calendar");
     });
     let mutationCalled = false;
-    await page.route("**/api/schedules/*", async (route) => {
+    await page.route("**/api/v1/schedules/*", async (route) => {
       if (route.request().method() === "PUT") {
         mutationCalled = true;
       }
@@ -203,7 +203,7 @@ test.describe("regression: schedule.calendar", () => {
     await page.addInitScript(() => {
       localStorage.setItem("schedule-view-mode", "calendar");
     });
-    await page.route("**/api/schedules/*", (route) => {
+    await page.route("**/api/v1/schedules/*", (route) => {
       if (route.request().method() === "PUT") {
         return route.fulfill({ status: 500, body: '{"detail":"boom"}' });
       }

--- a/web/tests/regression/schedule-delete-confirm.spec.ts
+++ b/web/tests/regression/schedule-delete-confirm.spec.ts
@@ -76,7 +76,7 @@ test.describe("regression: schedule.delete-confirm", () => {
   /** UX node: schedule.delete-confirm.delete-error */
   test("schedule.delete-confirm.delete-error — failed delete keeps editor reachable", async ({ page }) => {
     await seedScheduleAndOpen(page);
-    await page.route("**/api/schedules/*", (route) => {
+    await page.route("**/api/v1/schedules/*", (route) => {
       if (route.request().method() === "DELETE") {
         return route.fulfill({ status: 500, body: '{"detail":"boom"}' });
       }

--- a/web/tests/regression/schedule-form.spec.ts
+++ b/web/tests/regression/schedule-form.spec.ts
@@ -216,7 +216,7 @@ test.describe("regression: schedule.form", () => {
 
     // Capture the create payload to assert end_time: null on the wire.
     const createResponse = page.waitForResponse(
-      (r) => r.url().endsWith("/api/schedules") && r.request().method() === "POST",
+      (r) => r.url().endsWith("/api/v1/schedules") && r.request().method() === "POST",
     );
     await sheet.getByRole("button", { name: "Create Schedule" }).click();
     const resp = await createResponse;
@@ -328,7 +328,7 @@ test.describe("regression: schedule.form", () => {
    */
   test("schedule.form.create-error — failed create keeps sheet open and toasts", async ({ page }) => {
     const pageId = await createPage("Sched Err", ["A", "", "", "", "", ""]);
-    await page.route("**/api/schedules", (route) => {
+    await page.route("**/api/v1/schedules", (route) => {
       if (route.request().method() === "POST") {
         return route.fulfill({ status: 422, body: '{"detail":"overlap"}' });
       }
@@ -365,7 +365,7 @@ test.describe("regression: schedule.form", () => {
   test("schedule.form.update-error — failed update keeps sheet open", async ({ page }) => {
     const pageId = await createPage("Update Err Page");
     const schedId = await createSchedule(pageId, "09:00", "10:00", "weekdays");
-    await page.route(`**/api/schedules/${schedId}`, (route) => {
+    await page.route(`**/api/v1/schedules/${schedId}`, (route) => {
       if (route.request().method() === "PUT") {
         return route.fulfill({ status: 500, body: '{"detail":"boom"}' });
       }
@@ -467,7 +467,7 @@ test.describe("regression: schedule.form", () => {
   test("schedule.form.creating — Create button shows pending state", async ({ page }) => {
     const pageId = await createPage("Sched Pending", ["A", "", "", "", "", ""]);
     let release: () => void = () => {};
-    await page.route("**/api/schedules", async (route) => {
+    await page.route("**/api/v1/schedules", async (route) => {
       if (route.request().method() === "POST") {
         await new Promise<void>((r) => {
           release = r;
@@ -507,7 +507,7 @@ test.describe("regression: schedule.form", () => {
   test("schedule.form.updating — Update button shows pending state", async ({ page }) => {
     const pageId = await createPage("Updating Page");
     const schedId = await createSchedule(pageId, "09:00", "10:00", "weekdays");
-    const release = await slowRoute(page, `**/api/schedules/${schedId}`, ["PUT"]);
+    const release = await slowRoute(page, `**/api/v1/schedules/${schedId}`, ["PUT"]);
     await page.goto("/schedule");
     await page
       .getByRole("button", { name: /Edit schedule/i })

--- a/web/tests/regression/schedule-list.spec.ts
+++ b/web/tests/regression/schedule-list.spec.ts
@@ -32,7 +32,7 @@ test.describe("regression: schedule.list", () => {
   /** UX node: schedule.list.loading */
   test("schedule.list.loading — pending query shows skeleton", async ({ page }) => {
     let release: () => void = () => {};
-    await page.route("**/api/schedules*", async (route) => {
+    await page.route("**/api/v1/schedules*", async (route) => {
       if (route.request().method() === "GET") {
         await new Promise<void>((r) => {
           release = r;
@@ -82,7 +82,7 @@ test.describe("regression: schedule.list", () => {
     page,
   }) => {
     // Mock /schedules to inject a synthetic row whose page_id resolves to a collection.
-    await page.route("**/api/schedules*", (route) => {
+    await page.route("**/api/v1/schedules*", (route) => {
       if (route.request().method() !== "GET") return route.continue();
       return route.fulfill({
         status: 200,
@@ -102,7 +102,7 @@ test.describe("regression: schedule.list", () => {
         }),
       });
     });
-    await page.route("**/api/collections", (route) => {
+    await page.route("**/api/v1/collections", (route) => {
       if (route.request().method() !== "GET") return route.continue();
       return route.fulfill({
         status: 200,
@@ -119,7 +119,7 @@ test.describe("regression: schedule.list", () => {
 
   /** UX node: schedule.list.row-sun-schedule */
   test("schedule.list.row-sun-schedule — sun-based schedule rows render via mocked payload", async ({ page }) => {
-    await page.route("**/api/schedules*", (route) => {
+    await page.route("**/api/v1/schedules*", (route) => {
       if (route.request().method() !== "GET") return route.continue();
       return route.fulfill({
         status: 200,

--- a/web/tests/regression/schedule-toolbar.spec.ts
+++ b/web/tests/regression/schedule-toolbar.spec.ts
@@ -45,8 +45,11 @@ test.describe("regression: schedule.toolbar", () => {
   /** UX node: schedule.toolbar.toggle-pending */
   test("schedule.toolbar.toggle-pending — pending toggle disables switch", async ({ page }) => {
     let release: () => void = () => {};
-    await page.route("**/api/schedules/enabled", async (route) => {
-      if (route.request().method() === "PUT") {
+    // `PUT /schedules/enabled` is now `PATCH /v1/boards/{board} {schedule_enabled}`.
+    // The board PATCH also carries the default-page write, so match on the
+    // body key — otherwise this would stall a mutation it never used to.
+    await page.route("**/api/v1/boards/*", async (route) => {
+      if (route.request().method() === "PATCH" && "schedule_enabled" in (route.request().postDataJSON() ?? {})) {
         await new Promise<void>((r) => {
           release = r;
         });
@@ -61,8 +64,10 @@ test.describe("regression: schedule.toolbar", () => {
 
   /** UX node: schedule.toolbar.toggle-error */
   test("schedule.toolbar.toggle-error — failed toggle surfaces error toast", async ({ page }) => {
-    await page.route("**/api/schedules/enabled", (route) => {
-      if (route.request().method() === "PUT") {
+    // See the toggle-pending note: the schedule switch now writes
+    // `PATCH /v1/boards/{board} {schedule_enabled}`.
+    await page.route("**/api/v1/boards/*", (route) => {
+      if (route.request().method() === "PATCH" && "schedule_enabled" in (route.request().postDataJSON() ?? {})) {
         return route.fulfill({ status: 500, body: '{"detail":"boom"}' });
       }
       return route.continue();
@@ -109,8 +114,11 @@ test.describe("regression: schedule.toolbar", () => {
 
   /** UX node: schedule.toolbar.default-page-error */
   test("schedule.toolbar.default-page-error — failed set-default toasts error", async ({ page }) => {
-    await page.route("**/api/schedules/default-page", (route) => {
-      if (route.request().method() === "PUT") {
+    // `PUT /schedules/default-page` is now `PATCH /v1/boards/{board}
+    // {default_page_id}` — same board PATCH as the schedule toggle, so the
+    // body key is what keeps this aimed at the set-default call.
+    await page.route("**/api/v1/boards/*", (route) => {
+      if (route.request().method() === "PATCH" && "default_page_id" in (route.request().postDataJSON() ?? {})) {
         return route.fulfill({ status: 500, body: '{"detail":"boom"}' });
       }
       return route.continue();

--- a/web/tests/schedule-management.spec.ts
+++ b/web/tests/schedule-management.spec.ts
@@ -41,13 +41,17 @@ test.describe("Schedule Management", () => {
     const toggleEl = page.getByTestId("schedule-enabled-toggle");
     await expect(toggleEl).toBeVisible({ timeout: 10_000 });
 
-    // Toggle on
-    const apiResponse = page.waitForResponse((r) => r.url().includes("/schedules/enabled") && r.status() === 200);
+    // Toggle on. `PUT /schedules/enabled` is now `PATCH /v1/boards/{board}`.
+    const apiResponse = page.waitForResponse(
+      (r) => r.url().includes("/api/v1/boards/") && r.request().method() === "PATCH" && r.status() === 200,
+    );
     await toggleEl.click();
     await apiResponse;
 
     // Toggle back off
-    const revertResponse = page.waitForResponse((r) => r.url().includes("/schedules/enabled") && r.status() === 200);
+    const revertResponse = page.waitForResponse(
+      (r) => r.url().includes("/api/v1/boards/") && r.request().method() === "PATCH" && r.status() === 200,
+    );
     await toggleEl.click();
     await revertResponse;
   });


### PR DESCRIPTION
## What this is

`/v1` has **31 operations** covering boards, pages, schedules, collections, plugins, templating and service health. The web client called **175 distinct endpoints**, because it also does appliance administration — settings, config, auth, debug, network, panels, backup, mqtt, system — which v1 deliberately does not cover and should not.

So this is not "migrate the web UI to v1". It is: **for every web-client call that `/v1` supersedes, move it to `/v1`; leave the rest on the internal endpoints, with a stated reason.**

| | Before | After |
|---|---|---|
| Distinct endpoints called by `web/src/lib/api/` | **175** | **161** |
| …on `/v1` | 0 | **19** |
| …on the internal surface | 175 | **142** |
| Wrapper methods | 179 | 169 |
| Internal endpoints removed | — | **33** |
| Dead wrappers deleted instead of migrated | — | **10** |

Vitest: **1626 → 1612 passing, 0 failures** (14 tests removed with the dead wrappers they were the only caller of). `typecheck`, `eslint`, `prettier --check` clean. Python untouched — **6780 passing** (the one failure, `test_no_tracked_file_in_this_repo_reaches_a_vulnerable_parser`, is `git ls-files` failing inside the container because a worktree's `.git` is a file pointing outside the mount; it fails identically on unmodified `next`).

---

## 1. The inventory

**Wave 3 deletes exactly the "→ /v1" column.** Everything marked *internal* must survive.

### Superseded — moved to `/v1` (33 endpoints → 19)

| Internal endpoint | → `/v1` | Exactness |
|---|---|---|
| `GET /pages` | `GET /v1/pages` | v1 calls `pages_routes.list_pages()` — same handler, same `PageListResponse` |
| `POST /pages` | `POST /v1/pages` | same handler, 201 + bare `Page` |
| `GET /pages/{id}` | `GET /v1/pages/{id}` | same handler, same `Page` |
| `PUT /pages/{id}` | `PUT /v1/pages/{id}` | same handler, same `PageUpdateResponse` (incl. `incompatible_references`) |
| `DELETE /pages/{id}` | `DELETE /v1/pages/{id}` | same handler, same `PageDeleteResponse` |
| `POST /pages/{id}/send` | `POST /v1/boards/{b}/message` `{page_id}` | **wrapper was dead — deleted, not migrated.** See §3 for the E2E caveat |
| `GET /schedules` | `GET /v1/schedules` | same handler; `board_id` passes through, incl. `*` |
| `POST /schedules` | `POST /v1/schedules` | same handler, same `ScheduleWriteResponse` (incl. #1245 `warnings`) |
| `GET /schedules/{id}` | `GET /v1/schedules/{id}` | **dead wrapper — deleted** |
| `PUT /schedules/{id}` | `PUT /v1/schedules/{id}` | same handler, incl. sun-time enrichment |
| `DELETE /schedules/{id}` | `DELETE /v1/schedules/{id}` | same handler |
| `GET /schedules/enabled` | `GET /v1/boards/{b}` → `.schedule_enabled` | **dead wrapper — deleted** |
| `PUT /schedules/enabled` | `PATCH /v1/boards/{b}` `{schedule_enabled}` | same `SettingsService.set_schedule_enabled`; body widens to `BoardDetail`, no caller read the old one |
| `GET /schedules/default-page` | `GET /v1/boards/{b}` → `.default_page_id` | **dead wrapper — deleted** |
| `PUT /schedules/default-page` | `PATCH /v1/boards/{b}` `{default_page_id}` | same `ScheduleService.set_default_page` + same page-exists 404 |
| `GET /collections` | `GET /v1/collections` | same handler |
| `POST /collections` | `POST /v1/collections` | same handler, 201 + bare `Collection` |
| `GET /collections/{id}` | `GET /v1/collections/{id}` | **dead wrapper — deleted** |
| `PUT /collections/{id}` | `PUT /v1/collections/{id}` | same handler |
| `DELETE /collections/{id}` | `DELETE /v1/collections/{id}` | same handler |
| `GET /plugins/{id}` | `GET /v1/plugins/{id}` | same handler, same `PluginDetail`, same `***` masking |
| `PUT /plugins/{id}/config` | `PATCH /v1/plugins/{id}` `{config}` | v1 dispatches to the same handler; answers `PluginDetail` instead of `{plugin_id, config}` |
| `POST /plugins/{id}/enable` | `PATCH /v1/plugins/{id}` `{enabled: true}` | same handler; answers `PluginDetail` |
| `POST /plugins/{id}/disable` | `PATCH /v1/plugins/{id}` `{enabled: false}` | same handler; answers `PluginDetail` |
| `GET /plugins/{id}/data` | `GET /v1/plugins/{id}/data` | **dead wrapper — deleted** |
| `GET /plugins/variables/all` | `GET /v1/variables` | **dead wrapper — deleted** (v1 merges it into the catalogue) |
| `GET /displays` | `GET /v1/plugins` | **dead wrapper — deleted** |
| `GET /displays/{type}` | `GET /v1/plugins/{id}/data` → `.lines` | **dead wrapper — deleted** |
| `POST /displays/{type}/send` | `POST /v1/boards/{b}/message` | **dead wrapper — deleted** |
| `POST /settings/board/{id}/pause` | `PATCH /v1/boards/{b}` `{paused}` | same `SettingsService.set_paused`; body widens to `BoardDetail`, the one consumer only invalidates |
| `GET /templates/variables` | `GET /v1/variables` | **provable superset** — v1 folds in `/plugins/variables/all`, and both sides read the same `registry.get_all_variables()` (`TemplateEngine.get_available_variables` forwards to it), so the merge adds nothing to `variables`/`max_lengths`; v1 adds `plugin_system_enabled` |
| `GET /templates/formula-functions` | `GET /v1/functions` | same handler, same `FormulaFunctionsResponse` |
| `GET /status` | `GET /v1/status` | same `service_routes.get_status()`, same `StatusResponse` |

### Internal — v1 has no equivalent, and that is correct (142)

**These are the endpoints Wave 3 must NOT delete.**

<details>
<summary><b>Boards, panels and board content (24)</b> — v1's board view is a consumer projection, not the appliance's board record</summary>

| Endpoint | Why it stays |
|---|---|
| `GET /board/current-message` | v1's `BoardDetail` drops `expected_characters` and `api_mode`. `active-page-display.tsx:522` diffs `characters` against `expected_characters` to render the out-of-sync alert — **v1 gap** |
| `GET /settings/active-page` | v1 has `active_page_id` but drops `resolved_next_check_seconds`, which `use-board.ts:80` uses as the collection re-poll cadence (#1513) — **v1 gap** |
| `PUT /settings/active-page` | v1's `ActivePageResponse` drops `error` and `paused`. `active-page-display.tsx:403` branches on `result.error` for the #1791 "persisted but never reached the board" case — **v1 gap** |
| `GET /schedules/active/page` | v1 merges the page ids but drops `current_time`, `current_day`, `resolved_next_check_seconds` and the whole `temporary_override` object — **v1 gap** |
| `GET /settings/board` | v1's `BoardSummary` deliberately drops credentials, `tiles`, `board_color`, `code62_glyph`, `notes_wide/tall`, `api_mode`, `host`, `port`. Settings needs all of them. Correctly internal |
| `PUT /settings/board`, `POST /settings/board/add`, `DELETE /settings/board/{id}` | fleet administration; v1 has no board create/delete by design |
| `POST /settings/board/{id}/detect-size`, `.../identify` | hardware probing over the board's own transport |
| `GET /panels`, `POST /panels`, `PATCH /panels/{id}`, `DELETE /panels/{id}` | FiestaPanel administration |
| `GET /panel/{id}`, `GET /panel/{id}/frame` | public TV-viewer endpoints (no session); v1 is auth-gated |
| `GET /settings/hdmi-kiosk`, `POST /settings/hdmi-kiosk` | FiestaPi kiosk control |
| `POST /debug/blank`, `POST /debug/fill` | v1's `DELETE`/`POST .../message` covers the action, but these are the Debug page's install-wide controls with no board argument; retargeting them is a UX change, not a client migration. Flagged for a follow-up |
| `POST /force-refresh`, `POST /send-welcome-message` | appliance actions |
| `GET /silence-status`, `PUT /settings/silence-schedule` | silence/quiet-hours feature; not in v1 |
| `GET/POST/DELETE /settings/temporary-override` | timed-override lifecycle; v1 expresses only the *set* half, via `message.duration_minutes`, and answers a different shape |
| `POST /schedules/validate` | overlap/gap analysis; not in v1 |

</details>

<details>
<summary><b>Plugins beyond the v1 five (18)</b> — install/update/instances/options are appliance management</summary>

| Endpoint | Why it stays |
|---|---|
| `GET /plugins` | v1's `PluginEntry` drops `update_available`, `update_blocked_reason`, `source`, `settings_schema`, `config`, `instance_label`, `base_plugin_id`, `supports_triggers`, `fiestaboard_version` and `plugin_system_enabled`. The Integrations page reads most of them — **v1 gap** |
| `GET /displays/{type}/raw`, `POST /displays/raw/batch` | `/v1/plugins/{id}/data` raises **400/503** for a disabled or unavailable plugin, where the display read answers **200 with `available: false`** — which is what Integrations renders. v1 also has no batch form; the variable picker fetches N plugins in one call — **v1 gap, ×2** |
| `GET /plugins/{id}/manifest` | manifest is not on the v1 detail |
| `GET/POST /plugins/{id}/demo-page` | demo-page lifecycle |
| `POST /plugins/{id}/options/{optionsId}` | remote-options fields (cursor/paging) |
| `GET /plugins/{id}/variables`, `GET /plugins/errors` | per-plugin variables + load/breaker diagnostics |
| `GET/POST /plugins/{id}/instances`, `DELETE /plugins/{id}/instances/{label}` | multi-instance plugins |
| `GET /plugins/registry`, `POST /plugins/registry/{id}/install`, `POST /plugins/install`, `DELETE /plugins/{id}/uninstall`, `POST /plugins/{id}/update`, `GET /plugins/updates`, `POST /plugins/updates/check`, `POST /plugins/updates/apply` | plugin marketplace + updater |
| `GET /settings/plugins`, `PUT /settings/plugins` | plugin-subsystem settings |

</details>

<details>
<summary><b>Pages beyond CRUD (7)</b></summary>

| Endpoint | Why it stays |
|---|---|
| `GET /pages/current-display` | "what is on the board right now, as a page"; not in v1 |
| `POST /pages/{id}/preview`, `POST /pages/preview/batch` | render-without-send; v1's `/render` takes a template, not a page id, and has no batch form |
| `GET /pages/{id}/share`, `POST /pages/import` | share-string encode/decode |
| `GET /staff-picks`, `GET /staff-picks/{id}/share` | curated catalogue |

</details>

<details>
<summary><b>Templating beyond the v1 three (4)</b></summary>

| Endpoint | Why it stays |
|---|---|
| `POST /templates/render` | v1's `/v1/render` derives `device_type` from a `board` query param. The page builder renders for the **page's** device type (`page-builder.tsx:1176`, `compose-page-dialog.tsx:113`, `inline-board-preview.tsx:48`), which need not match any configured board — **v1 gap: `/v1/render` cannot render for an arbitrary geometry** |
| `POST /templates/render/live` | renders *and* sends, returning `rendered`/`lines`/`line_count` plus `sent_to_board`; v1's message returns `characters`/`text` and no line breakdown |
| `POST /templates/validate` | syntax errors with line/column; not in v1 |
| `GET /home-assistant/entities` | Home Assistant entity catalogue |

</details>

<details>
<summary><b>Settings (35), config (11), auth (9), debug (8), network (7), system (8), backup (2), mqtt (2), AI (5), plugin helper endpoints (11)</b> — appliance administration, correctly absent from v1</summary>

`GET/PUT /settings/{transitions,output,display,location,beta,polling,mqtt,ai,plugins}`, `GET /settings/all`, `GET /settings/location/sun-times`, `GET /settings/location/sun-times-week`, `POST /settings/ai/test` · `GET /config`, `GET /config/full`, `GET/PUT /config/board`, `GET /config/validate`, `GET/PUT /config/general`, `POST /config/board/{test,scan,enable-local-api}` · `GET /auth/status`, `POST /auth/{logout,change-password,change-username,preference,disable}`, `GET/POST/DELETE /auth/mcp-token` · `POST /debug/{blank,fill,info,clear-cache,test-connection}`, `GET /debug/{cache-status,system-info,network-diagnostics}` · `GET /network/wifi/{capability,status,saved}`, `POST /network/wifi/{scan,connect,disconnect}`, `DELETE /network/wifi/saved/{con}` · `GET /version`, `POST /start`, `POST /stop`, `GET /system/update-check`, `GET /system/update/status`, `POST /system/update`, `POST /system/update/auto`, `POST /system/restart`, `POST /system/shutdown` · `GET /backup/export`, `POST /backup/import` · `GET /mqtt/status` · `POST /ai/operations`, `POST /pages/ai/generate` · `GET /transitions/plugins`, `POST /transitions/{preview,test-live,restore}` · `GET /baywheels/stations{,/nearby,/search}`, `GET /muni/stops{,/nearby,/search}`, `GET /stocks/search`, `POST /stocks/validate`, `POST /traffic/routes/{geocode,validate}`, `POST /generic-data/test-fetch`

`GET /health` is called directly from `boot-gate.tsx` (not through the client) and **must stay**: `/health` is in `_PUBLIC_EXACT` in `src/auth/middleware.py`, `/v1/health` is not — see the gaps below.

</details>

---

## 2. Dead wrappers deleted instead of migrated — 10

Measured: **41 of 179** methods in `web/src/lib/api/` had no product caller. Ten of them are in the superseded column, so they were deleted with their tests rather than repointed:

`pagesApi.sendPage` · `collectionsApi.getCollection` · `schedulesApi.getSchedule` · `schedulesApi.getDefaultPage` · `schedulesApi.getScheduleEnabled` · `pluginsApi.getPluginData` · `pluginsApi.getAllPluginVariables` · `miscApi.getDisplays` · `miscApi.getDisplay` · `miscApi.sendDisplay`

Their now-orphaned response types went with them (`PageSendResponse`, `DefaultPageResponse`, `ScheduleEnabledResponse`, `PluginDataResponse`, `AllPluginVariablesResponse`, `PluginConfigUpdateResponse`, `PluginEnableResponse`, `DisplaysResponse`, `DisplayInfo`, `DisplayResponse`, `DisplaySendResponse`), plus 14 tests and the msw handlers that existed only for them.

**The other 31 dead wrappers were left alone** — they are on the internal surface (config aliases, Bay Wheels / Muni / stocks / traffic helper endpoints, `startService`/`stopService`, `getFullConfig`, `validateConfig`, …), so deleting them is not this slice's call. Listing them here so Wave 3 has it: `generateAiPage`, `getFullConfig`, `getFiestaboardConfig`, `updateFiestaboardConfig`, `validateConfig`, `listBayWheelsStations`, `findNearbyBayWheelsStations`, `searchBayWheelsStationsByAddress`, `listMuniStops`, `findNearbyMuniStops`, `searchMuniStopsByAddress`, `geocodeAddress`, `validateTrafficRoute`, `searchStockSymbols`, `validateStockSymbol`, `getPluginUpdates`, `getPluginVariables`, `getPluginDemoPage`, `getPluginErrors`, `listPluginInstances`, `getTemporaryOverride`, `getTransitionSettings`, `getOutputSettings`, `updateOutputSettings`, `getGeneralConfig`, `getPollingSettings`, `getDisplaySettings`, `startService`, `stopService`, `setAutoUpdate`, `testDebugConnection`.

---

## 3. The E2E interceptor sweep

Two halves, both of which had to move.

**`web/tests/helpers.ts`** — imported by every spec, named after no domain, would not show up in a grep of the specs. Eleven fleet-setup fixtures called endpoints in the superseded column; all eleven moved:

`createPage`, `deletePage`, `deletePagesByDevice`, `deleteAllPages` → `/v1/pages` · `createCollection`, `deleteAllCollections` → `/v1/collections` · `createSchedule`, `deleteSchedule`, `deleteAllSchedules` → `/v1/schedules` (incl. `?board_id=*`) · `setScheduleEnabled` → `PATCH /v1/boards/primary {schedule_enabled}` · `enablePlugin`, `disablePlugin`, `updatePluginConfig` → `PATCH /v1/plugins/{id}`.

The bodies these read (`data.id`, `data.pages`, `data.collections`, `data.schedules`) are byte-identical on v1 because `/v1` delegates to the same handlers; no envelope reads were involved. The two that *did* change shape discard the response and only check `res.ok`.

**Route interceptors** (the first E2E round's failures). The loading-state specs `page.route()` an endpoint, stall the response, and assert a skeleton or spinner. Once the client moved to `/v1` the interceptor stopped matching, nothing was delayed, and the pending state never rendered.

Playwright globs are fully anchored — `globToRegexPattern` in the bundled playwright-core emits `^…$`, so `**/api/collections` compiles to `^(.*/)api/collections$`. Verified empirically against the installed copy: it never matched `/api/collections/{id}` and does not match `/api/v1/collections` either. That makes most of the fix a straight `api/` → `api/v1/` substitution with **no change of scope**:

| Spec | Pattern | × |
|---|---|---|
| `collections.spec.ts` | `**/api/collections{,/{id}}` | 5 |
| `pages-list.spec.ts` | `**/api/pages` | 4 |
| `pages-edit.spec.ts` | `**/api/pages/{id}` | 4 |
| `schedule-list.spec.ts` | `**/api/schedules*`, `**/api/collections` | 4 |
| `schedule-form.spec.ts` | `**/api/schedules{,/{id}}` + a `waitForResponse` | 5 |
| `schedule-calendar.spec.ts` | `**/api/schedules/*` | 2 |
| `schedule-delete-confirm.spec.ts` | `**/api/schedules/*` | 1 |
| `integrations-marketplace-detail.spec.ts` | `**/api/plugins/date_time` | 1 |
| `helpers.ts` | `slowRoute` JSDoc example | 1 |

Four sites needed more than a path change, because the endpoint itself collapsed. Each keeps its original aim with a **body-key guard** rather than widening to the whole board/plugin `PATCH` — otherwise the assertion would start passing for the wrong reason:

- `PUT /schedules/enabled` and `PUT /schedules/default-page` are both now `PATCH /v1/boards/{board}`, so the toolbar specs discriminate on `schedule_enabled` vs `default_page_id`.
- `PUT /plugins/{id}/config` is now `PATCH /v1/plugins/{id}`, which shares its URL with the detail `GET` and with enable/disable — so the saving spec guards on method + `config`, and the two detail-`GET` throttles gained a `method() === "GET"` guard they did not previously need.
- `POST /plugins/{id}/disable` is now `PATCH /v1/plugins/{id}`, so the toggle specs guard on `enabled === false`.
- The schedule-mode `waitForResponse` in `schedule-management` and `multi-board-schedule` waited on `/schedules/enabled`; it now waits on a `PATCH` to `/api/v1/boards/`.

**Left alone deliberately**: every interceptor on a path this PR did not migrate — `**/api/plugins` (the list; v1's projection drops fields the Integrations page needs), `**/api/displays/{id}/raw`, `**/api/board/current-message`, `**/api/pages/import`, `**/api/pages/{id}/share`, `/staff-picks`, `/config/*`, `/settings/*`, `/auth/*`, `/network/*`, `/system/*`, and the `/api/plugins(\?.*)?$` regex. A checker over every matcher in `web/tests/` reports **0** remaining interceptors on a migrated path.

**Still left for Wave 3 (not this slice):** ~200 inline `fetch()` fixtures across ~40 specs still target internal paths, and several — `tests/api.spec.ts`, `tests/api-extended.spec.ts`, `tests/error-handling.spec.ts`, `tests/board-send-path.spec.ts` — are *deliberately* the internal surface's contract tests. Retargeting or retiring those is a decision, not a mechanical sweep, and it belongs with the deletion PR that forces it.

---

## 4. Gaps found in `/v1`

Every one of these is a call I did **not** migrate, because v1's version is not exact.

1. **`GET /v1/boards/{b}` drops `expected_characters`.** The dashboard's "board is out of sync" alert diffs it against `characters` (`active-page-display.tsx:522`). Without it that alert cannot exist.
2. **`GET /v1/boards/{b}` drops `resolved_next_check_seconds`.** `use-board.ts:80` uses it as the collection re-poll interval (#1513); the fixed-timer fallback re-introduces the bug it fixed.
3. **`PUT /v1/boards/{b}/active-page` drops `error`.** #1791 added it precisely so a 200 that never reached the board is distinguishable; v1's `ActivePageResponse` has `sent` but no reason. It also drops `paused`.
4. **`GET /v1/boards/{b}` drops the `temporary_override` block** that `GET /schedules/active/page` carries, plus `current_time`/`current_day`.
5. **`POST /v1/render` cannot render for an arbitrary device type.** It takes `board` and resolves the geometry from that board. The page builder renders for the *page's* device type, which need not match any board on the install.
6. **`GET /v1/plugins/{id}/data` can never return `available: false`.** The model documents `available` and `error`, but the handler it delegates to (`plugins_routes.get_plugin_data`) raises **400** for a disabled plugin and **503** for an unavailable one before those fields can be populated. `GET /displays/{t}/raw` answers 200 with `available: false`, which is what the Integrations page renders. Either the model's contract or the delegation is wrong.
7. **`GET /v1/plugins` has no batch form.** The variable picker fetches N plugins' data in one `POST /displays/raw/batch`; on v1 that becomes N round trips.
8. **`GET /v1/plugins` drops the fields the Integrations page runs on** — `update_available`, `source`, `settings_schema`, `config`, `instance_label`, `supports_triggers`.
9. **`GET /v1/health` is auth-gated where `GET /health` is public.** `src/auth/middleware.py:59` lists `/health` in `_PUBLIC_EXACT`; `/v1/*` takes bearer *or* cookie but is never public. `boot-gate.tsx:54` polls `/health` before a session exists, so v1's health check cannot replace it — and neither can a liveness probe or nginx upstream check.
10. **`PATCH /v1/boards/{b}` 404s on an install with no boards**, where `PUT /schedules/enabled` fell back to the legacy global `schedule.enabled` mirror (`settings/service.py:1748`). Migrated anyway: the three consumers all run after the setup wizard has configured a board, and the pre-board mirror is deprecated. Noting it because it is a real behaviour difference.

---

## 5. Verification

```
npm run typecheck   clean
npm run lint        clean
prettier --check .  clean
npm test -- --run   146 files, 1612 passed, 7 skipped, 0 failed   (baseline next: 146 / 1626 / 7 / 0)
pytest tests/       6780 passed, 2 skipped, 1 env-only failure (git ls-files inside the container;
                    identical on unmodified next)
playwright          587 passed, 23 skipped, 0 failed  (10.9m)
```

The 14-test vitest delta is exactly the tests belonging to the 10 deleted dead wrappers. Every response-shape change is re-pinned in the test with a comment naming the change (`api-extended.test.ts` — `setDefaultPage`, `setScheduleEnabled`, `updatePluginConfig`, `enablePlugin`, `disablePlugin`); no assertion was weakened.

**Playwright was run locally against a stack built from this branch**, shaped like the CI job rather than the dev container: `docker build --target runtime` (the production bundle — the dev container's Vite server rejects a foreign `Host` header, which is not a code problem but does make the dev image unusable for this), one app container plus the mock-board and mock-cloud sidecars on the bridge network, addressed by container IP exactly as `integration-tests.yml` does. All three of the reported failure classes pass:

```
collections.spec.ts                 11 passed   (incl. list.loading, form.creating)
integrations-*.spec.ts              36 passed   (incl. plugin.config-sheet.loading)
pages-* / schedule-* regression     70 passed
full suite (CI ignores, 1 worker)  587 passed, 23 skipped, 0 failed
```
