### PR TITLE
feat(api): publish 33 operations, not 231 — hide the internal surface

### DIFF
--- a/.claude/agents/ts-sync-validator.md
+++ b/.claude/agents/ts-sync-validator.md
@@ -14,7 +14,7 @@ You are the FiestaBoard **ts-sync-validator** agent. The codebase hand-syncs Pyd
 ## Preconditions
 
 1. Confirm `src/api_server.py` and `web/src/lib/api.ts` both exist.
-2. Confirm the dev container is up at `http://localhost:4420` — you'll fetch the live OpenAPI schema as ground truth (`curl -s http://localhost:4420/api/openapi.json`). If the container is down, fall back to AST parsing of `models.py` files and warn the user that endpoint-level coverage is incomplete.
+2. Confirm the dev container is up at `http://localhost:4420` — you'll fetch the live OpenAPI schema as ground truth (`curl -s http://localhost:4420/api/internal/openapi.json`). Use the **internal** document: `/api/openapi.json` publishes only the 33 consumer-facing `/v1` operations since `src/v1/visibility.py` hid the internal surface, and the models this check compares live behind the hidden paths. Fetching the public document instead would produce a clean report that checked almost nothing. If the container is down, fall back to AST parsing of `models.py` files and warn the user that endpoint-level coverage is incomplete.
 
 ## Process
 

--- a/.claude/commands/check-types.md
+++ b/.claude/commands/check-types.md
@@ -7,7 +7,7 @@ Optional arguments:
 - `--strict` — also flag interfaces with uncertain comparisons (unions, nested generics). Off by default.
 
 The agent (read-only) will:
