### PR TITLE
fix(v1): close the five gaps the web migration found in /v1

### DIFF
--- a/src/auth/middleware.py
+++ b/src/auth/middleware.py
@@ -4,7 +4,8 @@ Activated only when ``FIESTABOARD_AUTH_ENABLED`` is truthy — otherwise it
 short-circuits to a no-op so existing local-only installs are unaffected.
 
 Public paths (no auth required):
-    * ``/`` and ``/health`` — liveness probes / nginx upstream checks
+    * ``/``, ``/health`` and ``/v1/health`` — liveness probes / nginx
+      upstream checks / the web UI's pre-session boot gate
     * ``/auth/*`` — login / setup / status itself
     * ``/openapi.json``, ``/docs``, ``/redoc`` — API docs (still useful)
     * CORS preflight (``OPTIONS``) requests
@@ -56,7 +57,15 @@ _PUBLIC_PREFIXES: tuple = (
 )
 
 # Exact paths that never require authentication.
-_PUBLIC_EXACT: frozenset = frozenset({"/", "/auth", "/health"})
+#
+# ``/v1/health`` is here for the same two reasons ``/health`` is, and it is
+# the same handler: a container liveness probe has no session to present, and
+# the web UI polls it *before* it has one to decide whether the API is up. A
+# health endpoint that answers 401 can serve neither purpose, which made the
+# whole ``/v1`` surface unusable as the one a consumer is pointed at. Both
+# nginx regimes are listed because ``/api`` is stripped from most traffic and
+# left intact on some paths — the same double form ``_is_v1_path`` handles.
+_PUBLIC_EXACT: frozenset = frozenset({"/", "/auth", "/health", "/v1/health", "/api/v1/health"})
 
 
 def _is_public_path(path: str) -> bool:

--- a/src/plugins/service.py
+++ b/src/plugins/service.py
@@ -143,6 +143,29 @@ class PluginService:
         """
         self.registry.clear_update_status(plugin_id)
 
+    # -- reads ---------------------------------------------------------------
+
+    async def fetch_data(self, plugin_id: str) -> Any:
+        """The plugin's current data, with an unavailable plugin *reported*.
+
+        Returns the registry's own :class:`~src.plugins.base.PluginResult`.
+        Only one outcome raises: :class:`PluginNotFound`, for an id the
+        registry has never heard of, because that is a mistake in the request
+        rather than a fact about the plugin. Disabled, unconfigured, a
+        transition plugin with no data, and a fetch that threw all come back
+        ``available=False`` with the reason in ``error`` — the registry
+        already distinguishes those four, and flattening them into one
+        refusal throws that away.
+
+        ``fetch_plugin_data`` makes network calls, so it runs on a worker
+        thread. Inline it would seize the single event loop for the whole
+        fetch (``tests/test_plugin_data_event_loop.py``).
+        """
+        registry = self.registry
+        if registry.get_plugin(plugin_id) is None:
+            raise PluginNotFound(f"Plugin not found: {plugin_id}")
+        return await asyncio.to_thread(registry.fetch_plugin_data, plugin_id)
+
     # -- config / enablement mutations --------------------------------------
 
     def update_plugin_config(self, plugin_id: str, config: dict[str, Any]) -> dict[str, Any]:

--- a/src/v1/models.py
+++ b/src/v1/models.py
@@ -70,6 +70,14 @@ class BoardDetail(BoardSummary):
         default=None,
         description="``characters`` decoded back to text, for reading. Null when ``characters`` is null.",
     )
+    expected_characters: list[list[int]] | None = Field(
+        default=None,
+        description=(
+            "The flap grid FiestaBoard last sent to this board. When it differs from ``characters`` the board "
+            "has drifted from what was sent — a flap that did not turn, or something else writing to the board. "
+            "Null until this instance has sent anything."
+        ),
+    )
     read_at: str | None = Field(
         default=None,
         description="When ``characters`` was read from the board (ISO 8601). Null for a live read.",
@@ -85,6 +93,14 @@ class BoardDetail(BoardSummary):
     resolved_page_id: str | None = Field(
         default=None,
         description="The page actually being displayed, with any collection resolved to a member page.",
+    )
+    resolved_next_check_seconds: int | None = Field(
+        default=None,
+        description=(
+            "Seconds until ``resolved_page_id`` may change on its own, when it came from a collection that "
+            "rotates. Poll again after this long rather than on a guessed timer. Null for a plain page and for "
+            "a collection that cannot rotate."
+        ),
     )
     source: Literal["manual", "schedule", "none"] = Field(
         description="Where ``resolved_page_id`` came from.",
@@ -236,6 +252,13 @@ class ActivePageResponse(BaseModel):
     board_id: str
     page_id: str | None = Field(description="What is now pinned. Null means nothing is.")
     sent: bool = Field(description="Whether the new page reached the board immediately.")
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Why the page did not reach the board, when ``sent`` is false. The selection is stored either way, "
+            "so a 200 here is not on its own proof that anything was displayed (#1791)."
+        ),
+    )
     warnings: list[str] = Field(
         default_factory=list,
         description="Non-fatal problems, e.g. collection members that do not fit this board.",

--- a/src/v1/routes_boards.py
+++ b/src/v1/routes_boards.py
@@ -113,7 +113,11 @@ async def list_boards() -> BoardListResponse:
     ),
 )
 async def get_board(board: str) -> BoardDetail:
-    from src.collections.service import get_collection_service, resolve_active_page_id
+    from src.collections.service import (
+        get_collection_service,
+        resolve_active_page_id,
+        resolve_next_check_seconds,
+    )
     from src.time_service import get_time_service
 
     board_id, entry = resolve_board(board)
@@ -124,15 +128,21 @@ async def get_board(board: str) -> BoardDetail:
 
     service = runtime.get_service()
     characters: list[list[int]] | None = None
+    expected_characters: list[list[int]] | None = None
     read_at: str | None = None
     if service is not None:
         rt = service.get_runtime(board_id)
         if rt is not None:
+            # What was *sent* and what the board *shows* are two different
+            # facts, and the difference is the only way a caller can notice
+            # the board has drifted — a flap that did not turn, or another
+            # writer. GET /board/current-message publishes both; so does this.
+            expected_characters = getattr(rt.client, "_last_characters", None) if rt.client is not None else None
             characters = rt.polled_characters
             if characters is not None and rt.polled_at is not None:
                 read_at = datetime.fromtimestamp(rt.polled_at, tz=UTC).isoformat()
             if characters is None:
-                characters = getattr(rt.client, "_last_characters", None) if rt.client is not None else None
+                characters = expected_characters
 
     active_page_id = settings_service.get_active_page_id(board_id=board_id)
     scheduled_page_id = None
@@ -157,10 +167,12 @@ async def get_board(board: str) -> BoardDetail:
         **base.model_dump(),
         characters=characters,
         text=characters_to_message(characters) if characters else None,
+        expected_characters=expected_characters,
         read_at=read_at,
         active_page_id=active_page_id,
         scheduled_page_id=scheduled_page_id,
         resolved_page_id=resolve_active_page_id(chosen, get_collection_service),
+        resolved_next_check_seconds=resolve_next_check_seconds(chosen, get_collection_service),
         source=source,
         default_page_id=schedule_service.get_default_page(board_id=board_id),
         override_expires_at=(override.expires_at if override is not None and board_id == primary_id else None),
@@ -486,7 +498,9 @@ async def clear_board_message(board: str) -> MessageResponse:
     description=(
         "Sets the page (or collection) this board shows until something changes it — the sticky selection a "
         "schedule falls back from. The page is rendered and sent immediately. Send `null` to unpin, after which "
-        "the board follows its schedule again. Pinning a page whose size does not match the board is rejected."
+        "the board follows its schedule again. Pinning a page whose size does not match the board is rejected.\n\n"
+        "The selection is stored whether or not the send succeeded, so check `sent` — and `error`, which names "
+        "the render or send failure when it is false."
     ),
 )
 async def set_board_active_page(board: str, request: ActivePageRequest) -> ActivePageResponse:
@@ -499,5 +513,9 @@ async def set_board_active_page(board: str, request: ActivePageRequest) -> Activ
         board_id=board_id,
         page_id=response.get("page_id"),
         sent=bool(response.get("sent_to_board")),
+        # #1791 added this to the internal response precisely so a 200 that
+        # never reached the board is detectable. Dropping it made every v1
+        # pin look like a success.
+        error=response.get("error"),
         warnings=list(response.get("warnings") or []),
     )

--- a/src/v1/routes_meta.py
+++ b/src/v1/routes_meta.py
@@ -10,9 +10,10 @@ to know to ask both.
 
 from __future__ import annotations
 
-from fastapi import Query
+from fastapi import HTTPException, Query
 
 from src.api_errors import errors
+from src.devices import DeviceType
 from src.plugins import routes as plugins_routes
 from src.service_api import routes as service_routes
 from src.service_api.models import HealthResponse, StatusResponse
@@ -86,8 +87,8 @@ async def list_functions() -> FormulaFunctionsResponse:
     description=(
         "Runs a template against the current data and gives you back the text, so you can see what a page would "
         "look like before you save it. Pass `board` — a board id or `primary` — to lay it out for that board's "
-        "size; without it the template is rendered at the default flagship geometry. Nothing is written to any "
-        "board."
+        "size, or `device_type` to lay it out for a hardware shape you have not configured a board for; without "
+        "either, the template is rendered at the default flagship geometry. Nothing is written to any board."
     ),
 )
 async def render_template(
@@ -96,14 +97,30 @@ async def render_template(
         default=None,
         description="Board id, or 'primary', whose geometry the template should be laid out for.",
     ),
+    device_type: DeviceType | None = Query(
+        default=None,
+        description=(
+            "Board shape to lay the template out for, as an alternative to naming a board. Use this to preview "
+            "a page whose device type no configured board has."
+        ),
+    ),
 ) -> TemplateRenderResponse:
-    device_type = None
+    # Geometry from a board was the only way in, so a page for a shape this
+    # install has no board of — the Note page you are writing before the Note
+    # arrives — could not be previewed at its own size at all. The board form
+    # stays the convenient default; this is the escape hatch.
+    if board is not None and device_type is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="Send either board or device_type, not both — they can disagree about the geometry.",
+        )
+    resolved: str | None = device_type
     if board is not None:
-        device_type = resolve_board(board)[1].get("device_type") or "flagship"
+        resolved = resolve_board(board)[1].get("device_type") or "flagship"
     return await templates_routes.render_template(
         TemplateRenderRequest(
             template=request.template,
-            device_type=device_type,
+            device_type=resolved,
             line_metadata=request.line_metadata,
         )
     )

--- a/src/v1/routes_plugins.py
+++ b/src/v1/routes_plugins.py
@@ -107,15 +107,37 @@ async def update_plugin(plugin_id: str, request: PluginUpdate) -> PluginDetail:
     description=(
         "The plugin's latest fetch, in both forms the internal API served separately: `data` is the raw variable "
         "payload a template reads from, and `lines`/`text` are the board-ready rendering of it. `available` is "
-        "false, with `error` set, when the plugin is disabled, unconfigured, or its source could not be reached."
+        "false, with `error` set, when the plugin is disabled, unconfigured, or its source could not be reached — "
+        "a 200, because that is the answer to the question asked. 404 means no such plugin is installed."
     ),
 )
+@plugins_routes.plugin_errors_to_http
 async def get_plugin_data(plugin_id: str) -> PluginData:
+    """Report the plugin's state rather than refusing over it.
+
+    The response model published ``available`` and ``error`` from the start,
+    but the internal handler this used to delegate to raises 400 for a
+    disabled plugin and 503 for one whose fetch failed — so neither field
+    could ever be false or set, and the schema documented a state the route
+    could not produce. The registry already answers all four unavailable
+    cases as a ``PluginResult``; v1 serves that, the way
+    ``POST /displays/raw/batch`` already does per source.
+
+    Reaching past that handler to the service is deliberate: it owns the
+    400/503 verdict the web UI depends on, and that verdict is not v1's. The
+    three ``plugins_routes`` names used here are shared plumbing — the
+    availability guard, the wired-up service, and the one error-to-status
+    table — not that handler's contract, so v1 resolves the registry through
+    exactly the seam every other plugin handler does.
+    """
     from src.displays.service import get_display_service
 
-    payload = await plugins_routes.get_plugin_data(plugin_id)
-    lines: list[str] = list(payload.formatted_lines or [])
-    if not lines and payload.available:
+    plugins_routes._require_plugin_system()
+    result = await plugins_routes._plugin_service().fetch_data(plugin_id)
+
+    available = bool(result.available)
+    lines: list[str] = list(result.formatted_lines or [])
+    if not lines and available:
         # The /displays half of the merge. A plugin that publishes no
         # formatted_lines of its own still has a board rendering — the display
         # service falls back to its data's "formatted" key — and GET
@@ -125,12 +147,12 @@ async def get_plugin_data(plugin_id: str) -> PluginData:
             lines = display.formatted.split("\n")
 
     return PluginData(
-        plugin_id=payload.plugin_id,
-        available=bool(payload.available),
-        data=payload.data,
+        plugin_id=plugin_id,
+        available=available,
+        data=result.data,
         lines=lines,
         text="\n".join(lines),
-        error=payload.error,
+        error=result.error,
     )
 
 

--- a/tests/test_v1_contract.py
+++ b/tests/test_v1_contract.py
@@ -276,6 +276,11 @@ def test_get_board_merges_the_three_reads_into_one_answer(client, boards, board_
     assert body["source"] == "manual"
     assert body["scheduled_page_id"] is None
     assert body["id"] == primary_id
+    # RE-PINNED: gained ``expected_characters`` (what was last sent, so drift
+    # from what the board shows is detectable at all) and
+    # ``resolved_next_check_seconds`` (a rotating collection's own re-poll
+    # cadence, #1513). Both are published by the internal reads this route
+    # merges and were dropped on the way through.
     assert set(body) == {
         "id",
         "name",
@@ -287,10 +292,12 @@ def test_get_board_merges_the_three_reads_into_one_answer(client, boards, board_
         "schedule_enabled",
         "characters",
         "text",
+        "expected_characters",
         "read_at",
         "active_page_id",
         "scheduled_page_id",
         "resolved_page_id",
+        "resolved_next_check_seconds",
         "source",
         "default_page_id",
         "override_expires_at",
@@ -656,7 +663,17 @@ def test_pinning_a_page_sets_it_and_reports_delivery(client, boards, board_clien
     response = client.put("/v1/boards/primary/active-page", json={"page_id": page_id})
 
     assert response.status_code == 200
-    assert response.json() == {"board_id": primary_id, "page_id": page_id, "sent": True, "warnings": []}
+    # RE-PINNED: gained ``error``, which #1791 added to the internal response
+    # so a 200 that never reached the board is detectable. Null here because
+    # this send worked; test_pinning_a_page_that_did_not_reach_the_board_says_why
+    # is the case that made it necessary.
+    assert response.json() == {
+        "board_id": primary_id,
+        "page_id": page_id,
+        "sent": True,
+        "error": None,
+        "warnings": [],
+    }
 
 
 def test_unpinning_clears_the_selection(client, boards, board_client):
@@ -846,11 +863,51 @@ def test_plugin_data_serves_both_the_raw_payload_and_the_board_lines(client):
     assert body["error"] is None
 
 
-def test_plugin_data_for_a_disabled_plugin_is_a_400(client):
+# RE-PINNED: a disabled plugin was a 400 with no body. The response model has
+# published ``available`` and ``error`` since the surface shipped, and the
+# handler it delegated to could not produce either — 400 for disabled, 503 for
+# a failed fetch. A published field that can never occur is a lie the schema
+# tells. The delegation was the half that was wrong: the registry already
+# returns available=False with the reason for all four unavailable cases, and
+# POST /displays/raw/batch already serves exactly that shape at 200. 404 stays
+# for an id that names no plugin, because that is a mistake in the request.
+def test_plugin_data_for_a_disabled_plugin_reports_it_rather_than_refusing(client):
     response = client.get("/v1/plugins/date_time/data")
 
-    assert response.status_code == 400
-    assert response.json() == {"detail": "Plugin not enabled: date_time"}
+    assert response.status_code == 200
+    assert response.json() == {
+        "plugin_id": "date_time",
+        "available": False,
+        "data": None,
+        "lines": [],
+        "text": "",
+        "error": "Plugin not enabled: date_time",
+    }
+
+
+def test_plugin_data_for_an_id_that_names_no_plugin_is_a_404(client):
+    """Availability is a fact about the plugin; a bad id is a bad request."""
+    response = client.get("/v1/plugins/nope/data")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Plugin not found: nope"}
+
+
+def test_plugin_data_reports_a_failed_fetch_rather_than_a_503(client):
+    """A source that could not be reached is the answer, not a broken instance."""
+    from src.plugins.base import PluginResult
+
+    client.patch("/v1/plugins/date_time", json={"enabled": True})
+    registry = Mock()
+    registry.get_plugin.return_value = object()
+    registry.fetch_plugin_data.return_value = PluginResult(available=False, error="Upstream timed out")
+
+    with patch("src.plugins.routes.get_plugin_registry", return_value=registry):
+        response = client.get("/v1/plugins/date_time/data")
+
+    assert response.status_code == 200
+    assert response.json()["available"] is False
+    assert response.json()["error"] == "Upstream timed out"
 
 
 # ── templating and service ──────────────────────────────────────────────────
@@ -928,3 +985,181 @@ def test_status_reports_per_board_state(client, boards, board_client):
 
     assert response.status_code == 200
     assert response.json()["boards"][primary_id]["paused"] is False
+
+
+# ── the health probe is public ──────────────────────────────────────────────
+#
+# ``GET /health`` has been in the middleware's public set since auth landed;
+# its v1 twin was not, which meant the surface a consumer is pointed at could
+# serve neither of the two things a health endpoint is for — a container
+# liveness probe (no session to present) and the web UI's boot gate (asked
+# before there is a session). Fixed in src/auth/middleware.py by adding the
+# path to ``_PUBLIC_EXACT``, alongside the one it is a twin of.
+
+
+@pytest.fixture
+def auth_enabled(client, monkeypatch):
+    """Auth switched on, an admin provisioned, and no session held.
+
+    ``/auth/setup`` logs the new user straight in, so the cookie jar is
+    cleared afterwards — otherwise every assertion below would ride on that
+    session and prove nothing about the unauthenticated path. The MCP token
+    is unset because ``src.api_server`` calls ``load_dotenv()`` at import and
+    a developer's ``.env`` can leak one into the test process.
+    """
+    from src.auth import routes as auth_routes
+
+    monkeypatch.setenv("FIESTABOARD_AUTH_ENABLED", "true")
+    monkeypatch.delenv("FIESTABOARD_MCP_TOKEN", raising=False)
+    auth_routes._FAILED_ATTEMPTS.clear()
+    created = client.post("/auth/setup", json={"username": "admin", "password": "Password123!"})
+    assert created.status_code in (200, 201), created.text
+    client.cookies.clear()
+    return client
+
+
+def test_health_answers_a_caller_with_no_credentials_at_all(auth_enabled):
+    """No cookie, no bearer, no anything — the liveness probe still answers."""
+    response = auth_enabled.get("/v1/health", headers={})
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_only_health_is_public_on_the_v1_surface(auth_enabled):
+    """The exemption is one route, not a hole in the surface.
+
+    Without this, widening ``_PUBLIC_EXACT`` to a ``/v1`` prefix would look
+    like a passing change.
+    """
+    assert auth_enabled.get("/v1/status").status_code == 401
+    assert auth_enabled.get("/v1/boards").status_code == 401
+
+
+def test_health_is_public_under_both_nginx_path_regimes():
+    """``/api`` is stripped from most traffic and left intact on some paths.
+
+    ``_is_v1_path`` already handles both forms; the public set has to as
+    well, or the exemption depends on which location block served it.
+    """
+    from src.auth.middleware import _is_public_path
+
+    assert _is_public_path("/v1/health") is True
+    assert _is_public_path("/api/v1/health") is True
+    assert _is_public_path("/v1/status") is False
+
+
+# ── drift, re-poll cadence, and a pin that never landed ─────────────────────
+
+
+def test_get_board_reports_what_was_sent_next_to_what_is_shown(client, boards):
+    """``expected_characters`` is how a caller detects the board has drifted.
+
+    ``GET /board/current-message`` publishes both halves; v1 published only
+    the polled one, so a v1 consumer could not notice a flap that failed to
+    turn — the out-of-sync alert the dashboard is built on.
+    """
+    sent = [[63] * FLAGSHIP_COLS for _ in range(FLAGSHIP_ROWS)]
+    shown = [[0] * FLAGSHIP_COLS for _ in range(FLAGSHIP_ROWS)]
+    board_client = _board_client()
+    board_client._last_characters = sent
+    service = Mock()
+    runtime = Mock()
+    runtime.polled_characters = shown
+    runtime.polled_at = 1_700_000_000.0
+    runtime.client = board_client
+    service.get_runtime.return_value = runtime
+
+    with patch(SERVICE, return_value=service), patch(RUNTIME_SERVICE, return_value=service):
+        response = client.get("/v1/boards/primary")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["characters"] == shown
+    assert body["expected_characters"] == sent
+    assert body["characters"] != body["expected_characters"]
+
+
+def test_get_board_reports_when_a_rotating_collection_may_change(client, boards, board_client):
+    """``resolved_next_check_seconds`` is the collection's own cadence (#1513).
+
+    Without it a client caches ``resolved_page_id`` on a guessed timer and
+    names the wrong page for most of the interval.
+    """
+    first = _seed_page(client, "One")
+    second = _seed_page(client, "Two")
+    collection_id = client.post("/v1/collections", json={"name": "Rotation", "page_ids": [first, second]}).json()["id"]
+    client.put("/v1/boards/primary/active-page", json={"page_id": collection_id})
+
+    body = client.get("/v1/boards/primary").json()
+
+    assert body["active_page_id"] == collection_id
+    assert isinstance(body["resolved_next_check_seconds"], int)
+    assert body["resolved_next_check_seconds"] >= 1
+
+
+def test_get_board_has_no_re_poll_cadence_for_a_plain_page(client, boards, board_client):
+    """A page that cannot rotate has no next check — null, not a made-up number."""
+    page_id = _seed_page(client)
+    client.put("/v1/boards/primary/active-page", json={"page_id": page_id})
+
+    assert client.get("/v1/boards/primary").json()["resolved_next_check_seconds"] is None
+
+
+def test_pinning_a_page_that_did_not_reach_the_board_says_why(client, boards, board_client):
+    """A 200 whose send failed must be distinguishable from one that worked.
+
+    #1791 added ``error`` to the internal response for exactly this; v1
+    dropped it, which turned every failed pin into an indistinguishable
+    success.
+    """
+    page_id = _seed_page(client)
+    board_client.render.return_value = (False, False)
+
+    response = client.put("/v1/boards/primary/active-page", json={"page_id": page_id})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["sent"] is False
+    assert body["error"] == f"Failed to send page to board: {page_id}"
+    # The selection is still stored — that is what makes the error load-bearing.
+    assert client.get("/v1/boards/primary").json()["active_page_id"] == page_id
+
+
+# ── rendering for a shape no board has ──────────────────────────────────────
+
+
+def test_render_sizes_the_output_to_an_explicit_device_type(client):
+    """Geometry from a board was the only way in, so a page for a device type
+    no configured board has could not be previewed at its own size at all."""
+    from src.settings.service import get_settings_service
+
+    get_settings_service().set_boards([{"device_type": "flagship", "name": "Kitchen"}])
+
+    response = client.post("/v1/render", json={"template": ["HI"]}, params={"device_type": "note"})
+
+    assert response.status_code == 200
+    assert response.json()["line_count"] == NOTE_ROWS
+
+
+def test_render_with_no_board_and_no_device_type_is_flagship(client):
+    response = client.post("/v1/render", json={"template": ["HI"]})
+
+    assert response.status_code == 200
+    assert response.json()["line_count"] == FLAGSHIP_ROWS
+
+
+def test_render_refuses_a_board_and_a_device_type_together(client, boards):
+    """They can disagree, and silently picking one would be the worse answer."""
+    response = client.post("/v1/render", json={"template": ["HI"]}, params={"board": "primary", "device_type": "note"})
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "Send either board or device_type, not both — they can disagree about the geometry."
+    }
+
+
+def test_render_rejects_an_unknown_device_type(client):
+    response = client.post("/v1/render", json={"template": ["HI"]}, params={"device_type": "billboard"})
+
+    assert response.status_code == 422


### PR DESCRIPTION
Migrating the web client onto `/v1` (#1934) found ten places where a v1 route
drops something its internal equivalent provides. This closes five of them —
each one a call the migration had to leave behind, so each one a reason
someone cannot use the surface `/v1` is about to be published as.

`/v1` is an adapter layer, so every fix here is either a field that was
dropped on the way through, or a delegation that disagreed with the contract
v1 published. One piece of real logic moved down into `PluginService`; nothing
new lives in `src/v1/`.

## 1 — `GET /v1/health` is public

`GET /health` has been in `_PUBLIC_EXACT` since auth landed; its v1 twin was
not, so `/v1` could serve neither of the two things a health endpoint is for —
a container liveness probe (no session to present) and the web UI's boot gate
(asked before there is a session). Extended the existing public-path set
rather than adding a second mechanism, listing both nginx regimes the way
`_is_v1_path` already does.

The exemption is one route: `GET /v1/status` and `GET /v1/boards` still 401,
pinned by `test_only_health_is_public_on_the_v1_surface` so widening this to a
`/v1` prefix cannot pass unnoticed.

## 2 — `GET /v1/plugins/{plugin}/data` — **the delegation was wrong, not the contract**

**Decision: fix the delegation.** `PluginData` has published `available` and
`error` since the surface shipped, and the handler it delegated to raises 400
for a disabled plugin and 503 for one whose fetch failed — so neither field
could ever be false or set. A published field that cannot occur is a lie the
schema tells, and a 503 where the model promised a body is the same lie in the
other direction.

Three things decided which half to change:

* **The registry already answers honestly.** `PluginRegistry.fetch_plugin_data`
  returns `PluginResult(available=False, error=...)` for all four unavailable
  cases — disabled, not found, transition plugin, fetch threw. The internal
  route flattens four distinguishable states into two refusals; nothing below
  it does.
* **This shape is already the house style for a verdict.** `POST
  /displays/raw/batch` serves exactly `available: false` + reason at 200, with
  a comment saying why ("the 200 carries `available: false` plus the reason,
  which is the answer, not a masked error"). So do `GET /config/validate`,
  `GET /network/wifi/capability` and `GET /system/update-check`, each with a
  manifest exception explaining it.
* **400 was a lie about the request.** `GET /v1/plugins` lists disabled
  plugins. A consumer that enumerates the catalogue and then reads each one's
  data got a 400 per plugin it had just been told was disabled — the caller
  did nothing wrong.

So: **200 with `available: false` + `error`** for disabled / unconfigured /
unreachable. **404** stays for an id that names no plugin, because that is a
mistake in the request rather than a fact about the plugin. **503** stays for
the plugin subsystem being unavailable.

The internal `GET /plugins/{plugin_id}/data` is **unchanged** — the web UI
consumes its 400/503 contract, and that verdict is not v1's to change here.
The shared part moved down instead: `PluginService.fetch_data` now owns the
not-found check and the threaded fetch, and v1 resolves it through
`plugins_routes._plugin_service()`, so both surfaces use the same collaborator
wiring and the same `_STATUS_BY_ERROR` table. No logic was added to `src/v1/`.

## 3 — `GET /v1/boards/{board}` reports `expected_characters`

What was *sent* and what the board *shows* are two different facts, and the
difference is the only way a caller can notice drift — a flap that did not
turn, or something else writing to the board. `GET /board/current-message`
publishes both halves; v1 published only the polled one, so a v1 consumer
could not build the dashboard's out-of-sync alert at all. Drift detection is
something FiestaBoard offers that the Vestaboard API does not, and v1 was
quietly dropping it.

## 4 — `resolved_next_check_seconds` and `error`

`GET /v1/boards/{board}` now carries `resolved_next_check_seconds` — a
rotating collection's own re-poll cadence (#1513). Without it a client caches
`resolved_page_id` on a guessed timer and names the wrong page for most of the
interval.

`PUT /v1/boards/{board}/active-page` now carries `error`. This is the more
serious of the pair: #1791 added it to the internal response precisely so a
200 that never reached the board is detectable, and v1 dropped it — turning
every failed pin into an indistinguishable success, the exact "refusal dressed
as a success" pattern this phase has been removing. The selection is persisted
whether or not the send worked, which is what makes the field load-bearing
rather than cosmetic.

## 5 — `POST /v1/render` accepts an explicit device type

Geometry came only from a *board*, so a page whose device type matches no
configured board — the Note page you write before the Note arrives — could not
be previewed at its own size at all. `?device_type=` is now an alternative to
`?board=`, typed as the `DeviceType` literal so a typo is a 422 rather than a
silent flagship render. `?board=` stays the convenient default; sending both
is a 400, because they can disagree and silently picking one is the worse
answer.

## Tests: every one failed first

Thirteen tests, written against the unmodified tree and observed failing
before the fix. Verbatim:

```
tests/test_v1_contract.py:284: in test_get_board_merges_the_three_reads_into_one_answer
E   AssertionError: assert {'active_page...e', 'id', ...} == {'active_page...racters', ...}
E     Extra items in the right set:
E     'expected_characters'
E     'resolved_next_check_seconds'
tests/test_v1_contract.py:670: in test_pinning_a_page_sets_it_and_reports_delivery
E   AssertionError: assert {'board_id': ...warnings': []} == {'board_id': ...r': None, ...}
E     Right contains 1 more item:
E     {'error': None}
tests/test_v1_contract.py:877: in test_plugin_data_for_a_disabled_plugin_reports_it_rather_than_refusing
E   assert 400 == 200
E    +  where 400 = <Response [400 Bad Request]>.status_code
tests/test_v1_contract.py:909: in test_plugin_data_reports_a_failed_fetch_rather_than_a_503
E   assert True is False
tests/test_v1_contract.py:1025: in test_health_answers_a_caller_with_no_credentials_at_all
E   assert 401 == 200
E    +  where 401 = <Response [401 Unauthorized]>.status_code
tests/test_v1_contract.py:1047: in test_health_is_public_under_both_nginx_path_regimes
E   AssertionError: assert False is True
E    +  where False = <function _is_public_path at 0xffffa88fa2a0>('/v1/health')
tests/test_v1_contract.py:1079: in test_get_board_reports_what_was_sent_next_to_what_is_shown
E   KeyError: 'expected_characters'
tests/test_v1_contract.py:1099: in test_get_board_reports_when_a_rotating_collection_may_change
E   KeyError: 'resolved_next_check_seconds'
tests/test_v1_contract.py:1108: in test_get_board_has_no_re_poll_cadence_for_a_plain_page
E   KeyError: 'resolved_next_check_seconds'
tests/test_v1_contract.py:1126: in test_pinning_a_page_that_did_not_reach_the_board_says_why
E   KeyError: 'error'
tests/test_v1_contract.py:1144: in test_render_sizes_the_output_to_an_explicit_device_type
E   assert 6 == 3
tests/test_v1_contract.py:1160: in test_render_refuses_a_board_and_a_device_type_together
E   assert 200 == 400
tests/test_v1_contract.py:1169: in test_render_rejects_an_unknown_device_type
E   assert 200 == 422

================== 13 failed, 64 passed, 3 warnings in 1.67s ===================
```

With the fix applied: `77 passed`.

### Deliberate re-pins in `tests/test_v1_contract.py`

Three, each with a comment in the file naming the change:

* `test_get_board_merges_the_three_reads_into_one_answer` — key set gains
  `expected_characters` and `resolved_next_check_seconds`.
* `test_pinning_a_page_sets_it_and_reports_delivery` — exact body gains
  `error: None`.
* `test_plugin_data_for_a_disabled_plugin_is_a_400` → renamed to
  `..._reports_it_rather_than_refusing`, 400 → 200 with the full body pinned.

Nothing else in the file changed, so the other 62 assertions are unmoved
evidence that the surface's existing promises still hold.

## Verification

**Full suite, `fb-test`, data dir mounted so a leak is visible:**

| | |
|---|---|
| `origin/next` | `1 failed, 6809 passed, 2 skipped` |
| this branch | `1 failed, 6822 passed, 2 skipped` |

A strict superset: +13, exactly the 13 new tests, nothing lost. The one
failure is the same on both sides and is environmental, not a regression —
`test_check_image_formats.py` shells out to `git ls-files`, which exits 128
inside the container because a worktree's `.git` is a file pointing outside
the mount.

**Data-dir leak count: 0.**

**Lint**, `ruff==0.16.5` over `src/ plugins/ tests/ scripts/`:

```
All checks passed!
469 files already formatted
```

**Ratchets:** `test_api_conventions_ratchet.py`, `test_layering_ratchet.py`,
`test_route_inventory.py` and `test_openapi_front_page.py` all green. No
manifest exception was added — the 200-with-a-verdict in gap 2 is a Pydantic
model field, not one of the `{"status": "error"}` / `{"success": false}` /
`{"valid": false}` literals `no_200_on_failure` looks for, and there is no
`return` inside an `except`. Route count is unchanged at 31, so
`test_v1_publishes_exactly_thirty_one_operations` needed no edit.

**Gap 1, against a running container** (image built from this branch,
`FIESTABOARD_AUTH_ENABLED=true`, admin provisioned, cookie jar empty, **no
`Authorization` header**):

```
$ curl -si http://127.0.0.1:4487/api/v1/health
HTTP/1.1 200 OK
Server: nginx/1.26.3
Date: Tue, 08 Sep 2026 08:20:01 GMT
Content-Type: application/json
Content-Length: 59
Connection: keep-alive
Vary: Accept-Encoding
X-Frame-Options: SAMEORIGIN
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block

{"status":"ok","service_running":false,"version":"8.34.17"}

$ curl -s -o /dev/null -w 'HTTP %{http_code}\n' http://127.0.0.1:4487/api/v1/status
HTTP 401
```

The 401 on `/v1/status` from the same credential-less client is what shows the
200 is an exemption for the probe and not auth being off.

## Files outside `src/v1/`

Two, both minimal and contiguous, because the gap could not be closed inside
`src/v1/`:

* `src/auth/middleware.py` — one entry added to `_PUBLIC_EXACT` plus its
  comment, and one docstring line. The whole point of gap 1 is that this is
  where the public-path decision lives.
* `src/plugins/service.py` — one new method, `PluginService.fetch_data`. Gap 2
  needs the registry's honest answer without a router's status code attached;
  per the layering ratchet's rule that is the service's job, not `src/v1/`'s.

## Scope

Five of the ten gaps, as assigned. The other five were not named in this
slice's brief, so nothing here is a decision to leave them open — they are
simply not in this PR.