-1. Prefer the live OpenAPI schema from `http://localhost:4420/api/openapi.json` as ground truth. Falls back to AST parsing of `models.py` if the container is down.
+1. Prefer the live OpenAPI schema from `http://localhost:4420/api/internal/openapi.json` as ground truth — the **internal** document, not `/api/openapi.json`. Since the internal surface was hidden (`src/v1/visibility.py`), `/api/openapi.json` publishes only the 33 consumer operations, so diffing against it would silently skip almost every model the web UI uses. Falls back to AST parsing of `models.py` if the container is down.
 2. Parse `web/src/lib/api.ts` for `export interface` blocks.
 3. Compare per-model: missing fields, extra fields, type mismatches, optionality mismatches, casing mismatches.
 4. Cross-check that every `response_model=<Model>` route in `api_server.py` has a matching TS fetch wrapper.

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -8,6 +8,26 @@ keywords: [FiestaBoard API, REST API, API endpoints, API reference, display API,
 
 FiestaBoard provides a REST API powered by FastAPI. Interactive API documentation is available at `http://localhost:4420/api/docs` when FiestaBoard is running.
 
+:::tip Start with `/api/v1`
+
+`/api/v1` is the API to build against: four nouns — board, page, schedule,
+plugin — and one way to do each thing. It is what `/api/docs` publishes, and
+it is the only surface with a compatibility promise.
+
+```bash
+curl -X POST http://localhost:4420/api/v1/boards/primary/message \
+  -H 'Content-Type: application/json' \
+  -d '{"text": "HELLO WORLD"}'
+```
+
+The flat paths listed below still answer exactly as they always have, but they
+are the web UI's internal channel and are no longer published in the OpenAPI
+document. `POST /send-message` and `POST /refresh` are the exceptions — they
+remain published, now marked deprecated, and each names its `/v1` replacement
+in a `Link` header.
+
+:::
+
 ## Base URL
 
 ```text

--- a/docs/setup/authentication.md
+++ b/docs/setup/authentication.md
@@ -88,7 +88,7 @@ page itself, and the OpenAPI docs keep working:
 
 - `GET /`, `GET /health`
 - `GET/POST /auth/*`
-- `GET /openapi.json`, `/docs`, `/redoc`
+- `GET /openapi.json`, `/internal/openapi.json`, `/docs`, `/redoc`
 
 Everything else (status, config, pages, plugins, etc.) requires a valid
 session cookie.

--- a/src/api_deprecation.py
+++ b/src/api_deprecation.py
@@ -1,0 +1,88 @@
+"""Deprecation notices on the wire, in one place.
+
+``deprecated=True`` on a route only greys the operation out in Swagger. The
+callers a deprecation actually exists for — a script in another repo, a
+plugin's SETUP guide, someone's cron job — never open Swagger. RFC 9745
+(``Deprecation``) and RFC 8594 (``Sunset``), plus an RFC 8288 ``Link`` naming
+the replacement, put the notice where those callers will see it: on every
+response.
+
+``src/api_server.py`` grew the first copy of this for the eleven deprecated
+plugin-specific routes (#1932). This module is that machinery lifted out so
+the second and third users — ``POST /send-message`` and ``POST /refresh``,
+the two legacy operations the published docs name and which therefore stay
+in the consumer schema after everything else is hidden — reuse it rather than
+growing a parallel mechanism.
+
+Which headers get sent is a deliberate per-caller choice:
+
+``Deprecation``
+    Always. It is the whole point.
+``Link: rel="successor-version"``
+    Whenever a replacement exists. Omitted where one genuinely does not
+    (``GET /transit/cache/status``).
+``Sunset``
+    Only where a removal date has actually been agreed. The eleven plugin
+    routes have one (#1915). ``/send-message`` and ``/refresh`` do not:
+    they are the endpoints the published documentation recommends, and
+    stamping a date on them would announce a removal nobody has scheduled.
+    An unbacked ``Sunset`` is worse than none — it teaches integrators that
+    the header is noise.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from fastapi import Depends, Response
+
+
+def successor_link(uri: str) -> str:
+    """An RFC 8288 ``Link`` value naming *uri* as the replacement.
+
+    *uri* may be a URI Template (RFC 6570) — ``/api/v1/boards/{board}/message``
+    — because the successor of a flat legacy route is frequently a
+    parameterised one, and a caller can read the template.
+    """
+    return f'<{uri}>; rel="successor-version"'
+
+
+def deprecation_notice(
+    *,
+    successor: str | None = None,
+    sunset: str | None = None,
+) -> Callable:
+    """A FastAPI dependency that stamps the deprecation headers on a response.
+
+    Args:
+        successor: URI (or URI Template) of the replacement, sent as
+            ``Link: rel="successor-version"``. ``None`` sends no ``Link``.
+        sunset: An HTTP-date at which the route is scheduled to be removed,
+            sent as ``Sunset``. ``None`` sends no ``Sunset`` — see the module
+            docstring for why that is the default rather than an oversight.
+
+    Returns:
+        A ``Depends(...)`` to put in a route's ``dependencies=`` list.
+    """
+    link = successor_link(successor) if successor else None
+
+    def _set_deprecation_headers(response: Response) -> None:
+        response.headers["Deprecation"] = "true"
+        if sunset is not None:
+            response.headers["Sunset"] = sunset
+        if link is not None:
+            response.headers["Link"] = link
+
+    # Read back by tests so a route's advertised successor can be pinned
+    # without calling the successor.
+    _set_deprecation_headers.successor_uri = successor  # type: ignore[attr-defined]
+    _set_deprecation_headers.sunset = sunset  # type: ignore[attr-defined]
+    return Depends(_set_deprecation_headers)
+
+
+#: The v1 replacement for both legacy write operations. ``POST`` puts content
+#: on the board (``/send-message``); ``DELETE`` reverts it to whatever the
+#: schedule says and re-drives the board, which is what ``POST /refresh``
+#: does — ``src/v1/routes_boards.py`` calls ``refresh_display`` outright. A
+#: ``Link`` relation names a resource, not a method, so the two share one.
+V1_BOARD_MESSAGE_SUCCESSOR = "/api/v1/boards/{board}/message"

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from typing import Any
 
 from dotenv import load_dotenv
-from fastapi import Depends, FastAPI, HTTPException, Query, Response
+from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse
 
@@ -30,6 +30,7 @@ from . import (  # noqa: E402,F401  (re-export)
     display_runtime,
     log_store,
 )
+from .api_deprecation import deprecation_notice  # noqa: E402
 from .auth import is_auth_enabled  # noqa: E402
 from .auth.middleware import AuthMiddleware  # noqa: E402
 from .auth.routes import router as auth_router  # noqa: E402
@@ -412,32 +413,51 @@ FiestaBoard drives one or more split-flap displays from templated pages.
 Put text on the board right now:
 
 ```bash
-curl -X POST http://fiestaboard.local:4420/api/send-message \\
+curl -X POST http://fiestaboard.local:4420/api/v1/boards/primary/message \\
   -H 'Content-Type: application/json' \\
   -d '{"text": "HELLO WORLD"}'
 ```
 
+`primary` works as a board id on every `/v1/boards/...` path, so a
+single-board install never has to look one up — and a multi-board install
+puts the id there instead.
+
 ### How the pieces fit
 
+Four nouns, and one way to do each thing:
+
+* A **board** is a physical display. `POST /v1/boards/{board}/message` writes
+  to it; `GET /v1/boards/{board}` says what is on it and why.
 * A **page** is a template: literal text plus `{{plugin_id.variable}}`
   placeholders that **plugins** fill with live data.
-* A **schedule** or a **collection** decides which page a board shows at a
-  given moment. `POST /send-message` bypasses both for a one-off write.
-* `/settings/*` and `/config/*` are the install's configuration;
-  `/system/*`, `/network/*` and `/auth/*` administer the appliance itself.
+* A **schedule** (or a **collection**) decides which page a board shows at a
+  given moment. A message write bypasses both for a one-off; `DELETE
+  /v1/boards/{board}/message` hands the board back to the schedule.
 
 ### Base URL
 
 nginx fronts the API under `/api`, so every path below is reached as
-`/api/<path>` — `GET /status` is `http://fiestaboard.local:4420/api/status`.
-These docs live at `/api/docs`, the schema at `/api/openapi.json`.
+`/api/<path>` — `GET /v1/status` is
+`http://fiestaboard.local:4420/api/v1/status`. These docs live at
+`/api/docs`, the schema at `/api/openapi.json`.
+
+### What is not here
+
+This document is the API to build against: 33 operations. The app serves
+~200 more, but they are the web UI's private RPC channel — undocumented on
+purpose, with no compatibility promise, and liable to change in any release.
+They are published separately at `/api/internal/openapi.json` for the UI's
+own contract checks. Two flat legacy operations, `POST /send-message` and
+`POST /refresh`, remain here because earlier documentation named them; both
+are deprecated and both name their `/v1` replacement in a `Link` header.
 
 ### Authentication
 
 Off by default: a fresh install answers every request. With
-`FIESTABOARD_AUTH_ENABLED=true`, requests carry the session cookie that
-`POST /auth/login` sets. MCP clients may instead send
-`Authorization: Bearer <token>` to `/api/mcp` (see `POST /auth/mcp-token`).
+`FIESTABOARD_AUTH_ENABLED=true`, a script sends
+`Authorization: Bearer <token>` (create one with `POST /auth/mcp-token`),
+which is accepted on every `/v1` path and on `/api/mcp`. The web UI instead
+carries the session cookie that `POST /auth/login` sets.
 """
 
 # Deliberate order — Swagger lists tags in this order, and anything not listed
@@ -1180,20 +1200,15 @@ def _deprecated_route(successor_plugin_id: str | None = None):
     ``successor_plugin_id=None`` means no successor exists yet
     (``/transit/cache/status``), and only ``Deprecation``/``Sunset`` are sent.
     """
-    link = None
+    successor = None
     if successor_plugin_id:
-        link = f'</api/plugins/{successor_plugin_id}/options/{{options_id}}>; rel="successor-version"'
+        successor = f"/api/plugins/{successor_plugin_id}/options/{{options_id}}"
 
-    def _set_deprecation_headers(response: Response) -> None:
-        response.headers["Deprecation"] = "true"
-        response.headers["Sunset"] = DEPRECATED_ROUTES_SUNSET
-        if link is not None:
-            response.headers["Link"] = link
-
+    dependency = deprecation_notice(successor=successor, sunset=DEPRECATED_ROUTES_SUNSET)
     # Read by tests/test_deprecated_route_headers.py to pin which route points
     # at which successor without calling eleven upstream APIs.
-    _set_deprecation_headers.successor_plugin_id = successor_plugin_id  # type: ignore[attr-defined]
-    return Depends(_set_deprecation_headers)
+    dependency.dependency.successor_plugin_id = successor_plugin_id  # type: ignore[attr-defined]
+    return dependency
 
 
 @app.get(

--- a/src/auth/middleware.py
+++ b/src/auth/middleware.py
@@ -7,6 +7,10 @@ Public paths (no auth required):
     * ``/`` and ``/health`` — liveness probes / nginx upstream checks
     * ``/auth/*`` — login / setup / status itself
     * ``/openapi.json``, ``/docs``, ``/redoc`` — API docs (still useful)
+    * ``/internal/openapi.json`` — the full schema, public for the same
+      reason ``/openapi.json`` is and because it is exactly what
+      ``/openapi.json`` published before the internal surface was hidden.
+      Gating it now would be a new restriction dressed up as a refactor.
     * CORS preflight (``OPTIONS``) requests
 
 Bearer-token paths (``/mcp/*`` and ``/v1/*``):
@@ -51,6 +55,7 @@ _PUBLIC_PREFIXES: tuple = (
     "/auth/",
     "/health",
     "/openapi.json",
+    "/internal/openapi.json",
     "/docs",
     "/redoc",
 )

--- a/src/board_api/routes.py
+++ b/src/board_api/routes.py
@@ -62,6 +62,7 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, HTTPException
 
 from src import display_runtime as runtime
+from src.api_deprecation import V1_BOARD_MESSAGE_SUCCESSOR, deprecation_notice
 from src.api_errors import errors
 from src.board_chars import characters_to_message
 from src.board_client import board_client_from_board_dict
@@ -214,14 +215,33 @@ async def get_board_current_message(force: bool = False, board_id: str | None = 
 # ---------------------------------------------------------------------------
 
 
-@router.post("/send-message", response_model=SendResponse, responses=errors(404, 409, 429, 500, 503))
+# One of the two legacy operations that stay in the published consumer schema
+# (``src/v1/visibility.py``). It is what ``docs/reference/api-endpoints.md``
+# and the front page of ``/api/docs`` have told readers to call for years, so
+# hiding it would break a documented path; instead it is flagged deprecated and
+# names its successor on every response. No ``Sunset``: no removal date has
+# been agreed for it, and an unbacked one teaches integrators to ignore the
+# header.
+@router.post(
+    "/send-message",
+    response_model=SendResponse,
+    responses=errors(404, 409, 429, 500, 503),
+    deprecated=True,
+    dependencies=[deprecation_notice(successor=V1_BOARD_MESSAGE_SUCCESSOR)],
+)
 async def send_message(request: MessageRequest):
-    """Send a custom message to a board.
+    """Deprecated: use ``POST /v1/boards/{board}/message`` instead.
+
+    Send a custom message to a board.
 
     ``board_id`` (optional) targets one board; omitted → the primary board,
     which is what every caller got before this endpoint could address a
     second one (issue #1247). Gate for gate this is the same policy the MCP
     executor applies — see ``src/ops/executors.py``.
+
+    The v1 successor takes the board in the path, so it cannot be forgotten,
+    and reports whether flaps actually moved rather than only that the
+    request was accepted.
     """
     service = runtime.get_service()
     if not service:

--- a/src/service_api/routes.py
+++ b/src/service_api/routes.py
@@ -36,6 +36,7 @@ from fastapi import APIRouter, HTTPException
 
 from src import __version__
 from src import display_runtime as runtime
+from src.api_deprecation import V1_BOARD_MESSAGE_SUCCESSOR, deprecation_notice
 from src.api_errors import errors
 from src.board_guards import _require_board
 from src.board_send_executor import run_board_send
@@ -209,9 +210,22 @@ async def stop_service():
 # ---------------------------------------------------------------------------
 
 
-@router.post("/refresh", response_model=RefreshResponse, responses=errors(404, 500, 503))
+# The second of the two legacy operations kept in the published consumer
+# schema — see the note on ``POST /send-message`` in src/board_api/routes.py.
+# Its successor is ``DELETE /v1/boards/{board}/message``, which calls this very
+# handler: reverting a board to its scheduled content and re-driving it is the
+# same act.
+@router.post(
+    "/refresh",
+    response_model=RefreshResponse,
+    responses=errors(404, 500, 503),
+    deprecated=True,
+    dependencies=[deprecation_notice(successor=V1_BOARD_MESSAGE_SUCCESSOR)],
+)
 async def refresh_display(board_id: str | None = None, payload: RefreshRequest | None = None):
-    """Manually trigger a display refresh.
+    """Deprecated: use ``DELETE /v1/boards/{board}/message`` instead.
+
+    Manually trigger a display refresh.
 
     Args:
         board_id: Optional board to refresh (query param, or

--- a/src/v1/__init__.py
+++ b/src/v1/__init__.py
@@ -27,12 +27,33 @@ from __future__ import annotations
 from . import routes_boards, routes_content, routes_meta, routes_plugins
 from .openapi import install_security_scheme
 from .router import router
+from .visibility import build_internal_openapi, hide_internal_operations, mount_internal_schema
 
 
 def mount_v1(app) -> None:
-    """Attach the v1 surface to *app*: its routes and its security scheme."""
+    """Attach the v1 surface to *app* and hide everything that is not it.
+
+    Order matters, and each step depends on the one before it:
+
+    1. include the ``/v1`` routes, so there is a consumer surface at all;
+    2. declare the security schemes, so the document says the API is
+       authenticated;
+    3. mount ``/internal/openapi.json``, so the full document has somewhere
+       to live *before* anything is taken out of the published one;
+    4. hide every non-``/v1`` operation. Last, because it sweeps the whole
+       route table — every router this module's caller included, plus the
+       internal-schema route added in step 3.
+    """
     app.include_router(router)
     install_security_scheme(app)
+    mount_internal_schema(app)
+    hide_internal_operations(app)
 
 
-__all__ = ["install_security_scheme", "mount_v1", "router"]
+__all__ = [
+    "build_internal_openapi",
+    "hide_internal_operations",
+    "install_security_scheme",
+    "mount_v1",
+    "router",
+]

--- a/src/v1/openapi.py
+++ b/src/v1/openapi.py
@@ -75,17 +75,47 @@ V1_TAG_METADATA: dict[str, Any] = {
 }
 
 
-def build_openapi(app) -> dict[str, Any]:
-    """The app's schema, with the security it actually enforces declared."""
+def _tags_used_by(schema: dict[str, Any]) -> set[str]:
+    """Every tag named by an operation the document actually contains."""
+    used: set[str] = set()
+    for operations in schema.get("paths", {}).values():
+        for operation in operations.values():
+            if isinstance(operation, dict):
+                used.update(operation.get("tags", []))
+    return used
+
+
+def build_openapi(
+    app,
+    *,
+    routes=None,
+    title: str | None = None,
+    description: str | None = None,
+) -> dict[str, Any]:
+    """The app's schema, with the security it actually enforces declared.
+
+    ``routes``, ``title`` and ``description`` override the app's own, which is
+    what lets the internal document (``src/v1/visibility.py``) reuse this
+    builder — the same security declaration, the same tag metadata — while
+    saying plainly on its front page that it is not a consumer API.
+
+    The declared tag list is filtered to the tags operations in *this*
+    document actually use. Once the internal surface is hidden the app still
+    declares twenty-two internal tag descriptions, and publishing headings for
+    sections a reader cannot reach is the same noise this whole change is
+    removing. Order is preserved, so the consumer surface still leads.
+    """
     schema = get_openapi(
-        title=app.title,
+        title=title if title is not None else app.title,
         version=app.version,
-        description=app.description,
-        routes=app.routes,
+        description=description if description is not None else app.description,
+        routes=app.routes if routes is None else routes,
         # Prepended, not appended: Swagger renders tags in this order and the
         # consumer surface has to be the first thing a newcomer sees.
         tags=[V1_TAG_METADATA, *(app.openapi_tags or [])],
     )
+    used = _tags_used_by(schema)
+    schema["tags"] = [tag for tag in schema.get("tags", []) if tag["name"] in used]
     schema.setdefault("components", {})["securitySchemes"] = SECURITY_SCHEMES
     schema["security"] = SECURITY_REQUIREMENT
     return schema

--- a/src/v1/visibility.py
+++ b/src/v1/visibility.py
@@ -1,0 +1,199 @@
+"""What a consumer sees, and where everything else went.
+
+Measured on ``next`` before this module existed: **231 published operations,
+0 routes using ``include_in_schema=False``**. 179 of them have no caller
+outside ``web/src``. The published OpenAPI document was the browser's private
+RPC surface, and a newcomer was asked to find the front door inside it.
+
+``/v1`` is that front door — 31 operations over four nouns. This module is
+what makes it findable, by taking everything else out of the published
+document:
+
+* :func:`hide_internal_operations` marks every non-``/v1`` operation
+  ``include_in_schema=False``. **This is a documentation change and nothing
+  else.** Every hidden route keeps its path, its methods, its handler, its
+  status codes and its response bodies; ``include_in_schema`` is read when
+  building the OpenAPI document and by nothing in the request path. Proven by
+  test rather than asserted here — ``tests/test_internal_schema.py`` calls a
+  sample of hidden routes and compares the answers.
+* Two legacy operations stay visible, because the published documentation
+  already names them and a reader following those docs must still be able to
+  find them: ``POST /send-message`` and ``POST /refresh``. Both are flagged
+  ``deprecated`` and carry ``Deprecation`` and
+  ``Link: rel="successor-version"`` headers naming their v1 equivalents.
+* :func:`build_internal_openapi` republishes the full document at
+  ``/api/internal/openapi.json``. Hidden must not mean gone: the web team
+  still needs a contract, and ``/check-types`` still needs a schema to diff
+  Pydantic models against TypeScript.
+
+Consumer-visible total: **33**.
+
+Why a sweep rather than 197 decorator edits
+-------------------------------------------
+The rule is "``/v1``, plus two named exceptions", and a rule is better spelled
+once than restated 197 times where it can drift on the 198th route. A new
+internal router is hidden the day it lands with no reviewer having to
+remember; a new *consumer* operation is a deliberate ``/v1`` path. The
+alternative — a keyword argument on every decorator — is 197 places for the
+policy to be wrong and nothing that fails when one of them is.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+from fastapi import routing as fastapi_routing
+from fastapi.routing import APIRoute
+from starlette.responses import JSONResponse
+
+from .openapi import build_openapi
+
+#: ``(method, path)`` of the operations that stay in the published document
+#: even though they are not ``/v1``. Both are named in
+#: ``docs/reference/api-endpoints.md`` and in the front page of ``/api/docs``,
+#: so hiding them would break a documented path for a reader following the
+#: docs as written. Both advertise their v1 successor on every response.
+PUBLIC_LEGACY_OPERATIONS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("POST", "/send-message"),
+        ("POST", "/refresh"),
+    }
+)
+
+#: Where the full document is served. Behind nginx (which strips ``/api``)
+#: that is ``/api/internal/openapi.json``.
+INTERNAL_SCHEMA_PATH = "/internal/openapi.json"
+
+INTERNAL_SCHEMA_TITLE = "FiestaBoard Internal API"
+
+INTERNAL_SCHEMA_DESCRIPTION = """\
+**Not a consumer API. No compatibility promise. Do not build against this.**
+
+Every operation the app serves, including the ones hidden from
+`/api/openapi.json`. It exists for two readers:
+
+* the web UI, which is the only caller of most of these paths and needs a
+  contract for `web/src/lib/api/*`;
+* `/check-types`, which diffs the Pydantic models behind these paths against
+  the TypeScript interfaces in `web/src/lib/api.ts`.
+
+The API a script, an integration or a person with `curl` should use is `/v1`,
+published at `/api/openapi.json` and documented at `/api/docs`. Paths in this
+document may change or disappear in any release.
+"""
+
+
+class _AlwaysInSchema(fastapi_routing.RouteContext):
+    """A route context that reports itself as documented, whatever the route.
+
+    ``get_openapi`` skips a route whose ``include_in_schema`` is false, and
+    offers no way to ask it not to. It does, however, accept a sequence of
+    ``RouteContext`` objects instead of routes — that is its own public
+    signature — and a context resolves its attributes through
+    ``__getattr__``. Overriding the one attribute with a property is enough
+    to build the full document **without mutating a single route**.
+
+    The alternative, flipping ``include_in_schema`` back on and restoring it
+    afterwards, would mean the app briefly serves a different public schema
+    than it did a microsecond earlier, and FastAPI >= 0.130 caches an
+    effective-route snapshot per included router that a bare attribute write
+    does not invalidate — so the flip would not even work. This does.
+    """
+
+    @property
+    def include_in_schema(self) -> bool:
+        return True
+
+
+def iter_api_routes(routes: Any, prefix: str = "") -> Iterator[tuple[str, APIRoute]]:
+    """Yield ``(served_path, route)`` for every ``APIRoute`` in the tree.
+
+    FastAPI >= 0.130 wraps ``include_router()`` results in an internal
+    ``_IncludedRouter`` node that carries the router's prefix and exposes no
+    ``path`` of its own, so the leaf routes below it have *unprefixed* paths.
+    Recursing through ``include_context`` and accumulating the prefix is what
+    turns ``route.path`` into the path the app actually serves — the same walk
+    ``tests/test_route_inventory.py`` does, for the same reason.
+
+    A ``Mount`` (the MCP sub-app) is deliberately not descended into: its
+    routes belong to that app and publish no OpenAPI operations here.
+    """
+    for route in routes:
+        include_context = getattr(route, "include_context", None)
+        if include_context is not None:
+            yield from iter_api_routes(
+                include_context.included_router.routes,
+                prefix + (include_context.prefix or ""),
+            )
+            continue
+        if isinstance(route, APIRoute):
+            yield prefix + route.path, route
+
+
+def is_consumer_operation(path: str, route: APIRoute) -> bool:
+    """True when *route* belongs in the published, consumer-facing document."""
+    if path == "/v1" or path.startswith("/v1/"):
+        return True
+    return any((method, path) in PUBLIC_LEGACY_OPERATIONS for method in route.methods or ())
+
+
+def hide_internal_operations(app: Any) -> list[APIRoute]:
+    """Take every non-consumer operation out of the published document.
+
+    Idempotent, and returns the routes it hid so a caller can count them.
+
+    Must run **after** every router is included and **before** anything builds
+    or serves a document: FastAPI caches an effective-route snapshot per
+    included router, keyed on a version counter that an attribute write does
+    not bump. ``mount_v1`` is the last statement in ``src/api_server.py`` for
+    exactly that reason. ``app.openapi_schema`` is cleared here as well, so a
+    document built earlier in the process cannot survive as the published one.
+    """
+    hidden: list[APIRoute] = []
+    for path, route in iter_api_routes(app.routes):
+        if is_consumer_operation(path, route):
+            continue
+        route.include_in_schema = False
+        hidden.append(route)
+    app.openapi_schema = None
+    return hidden
+
+
+def build_internal_openapi(app: Any) -> dict[str, Any]:
+    """The full document — every operation, hidden or not.
+
+    Built over :class:`_AlwaysInSchema` views of the app's routes, so it reads
+    the live route table and mutates nothing. Not cached: this is a
+    development-tooling endpoint whose whole value is being current.
+    """
+    contexts = [
+        _AlwaysInSchema(context.route, context._route_context)
+        for context in fastapi_routing.iter_route_contexts(app.routes)
+    ]
+    return build_openapi(
+        app,
+        routes=contexts,
+        title=INTERNAL_SCHEMA_TITLE,
+        description=INTERNAL_SCHEMA_DESCRIPTION,
+    )
+
+
+def mount_internal_schema(app: Any) -> None:
+    """Serve the full document at :data:`INTERNAL_SCHEMA_PATH`.
+
+    Registered the same way FastAPI registers ``/openapi.json`` itself — a
+    plain Starlette route with ``include_in_schema=False`` — so it is a
+    sibling of the document it serves rather than operation 232 inside it.
+    """
+
+    async def internal_openapi(request: Any) -> JSONResponse:
+        return JSONResponse(build_internal_openapi(app))
+
+    app.add_route(
+        INTERNAL_SCHEMA_PATH,
+        internal_openapi,
+        methods=["GET"],
+        name="internal_openapi",
+        include_in_schema=False,
+    )

--- a/tests/golden/api_routes.json
+++ b/tests/golden/api_routes.json
@@ -460,6 +460,15 @@
       "kind": "APIRoute"
     },
     {
+      "path": "/internal/openapi.json",
+      "methods": [
+        "GET",
+        "HEAD"
+      ],
+      "name": "internal_openapi",
+      "kind": "Route"
+    },
+    {
       "path": "/logs",
       "methods": [
         "GET"

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -8,6 +8,7 @@ visiting ``/api/docs`` the embedded Swagger UI must reference
 from fastapi.testclient import TestClient
 
 from src.api_server import app
+from src.v1.visibility import build_internal_openapi
 
 
 def test_app_has_api_root_path():
@@ -51,15 +52,17 @@ def test_openapi_schema_has_unique_operation_ids():
     operationId for both the GET and HEAD operations. Duplicate operationIds
     break OpenAPI client generators (openapi-generator, orval, etc.), which
     key off operationId to name generated methods.
+
+    Checked on the **internal** document. A collision needs two routes to
+    collide, and the published document has 33 of the app's ~230 operations —
+    checking it would leave the other ~197 unchecked while still passing.
     """
-    client = TestClient(app)
-    response = client.get("/openapi.json")
-    assert response.status_code == 200
-    schema = response.json()
+    schema = build_internal_openapi(app)
 
     ids = _operation_ids(schema)
+    assert len(ids) > 200, "the internal document should carry the whole surface"
     duplicates = {op_id for op_id in ids if ids.count(op_id) > 1}
-    assert not duplicates, f"Duplicate operationId(s) in /openapi.json: {sorted(duplicates)}"
+    assert not duplicates, f"Duplicate operationId(s): {sorted(duplicates)}"
 
 
 def test_openapi_schema_operation_ids_are_deterministic():
@@ -67,17 +70,12 @@ def test_openapi_schema_operation_ids_are_deterministic():
 
     route.methods is a set, so a default generate_unique_id that reads
     list(route.methods)[0] can pick GET one process run and HEAD the next.
-    Rebuilding the schema (as FastAPI does lazily, cached on app.openapi_schema)
-    must produce the same operationId for the /health route every time.
+    Rebuilding the schema must produce the same operationId for the /health
+    route every time. ``/health`` is internal, so the internal document is
+    where it can be read.
     """
-    client = TestClient(app)
-
-    # Force a fresh schema build each time, bypassing FastAPI's cache, so we
-    # actually re-exercise generate_unique_id rather than reading a cached dict.
-    app.openapi_schema = None
-    first = client.get("/openapi.json").json()
-    app.openapi_schema = None
-    second = client.get("/openapi.json").json()
+    first = build_internal_openapi(app)
+    second = build_internal_openapi(app)
 
     first_health_ids = sorted(
         op.get("operationId") for op in first["paths"]["/health"].values() if isinstance(op, dict)
@@ -86,3 +84,10 @@ def test_openapi_schema_operation_ids_are_deterministic():
         op.get("operationId") for op in second["paths"]["/health"].values() if isinstance(op, dict)
     )
     assert first_health_ids == second_health_ids
+
+
+def test_the_internal_schema_is_served_at_its_documented_path():
+    """``/check-types`` and the web contract both fetch it by this URL."""
+    response = TestClient(app).get("/internal/openapi.json")
+    assert response.status_code == 200
+    assert response.json()["info"]["title"] == "FiestaBoard Internal API"

--- a/tests/test_api_errors.py
+++ b/tests/test_api_errors.py
@@ -18,10 +18,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi.testclient import TestClient
-
 from src.api_errors import ErrorResponse, HTTPValidationError, errors
 from src.api_server import app
+from src.v1.visibility import build_internal_openapi
 
 
 def test_errors_maps_422_to_http_validation_error():
@@ -70,8 +69,13 @@ def _detail_type(schema: dict[str, Any], response: dict[str, Any]) -> str:
 
 
 def _openapi() -> dict[str, Any]:
-    app.openapi_schema = None  # bypass FastAPI's cached build
-    return TestClient(app).get("/openapi.json").json()
+    """The internal document — ``/pages/*`` is not in the published one.
+
+    ``src/v1/visibility.py`` publishes only the 33 consumer operations, and
+    both routes below are internal. Built fresh each call (it is never cached)
+    so this still re-exercises the schema build rather than reading a snapshot.
+    """
+    return build_internal_openapi(app)
 
 
 def test_openapi_serves_list_shaped_422_on_a_validation_only_route():

--- a/tests/test_displays_contract.py
+++ b/tests/test_displays_contract.py
@@ -149,7 +149,10 @@ def test_raw_is_marked_deprecated_in_the_published_schema(client):
     A generated client reads the schema, not the response headers, so the
     successor (GET /plugins/{plugin_id}/data) was invisible to it.
     """
-    schema = client.get("/openapi.json").json()
+    # The internal document: /displays/* is not in the published one since
+    # src/v1/visibility.py hid the internal surface, and a KeyError here would
+    # be the honest failure while a `.get(...)` would be a vacuous pass.
+    schema = client.get("/internal/openapi.json").json()
     assert schema["paths"]["/displays/{display_type}/raw"]["get"]["deprecated"] is True
     assert schema["paths"]["/displays/{display_type}"]["get"].get("deprecated") is not True
 

--- a/tests/test_internal_schema.py
+++ b/tests/test_internal_schema.py
@@ -1,0 +1,343 @@
+"""Hiding 198 operations is a documentation change and nothing else.
+
+Measured on ``next`` @ ``a7c84ce13``: the app published **231 operations**,
+179 of which have no caller outside ``web/src``, and **not one route** used
+``include_in_schema=False``. ``src/v1/visibility.py`` takes everything that is
+not ``/v1`` — and not one of the two legacy operations the published docs name
+— out of the published document, leaving **33**.
+
+The failure mode that would make that a disaster rather than an improvement is
+a hidden route that also stops *answering*. ``include_in_schema`` is read when
+the OpenAPI document is built and nowhere in the request path, so it cannot —
+but "cannot" is the claim, and this file is the evidence. It calls hidden
+routes and compares the answers against the same routes' recorded contracts,
+rather than asserting the attribute means what the docs say it means.
+
+The second failure mode is quieter: a schema test that goes green because it
+now checks nothing. Two guards below (``test_the_published_document_is_not_
+trivially_empty`` and ``test_the_internal_document_is_not_a_copy_of_the_public
+_one``) exist to make that visible rather than silent.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api_server import app
+from src.v1.visibility import (
+    INTERNAL_SCHEMA_PATH,
+    PUBLIC_LEGACY_OPERATIONS,
+    build_internal_openapi,
+    is_consumer_operation,
+    iter_api_routes,
+)
+
+_HTTP_METHODS = frozenset({"get", "post", "put", "patch", "delete", "head", "options", "trace"})
+
+#: The contract the whole change rests on.
+EXPECTED_PUBLISHED_OPERATIONS = 33
+
+
+def _operations(schema: dict) -> set[str]:
+    return {
+        f"{method.upper()} {path}"
+        for path, operations in schema["paths"].items()
+        for method in operations
+        if method in _HTTP_METHODS
+    }
+
+
+@pytest.fixture
+def client(_isolated_data_dir) -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture(scope="module")
+def published() -> dict:
+    return app.openapi()
+
+
+@pytest.fixture(scope="module")
+def internal() -> dict:
+    return build_internal_openapi(app)
+
+
+# ---------------------------------------------------------------------------
+# 1. The number
+# ---------------------------------------------------------------------------
+
+
+def test_a_consumer_sees_exactly_thirty_three_operations(published):
+    """231 -> 33. A 34th is a decision, not a side effect."""
+    assert len(_operations(published)) == EXPECTED_PUBLISHED_OPERATIONS
+
+
+def test_every_published_operation_is_v1_or_one_of_the_two_named_exceptions(published):
+    strays = sorted(
+        operation
+        for operation in _operations(published)
+        if not operation.split(" ", 1)[1].startswith("/v1")
+        and tuple(operation.split(" ", 1)) not in PUBLIC_LEGACY_OPERATIONS
+    )
+    assert strays == []
+
+
+def test_the_two_legacy_operations_the_published_docs_name_are_still_published(published):
+    """``docs/reference/api-endpoints.md`` tells readers to call these two.
+
+    Hiding them would break a documented path for someone following the docs
+    exactly as written, which is the one group this change exists to serve.
+    """
+    operations = _operations(published)
+    for method, path in PUBLIC_LEGACY_OPERATIONS:
+        assert f"{method} {path}" in operations
+
+
+def test_the_published_document_is_not_trivially_empty(published):
+    """Guard the guard: an import failure must not read as 'nicely small'."""
+    assert len(_operations(published)) > 30
+    assert "/v1/boards/{board}/message" in published["paths"]
+
+
+# ---------------------------------------------------------------------------
+# 2. Hidden is not gone — the routes
+# ---------------------------------------------------------------------------
+
+
+#: One hidden route per shape of thing that could have broken: a plain read, a
+#: read behind a path parameter, a write with a body, a 404 path, and one of
+#: the eleven deprecated routes. Each expectation is the answer the route gives
+#: on ``next``; none of them is "some 2xx".
+HIDDEN_ROUTES_AND_THEIR_ANSWERS = [
+    ("GET", "/health", 200),
+    ("GET", "/status", 200),
+    ("GET", "/pages", 200),
+    ("GET", "/settings/board", 200),
+    ("GET", "/plugins", 200),
+    ("GET", "/config/general", 200),
+    ("GET", "/schedules", 200),
+    ("GET", "/collections", 200),
+    ("GET", "/templates/formula-functions", 200),
+    ("GET", "/pages/no-such-page", 404),
+]
+
+
+@pytest.mark.parametrize(("method", "path", "expected_status"), HIDDEN_ROUTES_AND_THEIR_ANSWERS)
+def test_a_hidden_route_still_answers_exactly_as_before(client, method, path, expected_status):
+    response = client.request(method, path)
+    assert response.status_code == expected_status, response.text
+
+
+@pytest.mark.parametrize(("method", "path", "_status"), HIDDEN_ROUTES_AND_THEIR_ANSWERS)
+def test_every_route_this_file_calls_is_actually_hidden(published, method, path, _status):
+    """Otherwise the parametrization above proves nothing about hiding."""
+    assert f"{method} {path}" not in _operations(published)
+
+
+def test_a_hidden_route_returns_the_same_body_it_documents(client, internal):
+    """A hidden route's *shape* is unchanged, not merely its status code."""
+    body = client.get("/templates/formula-functions").json()
+    assert isinstance(body, dict)
+    assert "functions" in body
+    assert body["functions"], "the function catalogue must not have come back empty"
+    assert "/templates/formula-functions" in internal["paths"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Hidden is not gone — the document
+# ---------------------------------------------------------------------------
+
+
+def test_the_internal_document_is_served(client):
+    response = client.get(INTERNAL_SCHEMA_PATH)
+    assert response.status_code == 200
+    assert response.json()["info"]["title"] == "FiestaBoard Internal API"
+
+
+def test_the_internal_document_carries_every_operation_the_app_serves(internal):
+    """Every ``APIRoute`` in the live table, hidden or not, is in it."""
+    served = {
+        f"{method} {path}"
+        for path, route in iter_api_routes(app.routes)
+        for method in (route.methods or ())
+        if method.lower() in _HTTP_METHODS and method != "HEAD"
+    }
+    assert served - _operations(internal) == set()
+
+
+def test_the_internal_document_is_not_a_copy_of_the_public_one(published, internal):
+    """The whole point: it has the operations the published one dropped."""
+    assert len(_operations(internal)) > 200
+    assert _operations(published) <= _operations(internal)
+
+
+def test_the_internal_document_says_it_is_not_a_consumer_api(internal):
+    """A second published surface with no warning is a second public API."""
+    description = internal["info"]["description"]
+    assert "Not a consumer API" in description
+    assert "/v1" in description
+
+
+def test_building_the_internal_document_does_not_change_the_published_one(client):
+    """It reads the route table; it must not write to it.
+
+    The obvious implementation — flip ``include_in_schema`` back on, build,
+    flip it off — would make the published schema depend on whether anyone had
+    recently fetched the internal one. This pins that it does not.
+    """
+    before = _operations(client.get("/openapi.json").json())
+    client.get(INTERNAL_SCHEMA_PATH)
+    after = _operations(client.get("/openapi.json").json())
+    assert after == before == _operations(app.openapi())
+
+
+def test_the_internal_document_is_readable_without_a_session(client):
+    """``/check-types`` fetches it with plain curl, as it did ``/openapi.json``.
+
+    Gating it would be a new restriction dressed up as a refactor: this is
+    exactly what ``/openapi.json`` published, publicly, before the internal
+    surface was hidden.
+    """
+    from src.auth.middleware import _is_public_path
+
+    assert _is_public_path(INTERNAL_SCHEMA_PATH)
+
+
+# ---------------------------------------------------------------------------
+# 4. The rule that decides visibility
+# ---------------------------------------------------------------------------
+
+
+def test_the_sweep_covered_the_whole_route_table():
+    """Every APIRoute is now classified — no route escaped the walk.
+
+    The walk has to recurse through FastAPI's ``_IncludedRouter`` nodes to see
+    routes at all. A walk that silently stopped at the top level would hide
+    eleven routes, publish 220, and this is what notices.
+    """
+    routes = list(iter_api_routes(app.routes))
+    assert len(routes) > 200
+    hidden = [route for path, route in routes if not is_consumer_operation(path, route)]
+    published_by_route = [route for path, route in routes if is_consumer_operation(path, route)]
+
+    assert all(not route.include_in_schema for route in hidden)
+    assert all(route.include_in_schema for route in published_by_route)
+    assert len(hidden) > 190
+
+
+def test_hiding_is_idempotent():
+    """It runs at import; a second call (a test app factory) must be a no-op."""
+    from src.v1.visibility import hide_internal_operations
+
+    first = len(hide_internal_operations(app))
+    second = len(hide_internal_operations(app))
+    assert first == second
+    assert len(_operations(app.openapi())) == EXPECTED_PUBLISHED_OPERATIONS
+
+
+# ---------------------------------------------------------------------------
+# 5. The two that stayed visible say what they are
+# ---------------------------------------------------------------------------
+
+
+class _FakeBoardClient:
+    """A board client that records what was rendered, with real attributes.
+
+    Not a ``Mock``: the handler's throttle guard reads ``last_send_throttled``
+    with an ``is True`` check precisely so a Mock's truthy attributes do not
+    put every send on the 429 path.
+    """
+
+    def __init__(self):
+        self.rendered: list = []
+        self.last_send_throttled = False
+        self.min_send_interval_ms = 0
+        self.use_cloud = False
+        self._last_characters = None
+        self.skip_unchanged = True
+
+    def render(self, board_array, **kwargs):
+        self.rendered.append(board_array)
+        return True, True
+
+
+@pytest.fixture
+def sendable(_isolated_data_dir):
+    """A one-board install whose send path reaches a 200.
+
+    The deprecation headers are set by a FastAPI dependency, so they ride on
+    the *response*. A route that raises ``HTTPException`` never builds one —
+    which is why this fixture exists rather than asserting against the 409 an
+    unconfigured install gives.
+    """
+    from unittest.mock import Mock, patch
+
+    board = {"id": "board-primary", "device_type": "flagship", "notes_wide": 1, "notes_tall": 1}
+    board_client = _FakeBoardClient()
+
+    service = Mock()
+    service.vb_client = board_client
+    service.get_board_client = lambda board_id: board_client
+    service.request_board_refresh = Mock()
+    service.mark_showing_out_of_band = Mock()
+
+    settings_service = Mock()
+    board_settings = Mock()
+    board_settings.boards = [board]
+    settings_service.get_board_settings.return_value = board_settings
+    settings_service.get_primary_board_id.return_value = "board-primary"
+    settings_service.is_paused.return_value = False
+    transition = Mock()
+    transition.strategy = None
+    transition.step_interval_ms = 0
+    transition.step_size = 1
+    settings_service.get_transition_settings.return_value = transition
+
+    with (
+        patch("src.display_runtime.get_service", return_value=service),
+        patch("src.display_runtime.peek_service", return_value=service),
+        patch("src.display_runtime.get_settings_service", return_value=settings_service),
+        patch("src.board_guards.get_settings_service", return_value=settings_service),
+        patch("src.board_guards.Config.is_silence_mode_active", return_value=False),
+        patch("src.display_runtime._publish_mqtt_state_update"),
+    ):
+        yield TestClient(app)
+
+
+def test_send_message_advertises_its_v1_successor_on_the_wire(sendable):
+    """A caller following the old docs learns where the new door is.
+
+    The header, not the schema, because the callers this matters for — a cron
+    job, a shell script, someone's Home Assistant automation — never open
+    Swagger. That is the same reasoning #1932 recorded for the eleven
+    deprecated plugin routes, and it reuses that machinery.
+    """
+    response = sendable.post("/send-message", json={"text": "HELLO"})
+
+    assert response.status_code == 200
+    assert response.headers["Deprecation"] == "true"
+    assert response.headers["Link"] == '</api/v1/boards/{board}/message>; rel="successor-version"'
+
+
+def test_send_message_carries_no_sunset(sendable):
+    """No removal date has been agreed for it, so none is announced.
+
+    An unbacked ``Sunset`` teaches integrators that the header is noise, which
+    costs more than the eleven routes that do carry a real one gain.
+    """
+    response = sendable.post("/send-message", json={"text": "HELLO"})
+    assert "Sunset" not in response.headers
+
+
+@pytest.mark.parametrize("path", ["/send-message", "/refresh"])
+def test_the_kept_operations_are_flagged_deprecated_in_the_schema(published, path):
+    """Prose and schema may not disagree — the rule #1932 established."""
+    assert published["paths"][path]["post"]["deprecated"] is True
+
+
+@pytest.mark.parametrize("path", ["/send-message", "/refresh"])
+def test_the_kept_operations_name_their_successor_in_their_description(published, path):
+    description = published["paths"][path]["post"]["description"]
+    assert description.lstrip().lower().startswith("deprecated")
+    assert "/v1/boards/{board}/message" in description

--- a/tests/test_openapi_front_page.py
+++ b/tests/test_openapi_front_page.py
@@ -11,6 +11,15 @@ These tests hold the two failure modes that silently return:
 * a new router lands with a tag nobody described, and Swagger grows another
   bare heading at the bottom;
 * the front page's worked example drifts away from a route that exists.
+
+Two documents, and which one each test reads is load-bearing. Since
+``src/v1/visibility.py`` hid the internal surface, the **published** document
+carries 33 operations across three tags, and the **internal** one
+(``/api/internal/openapi.json``) carries all ~230 across all twenty-three.
+The "nobody described this tag" failure lives in the internal document — that
+is where a new router's tag first appears — so checking it against the
+published one would go quietly vacuous the moment a router is internal, which
+is every router.
 """
 
 from __future__ import annotations
@@ -20,15 +29,22 @@ import re
 import pytest
 
 from src.api_server import API_DESCRIPTION, OPENAPI_TAGS, app
+from src.v1.visibility import build_internal_openapi
 
 
 @pytest.fixture(scope="module")
 def schema() -> dict:
+    """The published, consumer-facing document — 33 operations."""
     return app.openapi()
 
 
 @pytest.fixture(scope="module")
-def used_tags(schema) -> set[str]:
+def internal_schema() -> dict:
+    """Every operation the app serves, including the hidden ones."""
+    return build_internal_openapi(app)
+
+
+def _tags_used_by(schema: dict) -> set[str]:
     tags: set[str] = set()
     for operations in schema["paths"].values():
         for operation in operations.values():
@@ -36,48 +52,112 @@ def used_tags(schema) -> set[str]:
     return tags
 
 
-def test_every_tag_a_route_uses_is_described(used_tags, schema):
+@pytest.fixture(scope="module")
+def used_tags(internal_schema) -> set[str]:
+    """Tags used by *any* route, hidden or not — where the failure lands."""
+    return _tags_used_by(internal_schema)
+
+
+def test_every_tag_a_route_uses_is_described(used_tags, internal_schema):
     """An undescribed tag is a bare heading in the docs sidebar.
 
-    Checked against the published schema, not ``OPENAPI_TAGS``: `v1` describes
-    itself in ``src/v1/openapi.py`` and is prepended there, so the constant is
-    only one of the document's two inputs.
+    Checked against the schema, not ``OPENAPI_TAGS``: `v1` describes itself in
+    ``src/v1/openapi.py`` and is prepended there, so the constant is only one
+    of the document's two inputs.
     """
-    described = {tag["name"] for tag in schema["tags"] if tag.get("description")}
+    described = {tag["name"] for tag in internal_schema["tags"] if tag.get("description")}
     assert used_tags <= described, (
-        f"tags used by routes but not described in the published schema: {sorted(used_tags - described)}"
+        f"tags used by routes but not described in the schema: {sorted(used_tags - described)}"
     )
 
 
-def test_no_described_tag_is_stale(used_tags, schema):
+def test_no_described_tag_is_stale(used_tags, internal_schema):
     """A described tag no route uses renders an empty section."""
-    declared = {tag["name"] for tag in schema["tags"]}
+    declared = {tag["name"] for tag in internal_schema["tags"]}
     assert declared <= used_tags, f"described tags no route uses: {sorted(declared - used_tags)}"
 
 
-def test_the_tag_order_is_the_declared_order(schema):
+def test_the_published_document_describes_only_the_tags_it_publishes(schema):
+    """Twenty stale headings would be exactly the noise this surface removed.
+
+    ``build_openapi`` filters the declared tag list down to the tags the
+    document's own operations use, so hiding the internal surface takes its
+    tag descriptions with it.
+    """
+    assert {tag["name"] for tag in schema["tags"]} == _tags_used_by(schema)
+    assert len(schema["tags"]) < len(OPENAPI_TAGS)
+
+
+def test_the_tag_order_is_the_declared_order(schema, internal_schema):
     """Swagger renders tags in schema order; the consumer surface leads.
 
-    Asserted against the **published schema** rather than ``OPENAPI_TAGS``.
-    That constant is only one input: ``src/v1/openapi.py`` prepends the ``v1``
-    tag, because v1 owns its own description and cannot be imported this early
-    in ``api_server``. Comparing to the input would have pinned a list the
+    Asserted against the schema rather than ``OPENAPI_TAGS``. That constant is
+    only one input: ``src/v1/openapi.py`` prepends the ``v1`` tag, because v1
+    owns its own description and cannot be imported this early in
+    ``api_server``. Comparing to the input would have pinned a list the
     document does not actually publish.
     """
+    declared_order = ["v1"] + [tag["name"] for tag in OPENAPI_TAGS]
     published = [tag["name"] for tag in schema["tags"]]
-    assert published == ["v1"] + [tag["name"] for tag in OPENAPI_TAGS]
+
+    # The published list is the declared list filtered to what it uses, so it
+    # must be a subsequence of it — same order, no reshuffling.
+    assert published == [name for name in declared_order if name in set(published)]
     assert published[0] == "v1", "the consumer surface must be the first thing a newcomer sees"
-    assert [t["name"] for t in schema["tags"]].index("pages") < [t["name"] for t in schema["tags"]].index("debug")
+
+    internal = [tag["name"] for tag in internal_schema["tags"]]
+    assert internal == declared_order
+    assert internal.index("pages") < internal.index("debug")
 
 
-def test_the_front_page_worked_example_calls_a_route_that_exists():
+def _schema_path_for(concrete_path: str, schema: dict) -> str | None:
+    """The templated schema path a concrete URL path resolves to.
+
+    ``/v1/boards/primary/message`` is served by ``/v1/boards/{board}/message``,
+    so a literal dictionary lookup would report the front page's own worked
+    example as a route that does not exist.
+    """
+    if concrete_path in schema["paths"]:
+        return concrete_path
+    concrete_segments = concrete_path.strip("/").split("/")
+    for candidate in schema["paths"]:
+        segments = candidate.strip("/").split("/")
+        if len(segments) != len(concrete_segments):
+            continue
+        if all(
+            template.startswith("{") or template == actual
+            for template, actual in zip(segments, concrete_segments, strict=True)
+        ):
+            return candidate
+    return None
+
+
+def test_the_front_page_worked_example_calls_a_route_that_exists(schema):
     """The hello-world curl must stay executable, not become folklore."""
     match = re.search(r"curl -X (?P<method>[A-Z]+) https?://[^/]+/api(?P<path>/\S+)", API_DESCRIPTION)
     assert match, "the front page must carry a runnable curl example"
     path, method = match.group("path"), match.group("method").lower()
-    operations = app.openapi()["paths"].get(path)
-    assert operations is not None, f"front-page example calls {path}, which is not a route"
-    assert method in operations, f"front-page example uses {method.upper()} {path}; route offers {sorted(operations)}"
+    schema_path = _schema_path_for(path, schema)
+    assert schema_path is not None, f"front-page example calls {path}, which is not a published route"
+    operations = schema["paths"][schema_path]
+    assert method in operations, (
+        f"front-page example uses {method.upper()} {path}; {schema_path} offers {sorted(operations)}"
+    )
+
+
+def test_the_front_page_leads_with_the_consumer_surface():
+    """The whole point of hiding 198 operations is that /v1 is what is found.
+
+    A front page whose worked example is one of the two deprecated legacy
+    paths would leave the newcomer exactly where they started.
+    """
+    match = re.search(r"curl -X [A-Z]+ https?://[^/]+/api(?P<path>/\S+)", API_DESCRIPTION)
+    assert match and match.group("path").startswith("/v1/")
+
+
+def test_the_front_page_says_where_the_hidden_surface_went():
+    """A reader must not take "undocumented" for "removed"."""
+    assert "/api/internal/openapi.json" in API_DESCRIPTION
 
 
 def test_the_front_page_says_more_than_the_old_one_line():

--- a/tests/test_schema_honesty_contract.py
+++ b/tests/test_schema_honesty_contract.py
@@ -201,9 +201,19 @@ def _operation(spec: dict, method: str, path: str) -> dict:
 
 @pytest.fixture(scope="module")
 def openapi() -> dict:
-    from src.api_server import app
+    """The **internal** document, not the published one.
 
-    return app.openapi()
+    Every operation this file asserts on — ``/config/board``, ``/settings/*``,
+    ``/templates/render`` — is internal, and ``src/v1/visibility.py`` took all
+    of them out of ``app.openapi()``. Reading the published document here
+    would not fail loudly; the two "the rule, not the instances" tests below
+    iterate ``paths`` and would simply find nothing to object to. A green,
+    vacuous ratchet is worse than a red one.
+    """
+    from src.api_server import app
+    from src.v1.visibility import build_internal_openapi
+
+    return build_internal_openapi(app)
 
 
 class TestDeprecationIsDeclared:


### PR DESCRIPTION
## The problem, measured

On `next` @ `d01a6e34c`:

| | |
|---|---|
| Published operations | **231** |
| Of those, serving only the web UI | **179** |
| Routes using `include_in_schema=False` | **0** |

There is no consumer-facing API. There is a browser's private RPC surface,
published wholesale, and a newcomer is asked to find the front door inside it.
#1930 built the front door — `/v1`, 31 operations, four nouns. This PR is what
makes it findable.

## What a consumer sees now

**231 → 33**, dumped from `app.openapi()` and counted, not reasoned about:

```
PUBLIC OPS (over the wire) 33
NON-V1 VISIBLE: ['POST /refresh', 'POST /send-message']
PUBLIC TAGS ['v1', 'service', 'board']
INTERNAL OPS (over the wire) 231
PUBLIC SUBSET OF INTERNAL: True
```

31 `/v1` operations plus the two the published documentation already names.
Those two stay because a reader following `docs/reference/api-endpoints.md` as
written must still find them. Both are now flagged `deprecated` and both carry
`Deprecation: true` plus `Link: </api/v1/boards/{board}/message>;
rel="successor-version"` on every response.

No `Sunset` on those two, deliberately: no removal date has been agreed for
them, and an unbacked `Sunset` teaches integrators that the header is noise —
which costs more than the eleven routes that carry a real one (#1915) gain.
That reasoning is recorded in `src/api_deprecation.py`.

## How

`src/v1/visibility.py`, a sweep rather than 197 decorator edits. The rule is
"`/v1`, plus two named exceptions", and a rule is better spelled once than
restated 197 times where it can drift on the 198th route. A new internal
router is hidden the day it lands; a new *consumer* operation is a deliberate
`/v1` path.

The deprecation-header machinery from #1932 was lifted out of `api_server.py`
into `src/api_deprecation.py` and `_deprecated_route` now calls it, so the two
new users reuse one mechanism instead of growing a second.

## Hidden is not gone: `/api/internal/openapi.json`

231 operations — byte-for-byte the surface `/openapi.json` carried before —
with a front page that says outright it is not a consumer API and has no
compatibility promise. Public, exactly as `/openapi.json` was, because gating
it now would be a new restriction dressed up as a refactor.

It is built over `RouteContext` views that force `include_in_schema` to true,
so it reads the live route table and **mutates nothing**. The obvious
implementation — flip the flag back on, build, flip it off — would make the
published schema depend on whether anyone had recently fetched the internal
one, and (measured) would not even work: FastAPI ≥ 0.130 caches an
effective-route snapshot per included router that a bare attribute write does
not invalidate, so the flip yielded 45 operations, not 231.
`test_building_the_internal_document_does_not_change_the_published_one` pins
the property.

## Zero regressions

### The route table

`tests/golden/api_routes.json` does **not** record `include_in_schema`. Its
entire diff is one added route, with **zero removals and zero modifications** —
the hiding itself produced no route-table change at all:

```diff
+    {
+      "path": "/internal/openapi.json",
+      "methods": [ "GET", "HEAD" ],
+      "name": "internal_openapi",
+      "kind": "Route"
+    },
```

`kind: "Route"`, not `APIRoute`, because it is registered exactly the way
FastAPI registers `/openapi.json` itself — a sibling of the document it
serves rather than operation 232 inside it.

### Every hidden route still answers

Proven by test, not asserted. `tests/test_internal_schema.py` calls ten hidden
routes across every shape that could have broken (plain read, read behind a
path parameter, 404 path, deprecated route) and pins the status each gives
today, with a companion test asserting each of those ten is in fact hidden —
otherwise the first ten would prove nothing.

### The ratchet still covers every route it covered

`build_route_metadata()` walks `app.routes`, not the schema, so
`include_in_schema` is invisible to it. Confirmed rather than assumed — the
covered-operation list is byte-identical to `origin/next`'s:

|  | `origin/next` | this branch |
|---|---|---|
| Route-metadata records | 236 | 237 *(+1: the new route)* |
| `APIRoute` records | 231 | 231 |
| Converted domains | 22 | 22 |
| **Ratchet-covered operations** | **209** | **209** |

`diff` of the two sorted key lists: empty.

`tests/test_route_inventory.py` and `tests/test_response_shape_goldens.py`
walk `app.routes` too and were likewise unaffected — checked, not assumed.

### The suite

|  | passed | failed | skipped | collected nodes |
|---|---|---|---|---|
| `origin/next` @ `d01a6e34c` | 6782 | 1 | 2 | 6785 |
| this branch | **6825** | 1 | 2 | **6828** |

**Strict superset: 43 nodes added, zero removed** (`comm -23` of the two
sorted node-id lists is empty). The one failure is
`test_check_image_formats.py::test_no_tracked_file_in_this_repo_reaches_a_vulnerable_parser`,
which fails identically on `origin/next` and is unrelated.

**Data-dir leak count: 0**, both runs (`.pytest-data` mounted over the image's
`VOLUME /app/data`).

`ruff==0.16.5`: `All checks passed!` / `471 files already formatted` over
`src plugins tests scripts`.

## Tests pointed at the internal document, and why

This is the failure mode the change invites: a schema test that goes green
because it now checks nothing. Five needed repointing, and all five would have
failed loudly rather than passing vacuously — the intermediate run had **27
failures** before they were moved:

| File | Why |
|---|---|
| `test_schema_honesty_contract.py` | Every operation it asserts on (`/config/board`, `/settings/*`, `/templates/render`) is internal. Two of its tests are "the rule, not the instances" loops over `paths` — against the published document they would have found nothing to object to and passed. |
| `test_api_errors.py` | Asserts on `/pages/preview/batch` and `/pages/import`. |
| `test_displays_contract.py` | Asserts `/displays/{display_type}/raw` is flagged deprecated. |
| `test_api_docs.py` | operationId uniqueness and determinism. A collision needs two routes to collide; checking 33 of ~230 would leave ~197 unchecked while still passing. `/health` (its determinism probe) is internal. |
| `test_openapi_front_page.py` | The "a new router lands with an undescribed tag" failure lands in the internal document — that is where a new router's tag first appears. Against the published one it goes vacuous the moment a router is internal, which is every router. |
| `.claude/commands/check-types.md`, `.claude/agents/ts-sync-validator.md` | Both fetched `/api/openapi.json`. They would now diff 33 operations and report clean while checking almost no model. |

## Non-vacuity, observed

Per CLAUDE.md's bar, each production change was broken and the failure watched.

**A. `hide_internal_operations(app)` commented out** — 13 failures:

```
E   AssertionError: assert 231 == 33
E   AssertionError: assert ['DELETE /aut...nel_id}', ...] == []
E     Left contains 198 more items, first extra item: 'DELETE /auth/mcp-token'
E   AssertionError: assert 'GET /health' not in {'DELETE /auth/mcp-token', ...}
FAILED tests/test_internal_schema.py::test_the_sweep_covered_the_whole_route_table
FAILED tests/test_internal_schema.py::test_hiding_is_idempotent
======================== 13 failed, 26 passed in 2.36s =========================
```

**B. the `deprecation_notice` dependency removed from `POST /send-message`**:

```
E   KeyError: 'Deprecation'
FAILED tests/test_internal_schema.py::test_send_message_advertises_its_v1_successor_on_the_wire
```

**C. `mount_internal_schema(app)` commented out**:

```
FAILED tests/test_internal_schema.py::test_the_internal_document_is_served
FAILED tests/test_api_docs.py::test_the_internal_schema_is_served_at_its_documented_path
```

## Also changed

* **The `/api/docs` front page.** It led with a `curl` at `/send-message` and
  described `/settings/*`, `/config/*`, `/system/*`, `/network/*` — paths a
  reader can no longer find in the document. It now leads with
  `POST /api/v1/boards/primary/message`, and a "What is not here" section says
  where the other ~200 operations went. Two new tests hold both.
* **Tag filtering.** `build_openapi` now filters the declared tag list to the
  tags the document's own operations use, so hiding the internal surface takes
  its twenty tag descriptions with it instead of leaving stale headings. The
  internal document still declares all 23, in the declared order, and
  `test_the_tag_order_is_the_declared_order` asserts against both.

## Left open

* `docs/reference/api-endpoints.md` is still 324 hand-written lines documenting
  ~51 now-hidden operations. It gained a `:::tip` pointing at `/v1` and
  explaining that the flat paths still answer but are no longer published.
  Generating it from the schema is its own piece of work and is named in the
  design spec.
* No Swagger UI for the internal document — only the JSON. `/docs` still
  renders the consumer surface, which is the intent; a second rendered page for
  the web team would be a small addition if they want one.
* The web UI is untouched and still calls the hidden paths, which answer
  exactly as before. Migrating it onto `/v1` is phase 2 of the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mYPdfxvAKCmztHasToHzH
