### PR TITLE
docs(api): generate the published API reference from the schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1281,18 +1281,29 @@ jobs:
         done
         echo "✅ All plugin structures valid"
 
-  # Docs quality gate: spell-check, markdown-lint, frontmatter-lint, and the
-  # docs contract check over all repository markdown (config: cspell.json,
-  # .markdownlint-cli2.jsonc). The contract check (lint-docs-contract.mjs)
-  # guards what the site repo's Docusaurus build depends on — this repo no
-  # longer builds the site, so without it a malformed doc would only fail
-  # two repos later. Runs on Node 24 because cspell 10 requires Node >= 22.18.
+  # Docs quality gate: spell-check, markdown-lint, frontmatter-lint, the docs
+  # contract check over all repository markdown (config: cspell.json,
+  # .markdownlint-cli2.jsonc), and the generated API reference's staleness
+  # check. The contract check (lint-docs-contract.mjs) guards what the site
+  # repo's Docusaurus build depends on — this repo no longer builds the site,
+  # so without it a malformed doc would only fail two repos later. Runs on
+  # Node 24 because cspell 10 requires Node >= 22.18, plus Python because
+  # docs/reference/api-endpoints.md is generated from the app's own OpenAPI
+  # document.
+  #
+  # `api` is in the condition alongside `markdown` on purpose: the API
+  # reference goes stale when a *route* changes, not when markdown changes,
+  # so gating this job on markdown alone would let every schema change
+  # through unchecked.
   lint-markdown:
     name: Lint Markdown
     runs-on: ubuntu-latest
     needs: detect-changes
-    if: needs.detect-changes.outputs.markdown == 'true' || needs.detect-changes.outputs.shared == 'true'
-    timeout-minutes: 5
+    if: >-
+      needs.detect-changes.outputs.markdown == 'true'
+      || needs.detect-changes.outputs.api == 'true'
+      || needs.detect-changes.outputs.shared == 'true'
+    timeout-minutes: 10
 
     steps:
     - uses: actions/checkout@v7
@@ -1318,6 +1329,20 @@ jobs:
 
     - name: Spell check
       run: npm run docs:lint:spell
+
+    - name: Set up Python deps
+      uses: ./.github/actions/setup-python-deps
+
+    # `--check` the way a formatter's `--check` runs: regenerate
+    # docs/reference/api-endpoints.md from `app.openapi()` and fail with a
+    # diff if the committed page differs. Without this the generator is a
+    # script somebody ran once, and the published reference starts rotting
+    # again the same day.
+    - name: Check the generated API reference is current
+      run: python scripts/generate_api_reference.py --check
+      env:
+        BOARD_READ_WRITE_KEY: test_key
+        WEATHER_API_KEY: test_key
 
   # Repo-wide broken-link check for the GitHub-rendered markdown
   # (docs/internal/**, plugins/**, root *.md). The published docs source

--- a/cspell.json
+++ b/cspell.json
@@ -39,6 +39,7 @@
     "\\w*&[a-z]+;\\w*"
   ],
   "words": [
+    "acked",
     "automations",
     "avahi",
     "balena",
@@ -95,6 +96,7 @@
     "repoint",
     "rescan",
     "retags",
+    "retarget",
     "rfkill",
     "rootdir",
     "rounddown",

--- a/docs/features/transitions.md
+++ b/docs/features/transitions.md
@@ -137,10 +137,10 @@ They only apply to built-in strategies. Transition plugins pace themselves throu
 
 ### A transition endpoint returns 404
 
-The `/transitions/*` API endpoints are gated behind the beta flag and respond `404` while it is off. See [API Endpoints](/docs/reference/api-endpoints#transition-plugin-endpoints).
+The `/transitions/*` API endpoints are gated behind the beta flag and respond `404` while it is off. They are part of the web UI's internal surface rather than the published API, so they appear in `/api/internal/openapi.json` rather than in the [API Endpoints](/docs/reference/api-endpoints) reference.
 
 ## Next Steps
 
 - [Page Editor](/docs/features/page-editor) - Set a per-page transition while you build a page
 - [Plugin Development Guide](/docs/development/plugin-guide) - Build your own transition plugin
-- [API Endpoints](/docs/reference/api-endpoints) - Drive transitions from the REST API
+- [API Endpoints](/docs/reference/api-endpoints) - The published REST API reference

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -1,360 +1,1927 @@
 ---
 sidebar_position: 1
-description: "Complete FiestaBoard REST API reference with endpoints for pages, schedules, plugins, and display control."
+description: "The generated FiestaBoard REST API reference: every published operation, its parameters, request body, responses and errors."
 keywords: [FiestaBoard API, REST API, API endpoints, API reference, display API, split-flap API]
 ---
 
+<!--
+  GENERATED FILE — DO NOT EDIT BY HAND.
+
+  Produced by scripts/generate_api_reference.py from the published OpenAPI
+  document (`app.openapi()`), so it cannot drift from the API it describes.
+  Edit the route, the Pydantic model or src/api_server.py::API_DESCRIPTION,
+  then regenerate:
+
+      python scripts/generate_api_reference.py
+
+  CI (`Lint Markdown` -> `Check the generated API reference is current`)
+  fails when this file differs from what the generator produces.
+-->
+
 # API Endpoints
 
-FiestaBoard provides a REST API powered by FastAPI. Interactive API documentation is available at `http://localhost:4420/api/docs` when FiestaBoard is running.
+FiestaBoard drives one or more split-flap displays from templated pages.
 
-:::tip Start with `/api/v1`
+## Hello world
 
-`/api/v1` is the API to build against: four nouns — board, page, schedule,
-plugin — and one way to do each thing. It is what `/api/docs` publishes, and
-it is the only surface with a compatibility promise.
+Put text on the board right now:
 
 ```bash
-curl -X POST http://localhost:4420/api/v1/boards/primary/message \
+curl -X POST http://fiestaboard.local:4420/api/v1/boards/primary/message \
   -H 'Content-Type: application/json' \
   -d '{"text": "HELLO WORLD"}'
 ```
 
-The flat paths listed below still answer exactly as they always have, but they
-are the web UI's internal channel and are no longer published in the OpenAPI
-document. `POST /send-message` and `POST /refresh` are the exceptions — they
-remain published, now marked deprecated, and each names its `/v1` replacement
-in a `Link` header.
+`primary` works as a board id on every `/v1/boards/...` path, so a
+single-board install never has to look one up — and a multi-board install
+puts the id there instead.
 
-:::
+## How the pieces fit
+
+Four nouns, and one way to do each thing:
+
+- A **board** is a physical display. `POST /v1/boards/{board}/message` writes
+  to it; `GET /v1/boards/{board}` says what is on it and why.
+
+- A **page** is a template: literal text plus `{{plugin_id.variable}}`
+  placeholders that **plugins** fill with live data.
+
+- A **schedule** (or a **collection**) decides which page a board shows at a
+  given moment. A message write bypasses both for a one-off; `DELETE
+  /v1/boards/{board}/message` hands the board back to the schedule.
 
 ## Base URL
 
-```text
-http://localhost:4420
-```
+nginx fronts the API under `/api`, so every path below is reached as
+`/api/<path>` — `GET /v1/status` is
+`http://fiestaboard.local:4420/api/v1/status`. These docs live at
+`/api/docs`, the schema at `/api/openapi.json`.
 
-When using the default deployment, prefix all paths with `/api` (e.g. `GET http://localhost:4420/api/health`).
+## What is not here
 
-## System Endpoints
+This document is the API to build against: 33 operations. The app serves
+~200 more, but they are the web UI's private RPC channel — undocumented on
+purpose, with no compatibility promise, and liable to change in any release.
+They are published separately at `/api/internal/openapi.json` for the UI's
+own contract checks. Two flat legacy operations, `POST /send-message` and
+`POST /refresh`, remain here because earlier documentation named them; both
+are deprecated and both name their `/v1` replacement in a `Link` header.
 
-### Health & Status
+## Authentication
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `GET` | `/health` | Health check, returns service health status |
-| `GET` | `/status` | Service status, uptime, and current configuration |
-| `GET` | `/config` | Current configuration settings |
+Off by default: a fresh install answers every request. With
+`FIESTABOARD_AUTH_ENABLED=true`, a script sends
+`Authorization: Bearer <token>` (create one with `POST /auth/mcp-token`),
+which is accepted on every `/v1` path and on `/api/mcp`. The web UI instead
+carries the session cookie that `POST /auth/login` sets.
 
-### Display Control
+## Credentials
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `POST` | `/refresh` | Refresh the current display |
-| `POST` | `/force-refresh` | Force refresh (bypasses preview cache) |
-| `POST` | `/send-message` | Send a custom message to a board (optional `board_id`) |
+Either credential satisfies any request; which one you hold depends on whether
+you are a script or the web UI. Both are declared in the OpenAPI document, so a
+client generator picks them up.
 
-### Service Control
+| Scheme | How it is sent | Notes |
+|--------|----------------|-------|
+| `apiToken` | `Authorization: Bearer <token>` | A FiestaBoard API token, sent as `Authorization: Bearer <token>`. Create one with `POST /auth/mcp-token` or pin one out of band with the `FIESTABOARD_MCP_TOKEN` environment variable. Accepted on every `/v1` route and on the MCP endpoint. This is the credential to use from a script: unlike the session cookie it needs no browser login flow. When no token is configured and authentication is disabled, the API is open and no credential is required — the default for a local-only install. |
+| `session` | `fiestaboard_session` (cookie) | The browser session cookie issued by `POST /auth/login`. What the web UI holds. A script should use `apiToken` instead. |
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `POST` | `/start` | Start the display service |
-| `POST` | `/stop` | Stop the display service |
+## Quick start
 
-## Page Endpoints
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `GET` | `/pages` | List all pages |
-| `POST` | `/pages` | Create a new page |
-| `GET` | `/pages/{id}` | Get a specific page |
-| `PUT` | `/pages/{id}` | Update a page |
-| `DELETE` | `/pages/{id}` | Delete a page |
-| `POST` | `/pages/{id}/preview` | Preview a page (with variables resolved) |
-
-`POST /pages` answers **201** with the created page itself, and
-`POST /pages/import` does the same. `PUT /pages/{id}` answers
-`{"page": {...}, "incompatible_references": [...]}` — the second key lists
-schedules and active-page references that no longer fit after a device/size
-change, and is empty otherwise. Failures are `{"detail": "<message>"}` with a
-4xx or 5xx status; no endpoint reports an error with HTTP 200.
-
-### Page Fields
-
-When creating or updating a page, the following fields are available:
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `name` | string | Page name (required) |
-| `type` | string | `"template"`, `"single"`, or `"composite"` |
-| `device_type` | string | `"flagship"` (22×6) or `"note"` (15×3). Default: `"flagship"` |
-| `template` | string[] | Template lines for template-type pages |
-| `duration_seconds` | number | How long to display (10–3600s, default 300) |
-
-### Batch Operations
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `POST` | `/pages/preview/batch` | Preview multiple pages at once |
-| `POST` | `/displays/raw/batch` | Get raw display data for multiple pages |
-
-## Schedule Endpoints
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `GET` | `/schedules` | List all schedule entries |
-| `POST` | `/schedules` | Create a new schedule entry |
-| `GET` | `/schedules/{id}` | Get a specific schedule entry |
-| `PUT` | `/schedules/{id}` | Update a schedule entry |
-| `DELETE` | `/schedules/{id}` | Delete a schedule entry |
-
-## Plugin Endpoints
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `GET` | `/plugins` | List all plugins with status |
-| `GET` | `/plugins/{id}` | Get plugin details |
-| `PUT` | `/plugins/{id}/config` | Update plugin configuration |
-| `POST` | `/plugins/{id}/enable` | Enable a plugin |
-| `POST` | `/plugins/{id}/disable` | Disable a plugin |
-| `GET` | `/plugins/{id}/data` | Get current plugin data |
-| `GET` | `/plugins/{id}/variables` | Get available template variables |
-
-## Settings Endpoints
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `GET` | `/settings/all` | Get all settings in a single call |
-| `GET` | `/settings/transitions` | Get transition animation settings and the built-in strategy list |
-| `PUT` | `/settings/transitions` | Update transition settings. `strategy` accepts a built-in name (`column`, `reverse-column`, `edges-to-center`, `row`, `diagonal`, `random`), `"plugin:<id>"` to drive a [transition plugin](/docs/features/transitions), or `null` for no animation |
-| `GET` | `/settings/output` | Get output target settings |
-| `PUT` | `/settings/output` | Update output target |
-| `GET` | `/settings/board` | Get board configuration |
-| `PUT` | `/settings/board` | Update board configuration |
-| `GET` | `/settings/temporary-override` | Get the current temporary override |
-| `POST` | `/settings/temporary-override` | Show a saved page — or one-off content — until it expires or is cancelled |
-| `DELETE` | `/settings/temporary-override` | Cancel the override and apply its revert mode |
-
-### Temporary Override
-
-A temporary override puts something on the board ahead of whatever the
-schedule or manual active page would show. It carries **exactly one** of:
-
-- `page_id` — a saved page or collection, or
-- `template` — one-off content that is never saved as a page.
-
-A user-initiated override deliberately beats the silence schedule, so these
-endpoints are not blocked while a board is snoozing.
-
-#### `POST /settings/temporary-override` — request body fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `page_id` | string | Saved page or collection to show. Mutually exclusive with `template` |
-| `template` | string[] | One-off board lines, never persisted as a page. Mutually exclusive with `page_id` |
-| `line_metadata` | object[] | Per-line `{ alignment, wrap }` for the `template` form |
-| `device_type` | string | Geometry the one-off was composed for: `"flagship"`, `"note"`, or `"note_array"` (default `"flagship"`) |
-| `notes_wide` / `notes_tall` | number | Note-array grid dimensions for the `template` form |
-| `duration_minutes` | number | 1–480. **Omit for an indefinite override** that lasts until it is cancelled |
-| `revert_mode` | string | `"schedule"` (default), `"blank"`, or `"page"` — what happens when a timed override expires |
-| `revert_page_id` | string | Required when `revert_mode` is `"page"` |
-
-`remaining_seconds` is `null` in the response both when no override is active
-and when the active override is indefinite. The same override block is
-embedded in `GET /schedules/active/page` so the dashboard needs no extra call.
-
-### Board Management
-
-Installs with more than one board follow a **per-board** model: each board
-has its own active page, schedule, and send routing, addressed by a
-`board_id` query param (or body field) on the relevant endpoints below.
-Omitting `board_id` always falls back to the primary board (`boards[0]`),
-which keeps single-board installs behaving exactly as before. **Pages** and
-**Collections** are not per-board — they're one shared library, and their
-pickers filter to the boards they're compatible with (see
-[Board Instance Fields](#board-instance-fields) for the size model).
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `PUT` | `/settings/board` | Update board configuration (devices, connection) |
-| `POST` | `/settings/board/add` | Add a new board instance |
-| `DELETE` | `/settings/board/{id}` | Remove a board instance |
-| `GET` | `/settings/active-page` | Get a board's active page id (`?board_id=`) |
-| `PUT` | `/settings/active-page` | Set a board's active page (renders and sends immediately) |
-| `GET` | `/silence-status` | Get a board's silence schedule status (`?board_id=`) |
-| `PUT` | `/settings/silence-schedule` | Set a board's silence schedule (`board_id` in the body) |
-| `POST` | `/pages/{id}/send` | Send a page (`?target=board&board_id=`) |
-| `GET` | `/board/current-message` | Read a board's current display (`?board_id=`) |
-
-#### `PUT /settings/board` — request body fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `boards` | object[] | Array of [BoardInstance](#board-instance-fields) objects (V2 format) |
-| `devices` | string[] | Device type list e.g. `["flagship", "note"]` (backward-compatible) |
-| `board_type` | string | Legacy field — still accepted |
-
-#### `PUT /settings/active-page` — request body fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `page_id` | string \| null | Page (or collection) id to activate, or `null` to clear |
-| `board_id` | string | Optional. Omitted → primary board (legacy behavior) |
-
-#### `PUT /settings/silence-schedule` — request body fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `enabled` | boolean | Whether silence is on for this board |
-| `start_time` | string | Window start, UTC ISO (e.g. `"04:00+00:00"`) |
-| `end_time` | string | Window end, UTC ISO |
-| `mode` | string | `"freeze"` (default), `"indicator"`, or `"page"` |
-| `page_id` | string \| null | Page shown when `mode` is `"page"`. Required in that mode, and validated against the target board's size |
-| `indicator_text` | string \| null | Text shown when `mode` is `"indicator"`. Trimmed and forced to uppercase; defaults to `SNOOZING` |
-| `indicator_position` | string \| null | `"center"` (default), `"top-left"`, `"top-right"`, `"bottom-left"`, `"bottom-right"` |
-| `board_id` | string | Optional. Unknown board → `404`. **Note the exception below** |
-
-Reads and writes here use `board_id` differently, on purpose:
-
-- **`PUT /settings/silence-schedule` without `board_id`** writes the
-  **install-wide** schedule — the default every board without its own override
-  resolves to. That is how an existing install keeps one set of quiet hours
-  until you deliberately give a board its own, and how a board you add later
-  inherits the install's quiet hours rather than staying loud. On an install
-  with exactly one board there is no such distinction, so the write also drops
-  that board's override rather than leaving it to shadow what you just saved.
-- **`GET /silence-status` without `board_id`** reports the **primary** board,
-  like every other status and send guard. It answers "is silence on right
-  now?", so it has to describe a board rather than a config layer. The response
-  echoes the board it describes. To read the install-wide layer itself, use
-  `GET /settings/all` → `silence_schedule.config`, which includes `by_board`.
-
-With `board_id`, both resolve that board: its own entry wins key by key, and
-anything it does not define falls back to the install-wide values.
-
-#### Board Instance Fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | string | UUID (auto-generated on create) |
-| `name` | string | Display name for this board |
-| `device_type` | string | `"flagship"` (22×6), `"note"` (15×3), or `"note_array"` (variable W×H) |
-| `board_color` | string | `"black"` or `"white"` |
-| `api_mode` | string | `"local"` or `"cloud"` |
-| `host` | string | Board IP address (local mode) |
-| `local_api_key` | string | Local API key |
-| `cloud_key` | string | Cloud Read/Write key |
-| `note_array_token` | string | Cloud API token (note-array boards in cloud mode) |
-| `notes_wide` / `notes_tall` | number | Note-array grid dimensions — resolves to `(notes_wide × 15) × (notes_tall × 3)` characters |
-| `enabled` | boolean | Whether this board is active |
-| `schedule_enabled` | boolean | Whether this board follows its schedule (vs. manual mode) |
-| `paused` | boolean | Whether this board's output is paused |
-
-## Transition Plugin Endpoints
-
-These endpoints back the **Transition Lab** and the transition pickers in the UI. They are gated behind the Transition Plugins beta flag (**Settings → Advanced → Beta Features**) and return `404` while it is off. See [Transitions](/docs/features/transitions) for the feature itself.
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `GET` | `/transitions/plugins` | List installed transition plugins with their settings schema, runtime caps, and `plugin:<id>` strategy string |
-| `POST` | `/transitions/preview` | Run a transition plugin in-process and return its frame sequence — nothing is sent to a board |
-| `POST` | `/transitions/test-live` | Run a transition plugin once on the real board |
-| `POST` | `/transitions/restore` | Snap a board back to its active page after a live test |
-
-### `POST /transitions/preview` — request body fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `plugin_id` | string | Transition plugin to drive (required) |
-| `to_text` | string | Text rendered into the target grid |
-| `from_text` | string | Optional. Text rendered into the starting grid. Default: blank |
-| `config` | object | Optional. Per-run overrides for the plugin's settings fields |
-| `device_type` | string | Optional. `"flagship"` (default), `"note"`, or `"note_array"` |
-| `notes_wide` / `notes_tall` | number | Optional. Note-array geometry (1–8 each) |
-
-The response is `{"frames": [{"grid": [[...]], "delay_ms": n}, ...], "total_delay_ms": n, "capped": bool, "plugin_id": "..."}`. `capped` is `true` when the plugin hit its `max_frames` or `max_runtime_seconds` limit and the sequence was truncated.
-
-### `POST /transitions/test-live` — request body fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `plugin_id` | string | Transition plugin to drive (required) |
-| `to_page_id` | string | Page the transition lands on (required) |
-| `from_page_id` | string | Optional. Page snapped to the board first, so the transition visibly starts from it |
-| `config` | object | Optional. Per-run overrides for the plugin's settings fields |
-| `board_id` | string | Optional. Omitted → primary board |
-
-Live tests respect silence mode and board pause, returning `409` rather than writing to a quiet or paused board. The board is left showing the target page — call `POST /transitions/restore` (body: optional `board_id`) to return it to its active page, or wait for the normal display loop.
-
-## Example Requests
-
-### Get Service Status
+`POST /v1/boards/{board}/message` is the front door. `primary` works as a board id on
+every `/v1/boards/...` path, so a single-board install never has to look one up.
 
 ```bash
-curl http://localhost:4420/api/status
-```
-
-### Send a Message
-
-```bash
-curl -X POST http://localhost:4420/api/send-message \
+curl -X POST http://fiestaboard.local:4420/api/v1/boards/primary/message \
+  -H "Authorization: Bearer $FIESTABOARD_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"text": "Hello World!"}'
+  -d '{"text": "HELLO WORLD"}'
 ```
 
-Message formatting: text longer than the board width is word-wrapped onto
-the following rows automatically, sized to your board's real geometry
-(6 rows × 22 columns on Flagship, 3 × 15 on Note). Width is counted in flaps,
-so a colour marker like `{red}` costs one tile, not five characters, and a word
-wider than the board is split across rows rather than cut off. A newline in the
-JSON body starts a new row, and wrapping fills within those explicit breaks.
-Lines beyond the board's row count are dropped (and logged).
+Drop the `Authorization` header on an install that has not turned
+authentication on — it is off by default.
 
-Backslashes are never reinterpreted here — JSON can already carry a real
-newline, so `{"text": "C:\\new"}` renders `C:\new` verbatim. The
-`\n`-as-line-break shorthand exists only on the MQTT plain-string
-`send_message` payload, for single-line clients that cannot type a newline;
-see [Home Assistant control](../features/home-assistant-control.md).
+## `v1` {#tag-v1}
 
-### Send a Message to a Specific Board
+The FiestaBoard API. Four nouns — board, page, schedule, plugin — and one way to do each thing.
 
-Add `board_id` to address a board other than the primary one. Board ids come
-from `GET /settings/board`.
+Start here: `POST /v1/boards/primary/message` with `{"text": "HELLO"}` puts text on your board. `primary` works as a board id on every `/v1/boards/...` path, so a single-board install never needs to look one up.
 
-```bash
-curl -X POST http://localhost:4420/api/send-message \
-  -H "Content-Type: application/json" \
-  -d '{"text": "Hello World!", "board_id": "your-board-id"}'
-```
+Every write reports what actually happened rather than merely acknowledging the request: `sent` is true only when flaps moved, and a `reason` says why when they did not.
 
-The message is sized to *that* board's geometry, and that board's own silence
-window and pause state decide whether it is delivered. An unknown board id is
-a `404`. Omitting `board_id` targets the primary board, which is what this
-endpoint has always done.
+### `GET /v1/boards` {#get-v1-boards}
 
-### List Plugins
+**List the boards this install drives**
 
-```bash
-curl http://localhost:4420/api/plugins
-```
+Every configured board, with the id you use in the rest of this API, its grid size, and whether it is currently paused or following its schedule. The board marked `is_primary` is the one the literal path segment `primary` resolves to, so a single-board install never has to look an id up at all.
 
-### Preview a Page
+**Responses**
 
-```bash
-curl -X POST http://localhost:4420/api/pages/1/preview
-```
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`BoardListResponse`](#schema-boardlistresponse) | Successful Response |
 
-## Interactive Documentation
+**Errors**
 
-For a complete interactive API explorer with request/response schemas, visit:
+| Status | Body | Meaning |
+|--------|------|---------|
+| `503` | [`ErrorResponse`](#schema-errorresponse) | A required dependency is unavailable. |
 
-```text
-http://localhost:4420/api/docs
-```
+### `GET /v1/boards/{board}` {#get-v1-boards-board}
 
-This provides a Swagger UI where you can try out any endpoint directly in your browser.
+**Read a board and everything it is doing**
 
-## Next Steps
+One answer to 'what is this board showing, and why'. It merges what the internal API splits across three endpoints: the flaps currently on the board, the page pinned to it by hand, and the page its schedule selects for right now. `source` says which of the two won. `board` may be a board id or the literal `primary`.
 
-- [Docker Setup](/docs/setup/docker-setup) - Understanding the API architecture
-- [Plugin Configuration](/docs/plugins/configuration) - Configuring plugins via API
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `board` | path | `string` | yes | — |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`BoardDetail`](#schema-boarddetail) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+| `503` | [`ErrorResponse`](#schema-errorresponse) | A required dependency is unavailable. |
+
+### `PATCH /v1/boards/{board}` {#patch-v1-boards-board}
+
+**Change how a board behaves**
+
+Rename a board, pause or resume it, turn its schedule on or off, or set the page it falls back to when the schedule has a gap. Only the fields you send are applied; omit the rest. Pausing stops every write to the board from every code path — the display loop, schedules, plugin triggers, MQTT and this API alike.
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `board` | path | `string` | yes | — |
+
+**Request body** (required) — [`BoardUpdate`](#schema-boardupdate)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | `string` \| `null` | no | Rename the board. (min length 1; max length 100) |
+| `paused` | `boolean` \| `null` | no | Pause or resume the board. While paused nothing is written to it from any code path. |
+| `schedule_enabled` | `boolean` \| `null` | no | Turn this board's schedule on or off. |
+| `default_page_id` | `string` \| `null` | no | Page shown when the schedule has a gap. Send null to clear it. |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`BoardDetail`](#schema-boarddetail) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `400` | [`ErrorResponse`](#schema-errorresponse) | Invalid request — the payload references something that does not exist or violates a rule. |
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+| `503` | [`ErrorResponse`](#schema-errorresponse) | A required dependency is unavailable. |
+
+### `POST /v1/boards/{board}/message` {#post-v1-boards-board-message}
+
+**Put something on a board**
+
+The one way to write to a board. Send exactly one of `text` (word-wrapped for you), `lines` (one string per row), `characters` (a raw flap grid), `page_id` (render a saved page) or `fill` (one flap code everywhere; 0 blanks the board).
+
+Add `duration_minutes` to make it temporary — it reverts to your schedule, a chosen page, or a blank board when the time is up. `board` may be a board id or the literal `primary`.
+
+`sent` in the response tells you whether flaps actually moved. It is false, with a `reason`, when the install's output target is UI-only and when the board already showed this exact content. A board that is paused or inside its silence window refuses the write with 409 rather than lying about it.
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `board` | path | `string` | yes | — |
+
+**Request body** (required) — [`MessageRequest (v1)`](#schema-src-v1-models-messagerequest)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `text` | `string` \| `null` | no | Plain text, word-wrapped to the board. Colour and character markers (`{red}`, `{63}`) work here. |
+| `lines` | array of `string` \| `null` | no | One string per board row, laid out without re-wrapping across rows. |
+| `characters` | array of array of `integer` \| `null` | no | A raw flap grid, sized exactly to the board. Codes are 0-71. |
+| `page_id` | `string` \| `null` | no | Render a saved page (or collection) and send the result. |
+| `fill` | `integer` \| `null` | no | Fill the whole board with one flap code (0-71). 0 blanks it. (0–71) |
+| `duration_minutes` | `integer` \| `null` | no | Show this for N minutes, then revert. Omit for a message that stays until something else replaces it. (1–480) |
+| `revert_mode` | `"schedule"` \| `"page"` \| `"blank"` \| `null` | no | What to show when a timed message expires. Requires duration_minutes. Defaults to "schedule". |
+| `revert_page_id` | `string` \| `null` | no | The page to revert to. Required when revert_mode is "page". |
+| `transition` | [`TransitionOverride`](#schema-transitionoverride) \| `null` | no | Override the install's transition animation for this one send. |
+| `force` | `boolean` | no | Send even when the board already shows this exact content, which is normally skipped. (default `false`) |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`MessageResponse`](#schema-messageresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `400` | [`ErrorResponse`](#schema-errorresponse) | Invalid request — the payload references something that does not exist or violates a rule. |
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `409` | [`ErrorResponse`](#schema-errorresponse) | Conflict — duplicate id, or a resource pinned by the environment. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+| `429` | [`ErrorResponse`](#schema-errorresponse) | Rate-limited — the request arrived inside a minimum interval; see Retry-After. |
+| `500` | [`ErrorResponse`](#schema-errorresponse) | The server could not complete the operation. Deliberately raised, not an unhandled error. |
+| `503` | [`ErrorResponse`](#schema-errorresponse) | A required dependency is unavailable. |
+
+### `DELETE /v1/boards/{board}/message` {#delete-v1-boards-board-message}
+
+**Clear a board and let its schedule take over**
+
+Undoes a `POST` to this path. Any timed message is cancelled, the board's content cache is dropped, and the display loop re-renders whatever the schedule or the pinned page says should be there — which is a blank board when nothing is scheduled. `sent` reports whether that re-render reached the board.
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `board` | path | `string` | yes | — |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`MessageResponse`](#schema-messageresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+| `500` | [`ErrorResponse`](#schema-errorresponse) | The server could not complete the operation. Deliberately raised, not an unhandled error. |
+| `503` | [`ErrorResponse`](#schema-errorresponse) | A required dependency is unavailable. |
+
+### `PUT /v1/boards/{board}/active-page` {#put-v1-boards-board-active-page}
+
+**Pin a page to a board**
+
+Sets the page (or collection) this board shows until something changes it — the sticky selection a schedule falls back from. The page is rendered and sent immediately. Send `null` to unpin, after which the board follows its schedule again. Pinning a page whose size does not match the board is rejected.
+
+The selection is stored whether or not the send succeeded, so check `sent` — and `error`, which names the render or send failure when it is false.
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `board` | path | `string` | yes | — |
+
+**Request body** (required) — [`ActivePageRequest`](#schema-activepagerequest)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `page_id` | `string` \| `null` | yes | Page or collection to pin to this board. Send null to unpin and fall back to the schedule. |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`ActivePageResponse`](#schema-activepageresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `400` | [`ErrorResponse`](#schema-errorresponse) | Invalid request — the payload references something that does not exist or violates a rule. |
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+| `502` | [`ErrorResponse`](#schema-errorresponse) | An upstream the server called on your behalf failed. |
+
+### `GET /v1/pages` {#get-v1-pages}
+
+**List saved pages**
+
+Every page saved on this install. A page is a reusable board layout — literal text, plugin variables, or rows composed from other sources — that a schedule, a collection or `POST /v1/boards/{board}/message` can refer to by id.
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`PageListResponse`](#schema-pagelistresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `503` | [`ErrorResponse`](#schema-errorresponse) | A required dependency is unavailable. |
+
+### `POST /v1/pages` {#post-v1-pages}
+
+**Create a page**
+
+Saves a new page and answers with it, including the generated `id` you refer to it by. `type` picks how it is built: `template` for text with `{{variables}}`, `single` for one plugin's output, `composite` for rows drawn from several sources. `device_type` must match the boards you intend to show it on.
+
+**Request body** (required) — [`PageCreate`](#schema-pagecreate)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | `string` | yes | min length 1; max length 100 |
+| `type` | `"single"` \| `"composite"` \| `"template"` | yes | — |
+| `device_type` | `"flagship"` \| `"note"` \| `"note_array"` | no | default `"flagship"` |
+| `display_type` | `string` \| `null` | no | — |
+| `rows` | array of [`RowConfig`](#schema-rowconfig) \| `null` | no | — |
+| `template` | array of `string` \| `null` | no | — |
+| `line_metadata` | array of [`LineMetadata`](#schema-linemetadata) \| `null` | no | — |
+| `duration_seconds` | `integer` | no | 10–3600; default `300` |
+| `transition_strategy` | `string` \| `null` | no | — |
+| `transition_interval_ms` | `integer` \| `null` | no | 0–5000 |
+| `transition_step_size` | `integer` \| `null` | no | min 1 |
+| `demo_plugin_id` | `string` \| `null` | no | — |
+| `notes_wide` | `integer` \| `null` | no | 1–8 |
+| `notes_tall` | `integer` \| `null` | no | 1–8 |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `201` | [`Page`](#schema-page) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `400` | [`ErrorResponse`](#schema-errorresponse) | Invalid request — the payload references something that does not exist or violates a rule. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+
+### `GET /v1/pages/{page_id}` {#get-v1-pages-page-id}
+
+**Read one page**
+
+The saved page with this id, exactly as stored — its type, its device size, its template or row configuration, and its per-page transition overrides. 404 when no page has this id.
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `page_id` | path | `string` | yes | — |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`Page`](#schema-page) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+
+### `PUT /v1/pages/{page_id}` {#put-v1-pages-page-id}
+
+**Update a page**
+
+Applies the fields you send and leaves the rest alone. The response carries the updated page plus `incompatible_references`: places that still point at this page — a board's schedule, a pinned selection — where your change has made the size no longer fit.
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `page_id` | path | `string` | yes | — |
+
+**Request body** (required) — [`PageUpdate`](#schema-pageupdate)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | `string` \| `null` | no | min length 1; max length 100 |
+| `device_type` | `"flagship"` \| `"note"` \| `"note_array"` \| `null` | no | — |
+| `display_type` | `string` \| `null` | no | — |
+| `rows` | array of [`RowConfig`](#schema-rowconfig) \| `null` | no | — |
+| `template` | array of `string` \| `null` | no | — |
+| `line_metadata` | array of [`LineMetadata`](#schema-linemetadata) \| `null` | no | — |
+| `duration_seconds` | `integer` \| `null` | no | 10–3600 |
+| `transition_strategy` | `string` \| `null` | no | — |
+| `transition_interval_ms` | `integer` \| `null` | no | 0–5000 |
+| `transition_step_size` | `integer` \| `null` | no | min 1 |
+| `notes_wide` | `integer` \| `null` | no | 1–8 |
+| `notes_tall` | `integer` \| `null` | no | 1–8 |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`PageUpdateResponse`](#schema-pageupdateresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `400` | [`ErrorResponse`](#schema-errorresponse) | Invalid request — the payload references something that does not exist or violates a rule. |
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+
+### `DELETE /v1/pages/{page_id}` {#delete-v1-pages-page-id}
+
+**Delete a page**
+
+Removes the page. If it was the last page, or was the one a board was showing, the response says what was put in its place so nothing is left pointing at a page that no longer exists.
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `page_id` | path | `string` | yes | — |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`PageDeleteResponse`](#schema-pagedeleteresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+
+### `GET /v1/schedules` {#get-v1-schedules}
+
+**List schedule entries**
+
+Every schedule entry, newest rules included. Pass `board_id` to narrow it to one board, or `*` for all boards at once. Each entry says which page shows between which times, on which days; the response also carries the fallback page and whether scheduling is switched on.
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `board_id` | query | `string` \| `null` | no | — |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`ScheduleListResponse`](#schema-schedulelistresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+| `503` | [`ErrorResponse`](#schema-errorresponse) | A required dependency is unavailable. |
+
+### `POST /v1/schedules` {#post-v1-schedules}
+
+**Create a schedule entry**
+
+Adds a rule: show `page_id` from `start_time` to `end_time` on the days `day_pattern` selects. Times may also be relative to sunrise or sunset (`start_type`, `start_sun_offset`), and a rule may recur weekly, on a calendar date every year, or once. Omit `board_id` for the default board.
+
+**Request body** (required) — [`ScheduleCreate`](#schema-schedulecreate)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `board_id` | `string` | no | min length 0; default `""` |
+| `page_id` | `string` | yes | min length 1 |
+| `start_time` | `string` | yes | — |
+| `end_time` | `string` \| `null` | no | — |
+| `day_pattern` | `"all"` \| `"weekdays"` \| `"weekends"` \| `"custom"` | no | default `"all"` |
+| `custom_days` | array of `string` \| `null` | no | — |
+| `enabled` | `boolean` | no | default `true` |
+| `recurrence_type` | `"weekly"` \| `"annual_date"` \| `"one_off_date"` | no | default `"weekly"` |
+| `annual_date` | `string` \| `null` | no | — |
+| `annual_end_date` | `string` \| `null` | no | — |
+| `one_off_date` | `string` \| `null` | no | — |
+| `one_off_end_date` | `string` \| `null` | no | — |
+| `start_type` | `"fixed"` \| `"sunrise"` \| `"sunset"` | no | default `"fixed"` |
+| `start_sun_offset` | `integer` | no | default `0` |
+| `end_type` | `"fixed"` \| `"sunrise"` \| `"sunset"` | no | default `"fixed"` |
+| `end_sun_offset` | `integer` | no | default `0` |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `201` | [`ScheduleWriteResponse`](#schema-schedulewriteresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `400` | [`ErrorResponse`](#schema-errorresponse) | Invalid request — the payload references something that does not exist or violates a rule. |
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+
+### `GET /v1/schedules/{schedule_id}` {#get-v1-schedules-schedule-id}
+
+**Read one schedule entry**
+
+The schedule entry with this id, plus `resolved_start_time` and `resolved_end_time` — the wall-clock times a sunrise- or sunset-relative rule works out to today.
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `schedule_id` | path | `string` | yes | — |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`ScheduleResponse`](#schema-scheduleresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+
+### `PUT /v1/schedules/{schedule_id}` {#put-v1-schedules-schedule-id}
+
+**Update a schedule entry**
+
+Applies only the fields you send, so a partial update cannot silently clear the ones you left out. `warnings` reports rules that now overlap or leave a gap without failing the write.
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `schedule_id` | path | `string` | yes | — |
+
+**Request body** (required) — [`ScheduleUpdate`](#schema-scheduleupdate)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `board_id` | `string` \| `null` | no | min length 0 |
+| `page_id` | `string` \| `null` | no | min length 1 |
+| `start_time` | `string` \| `null` | no | — |
+| `end_time` | `string` \| `null` | no | — |
+| `day_pattern` | `"all"` \| `"weekdays"` \| `"weekends"` \| `"custom"` \| `null` | no | — |
+| `custom_days` | array of `string` \| `null` | no | — |
+| `enabled` | `boolean` \| `null` | no | — |
+| `recurrence_type` | `"weekly"` \| `"annual_date"` \| `"one_off_date"` \| `null` | no | — |
+| `annual_date` | `string` \| `null` | no | — |
+| `annual_end_date` | `string` \| `null` | no | — |
+| `one_off_date` | `string` \| `null` | no | — |
+| `one_off_end_date` | `string` \| `null` | no | — |
+| `start_type` | `"fixed"` \| `"sunrise"` \| `"sunset"` \| `null` | no | — |
+| `start_sun_offset` | `integer` \| `null` | no | — |
+| `end_type` | `"fixed"` \| `"sunrise"` \| `"sunset"` \| `null` | no | — |
+| `end_sun_offset` | `integer` \| `null` | no | — |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`ScheduleWriteResponse`](#schema-schedulewriteresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `400` | [`ErrorResponse`](#schema-errorresponse) | Invalid request — the payload references something that does not exist or violates a rule. |
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+
+### `DELETE /v1/schedules/{schedule_id}` {#delete-v1-schedules-schedule-id}
+
+**Delete a schedule entry**
+
+Removes this schedule rule. The page it pointed at is untouched, and the board falls back to its remaining rules — or to its gap page when none of them match.
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `schedule_id` | path | `string` | yes | — |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`ScheduleDeleteResponse`](#schema-scheduledeleteresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+
+### `GET /v1/collections` {#get-v1-collections}
+
+**List the saved collections**
+
+Every collection. A collection is a set of pages plus a rule for choosing between them — rotate on a timer, pick at random, or switch on the value of a template expression — and it can be used anywhere a page id can.
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`CollectionListResponse`](#schema-collectionlistresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `503` | [`ErrorResponse`](#schema-errorresponse) | A required dependency is unavailable. |
+
+### `POST /v1/collections` {#post-v1-collections}
+
+**Create a collection**
+
+Saves a set of pages and how to choose between them. `selection_mode` is `time` (rotate every `time.interval_seconds`), `random`, or `variable` (evaluate `variable.rules` in order and show the first match). The generated id is prefixed `collection:` and is usable wherever a page id is.
+
+**Request body** (required) — [`CollectionCreate`](#schema-collectioncreate)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | `string` | yes | min length 1; max length 100 |
+| `page_ids` | array of `string` | yes | — |
+| `selection_mode` | `"time"` \| `"variable"` \| `"random"` | no | default `"time"` |
+| `time` | [`TimeModeConfig`](#schema-timemodeconfig) | no | — |
+| `variable` | [`VariableModeConfig`](#schema-variablemodeconfig) \| `null` | no | — |
+| `random` | [`RandomModeConfig`](#schema-randommodeconfig) \| `null` | no | — |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `201` | [`Collection`](#schema-collection) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `400` | [`ErrorResponse`](#schema-errorresponse) | Invalid request — the payload references something that does not exist or violates a rule. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+
+### `GET /v1/collections/{collection_id}` {#get-v1-collections-collection-id}
+
+**Read one collection**
+
+The collection with this id: its member page ids in order, its selection mode, and the config block for that mode — the rotation interval, or the expression rules that pick between the members.
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `collection_id` | path | `string` | yes | — |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`Collection`](#schema-collection) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+
+### `PUT /v1/collections/{collection_id}` {#put-v1-collections-collection-id}
+
+**Update a collection**
+
+Applies only the fields you send. Every page id in `page_ids` must exist, and a `variable` rule may only point at a page the collection contains.
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `collection_id` | path | `string` | yes | — |
+
+**Request body** (required) — [`CollectionUpdate`](#schema-collectionupdate)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | `string` \| `null` | no | min length 1; max length 100 |
+| `page_ids` | array of `string` \| `null` | no | — |
+| `selection_mode` | `"time"` \| `"variable"` \| `"random"` \| `null` | no | — |
+| `time` | [`TimeModeConfig`](#schema-timemodeconfig) \| `null` | no | — |
+| `variable` | [`VariableModeConfig`](#schema-variablemodeconfig) \| `null` | no | — |
+| `random` | [`RandomModeConfig`](#schema-randommodeconfig) \| `null` | no | — |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`Collection`](#schema-collection) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `400` | [`ErrorResponse`](#schema-errorresponse) | Invalid request — the payload references something that does not exist or violates a rule. |
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+
+### `DELETE /v1/collections/{collection_id}` {#delete-v1-collections-collection-id}
+
+**Delete a collection**
+
+Removes the collection. Its member pages are untouched, but anything still referring to the collection id — a schedule rule, a board's pinned selection — will stop resolving.
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `collection_id` | path | `string` | yes | — |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`CollectionDeleteResponse`](#schema-collectiondeleteresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+
+### `GET /v1/variables` {#get-v1-variables}
+
+**List every name a template can use**
+
+The whole template vocabulary in one answer: the built-in variables, everything the installed plugins contribute, the colour and symbol names, and the filters you can apply. `max_lengths` gives the longest value each variable can render to, which is what you size a row against.
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`VariableCatalog`](#schema-variablecatalog) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `503` | [`ErrorResponse`](#schema-errorresponse) | A required dependency is unavailable. |
+
+### `GET /v1/functions` {#get-v1-functions}
+
+**List the functions a template expression can call**
+
+Every function usable inside `{{ }}` — conditionals, arithmetic, text and date helpers — with its signature and a one-line summary. This is the reference for writing a collection's `variable` rules as well as for page templates.
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`FormulaFunctionsResponse`](#schema-formulafunctionsresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `503` | [`ErrorResponse`](#schema-errorresponse) | A required dependency is unavailable. |
+
+### `POST /v1/render` {#post-v1-render}
+
+**Render a template without saving or sending it**
+
+Runs a template against the current data and gives you back the text, so you can see what a page would look like before you save it. Pass `board` — a board id or `primary` — to lay it out for that board's size, or `device_type` to lay it out for a hardware shape you have not configured a board for; without either, the template is rendered at the default flagship geometry. Nothing is written to any board.
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `board` | query | `string` \| `null` | no | Board id, or 'primary', whose geometry the template should be laid out for. |
+| `device_type` | query | `"flagship"` \| `"note"` \| `"note_array"` \| `null` | no | Board shape to lay the template out for, as an alternative to naming a board. Use this to preview a page whose device type no configured board has. |
+
+**Request body** (required) — [`RenderRequest`](#schema-renderrequest)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `template` | `string` \| array of `string` | yes | A template string, or one string per board row. A list is padded to the board's height. |
+| `line_metadata` | array of `object` \| `null` | no | Per-line alignment and wrap options, one entry per line. |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`TemplateRenderResponse`](#schema-templaterenderresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `400` | [`ErrorResponse`](#schema-errorresponse) | Invalid request — the payload references something that does not exist or violates a rule. |
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+
+### `GET /v1/health` {#get-v1-health}
+
+**Check that the instance is up**
+
+Answers 200 whenever the process is serving. `service_running` reports whether the display loop — the thing that actually drives the boards — is running, which is separate from the API being reachable.
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`HealthResponse`](#schema-healthresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `503` | [`ErrorResponse`](#schema-errorresponse) | A required dependency is unavailable. |
+
+### `GET /v1/status` {#get-v1-status}
+
+**Read the display loop's state, board by board**
+
+What the instance is doing: whether the display loop is running, a summary of the resolved configuration, and per board whether it has a working connection, whether it is paused, which page it is showing, and why it failed to start if it did.
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`StatusResponse`](#schema-statusresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `503` | [`ErrorResponse`](#schema-errorresponse) | A required dependency is unavailable. |
+
+### `GET /v1/plugins` {#get-v1-plugins}
+
+**List installed plugins**
+
+Every plugin installed on this instance, whether or not it is switched on. A plugin is a data source — weather, transit, a stock ticker — that contributes template variables you can put on a page. `enabled` says whether it runs; `configured` says whether its required settings have been filled in.
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`PluginListResponse`](#schema-pluginlistresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `503` | [`ErrorResponse`](#schema-errorresponse) | A required dependency is unavailable. |
+
+### `GET /v1/plugins/{plugin_id}` {#get-v1-plugins-plugin-id}
+
+**Read one plugin**
+
+Everything about one plugin: its manifest, the template variables it contributes and their maximum lengths, its settings schema, and its current configuration. Stored secrets come back masked as `***`; sending that value back in a `PATCH` leaves the stored secret untouched.
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `plugin_id` | path | `string` | yes | — |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`PluginDetail`](#schema-plugindetail) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+| `503` | [`ErrorResponse`](#schema-errorresponse) | A required dependency is unavailable. |
+
+### `PATCH /v1/plugins/{plugin_id}` {#patch-v1-plugins-plugin-id}
+
+**Enable, disable or configure a plugin**
+
+One call for the three things you can do to a plugin. Send `enabled` to switch it on or off, `config` to replace its settings, or both — the settings are written first so a plugin is never enabled with a configuration you meant to replace. Answers with the plugin's full detail, secrets masked.
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `plugin_id` | path | `string` | yes | — |
+
+**Request body** (required) — [`PluginUpdate`](#schema-pluginupdate)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `enabled` | `boolean` \| `null` | no | Enable or disable the plugin. |
+| `config` | `object` \| `null` | no | Replace the plugin's settings. Send "***" for a secret you do not want to change. |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`PluginDetail`](#schema-plugindetail) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `400` | [`ErrorResponse`](#schema-errorresponse) | Invalid request — the payload references something that does not exist or violates a rule. |
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+| `503` | [`ErrorResponse`](#schema-errorresponse) | A required dependency is unavailable. |
+
+### `GET /v1/plugins/{plugin_id}/data` {#get-v1-plugins-plugin-id-data}
+
+**Read what a plugin is currently reporting**
+
+The plugin's latest fetch, in both forms the internal API served separately: `data` is the raw variable payload a template reads from, and `lines`/`text` are the board-ready rendering of it. `available` is false, with `error` set, when the plugin is disabled, unconfigured, or its source could not be reached — a 200, because that is the answer to the question asked. 404 means no such plugin is installed.
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `plugin_id` | path | `string` | yes | — |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`PluginData`](#schema-plugindata) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `400` | [`ErrorResponse`](#schema-errorresponse) | Invalid request — the payload references something that does not exist or violates a rule. |
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+| `503` | [`ErrorResponse`](#schema-errorresponse) | A required dependency is unavailable. |
+
+### `POST /v1/plugins/{plugin_id}/receive` {#post-v1-plugins-plugin-id-receive}
+
+**Push data into a plugin from outside**
+
+The webhook target. A plugin that declares a `receive` handler accepts a JSON body here and updates what it reports without polling anything — the way to drive a board from a system FiestaBoard cannot reach out to. 405 means this plugin does not accept pushes.
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `plugin_id` | path | `string` | yes | — |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`PluginReceiveResponse`](#schema-pluginreceiveresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `400` | [`ErrorResponse`](#schema-errorresponse) | Invalid request — the payload references something that does not exist or violates a rule. |
+| `403` | [`ErrorResponse`](#schema-errorresponse) | Forbidden. |
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `405` | [`ErrorResponse`](#schema-errorresponse) | The resource exists but does not implement this operation. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+| `503` | [`ErrorResponse`](#schema-errorresponse) | A required dependency is unavailable. |
+
+## `service` {#tag-service}
+
+The display loop itself: health, status, start/stop/refresh.
+
+### `POST /refresh` {#post-refresh}
+
+:::warning Deprecated
+
+`POST /refresh` is deprecated and answers with `Deprecation`, `Sunset` and
+`Link: rel="successor-version"` headers. Use `DELETE /v1/boards/{board}/message` instead.
+
+:::
+
+**Refresh Display**
+
+Manually trigger a display refresh.
+
+Args:
+    board_id: Optional board to refresh (query param, or
+        `{"board_id": ...}` in the JSON body). Omitted → legacy
+        behavior: refresh every board, primary first (issue #1244).
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `board_id` | query | `string` \| `null` | no | — |
+
+**Request body** (optional) — [`RefreshRequest`](#schema-refreshrequest) \| `null`
+
+_No fields._
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`RefreshResponse`](#schema-refreshresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+| `500` | [`ErrorResponse`](#schema-errorresponse) | The server could not complete the operation. Deliberately raised, not an unhandled error. |
+| `503` | [`ErrorResponse`](#schema-errorresponse) | A required dependency is unavailable. |
+
+## `board` {#tag-board}
+
+Write to a board out of band, and read back what is physically on it.
+
+### `POST /send-message` {#post-send-message}
+
+:::warning Deprecated
+
+`POST /send-message` is deprecated and answers with `Deprecation`, `Sunset` and
+`Link: rel="successor-version"` headers. Use `POST /v1/boards/{board}/message` instead.
+
+:::
+
+**Send Message**
+
+Send a custom message to a board.
+
+`board_id` (optional) targets one board; omitted → the primary board,
+which is what every caller got before this endpoint could address a
+second one (issue #1247). Gate for gate this is the same policy the MCP
+executor applies — see `src/ops/executors.py`.
+
+The v1 successor takes the board in the path, so it cannot be forgotten,
+and reports whether flaps actually moved rather than only that the
+request was accepted.
+
+**Request body** (required) — [`MessageRequest (board_api)`](#schema-src-board-api-models-messagerequest)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `text` | `string` | yes | — |
+| `board_id` | `string` \| `null` | no | — |
+
+**Responses**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`SendResponse`](#schema-sendresponse) | Successful Response |
+
+**Errors**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `404` | [`ErrorResponse`](#schema-errorresponse) | Resource not found. |
+| `409` | [`ErrorResponse`](#schema-errorresponse) | Conflict — duplicate id, or a resource pinned by the environment. |
+| `422` | [`HTTPValidationError`](#schema-httpvalidationerror) | Validation Error |
+| `429` | [`ErrorResponse`](#schema-errorresponse) | Rate-limited — the request arrived inside a minimum interval; see Retry-After. |
+| `500` | [`ErrorResponse`](#schema-errorresponse) | The server could not complete the operation. Deliberately raised, not an unhandled error. |
+| `503` | [`ErrorResponse`](#schema-errorresponse) | A required dependency is unavailable. |
+
+## Schemas
+
+Every model the operations above name, expanded once.
+
+### `ActivePageRequest` {#schema-activepagerequest}
+
+`PUT /v1/boards/{board}/active-page`.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `page_id` | `string` \| `null` | yes | Page or collection to pin to this board. Send null to unpin and fall back to the schedule. |
+
+### `ActivePageResponse` {#schema-activepageresponse}
+
+The result of pinning a page to a board.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `board_id` | `string` | yes | — |
+| `page_id` | `string` \| `null` | yes | What is now pinned. Null means nothing is. |
+| `sent` | `boolean` | yes | Whether the new page reached the board immediately. |
+| `error` | `string` \| `null` | no | Why the page did not reach the board, when `sent` is false. The selection is stored either way, so a 200 here is not on its own proof that anything was displayed (#1791). |
+| `warnings` | array of `string` | no | Non-fatal problems, e.g. collection members that do not fit this board. |
+
+### `BoardDetail` {#schema-boarddetail}
+
+One board plus what is on it right now.
+
+The merge named in the design: `GET /board/current-message` (what the
+flaps show), `GET /settings/active-page` (the sticky manual selection)
+and `GET /schedules/active/page` (what the schedule says) answered as
+one document, because "what is this board doing" is one question.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | yes | The board's stable id. Usable anywhere `{board}` appears in a v1 path. |
+| `name` | `string` | yes | Human-readable board name, as set in Settings. |
+| `device_type` | `string` | yes | Board hardware: "flagship", "note", or "note_array". |
+| `rows` | `integer` | yes | Grid height in flaps. |
+| `cols` | `integer` | yes | Grid width in flaps. |
+| `is_primary` | `boolean` | yes | True for the board that the alias "primary" resolves to. |
+| `paused` | `boolean` | yes | While true, FiestaBoard writes nothing to this board from any code path. |
+| `schedule_enabled` | `boolean` | yes | Whether this board follows its schedule rather than a fixed page. |
+| `characters` | array of array of `integer` \| `null` | no | The flap codes currently on the board, or null if nothing has been sent to it yet. |
+| `text` | `string` \| `null` | no | `characters` decoded back to text, for reading. Null when `characters` is null. |
+| `expected_characters` | array of array of `integer` \| `null` | no | The flap grid FiestaBoard last sent to this board. When it differs from `characters` the board has drifted from what was sent — a flap that did not turn, or something else writing to the board. Null until this instance has sent anything. |
+| `read_at` | `string` \| `null` | no | When `characters` was read from the board (ISO 8601). Null for a live read. |
+| `active_page_id` | `string` \| `null` | no | The page or collection pinned to this board by hand, if any. |
+| `scheduled_page_id` | `string` \| `null` | no | The page the schedule selects for right now. Null when scheduling is off or nothing matches. |
+| `resolved_page_id` | `string` \| `null` | no | The page actually being displayed, with any collection resolved to a member page. |
+| `resolved_next_check_seconds` | `integer` \| `null` | no | Seconds until `resolved_page_id` may change on its own, when it came from a collection that rotates. Poll again after this long rather than on a guessed timer. Null for a plain page and for a collection that cannot rotate. |
+| `source` | `"manual"` \| `"schedule"` \| `"none"` | yes | Where `resolved_page_id` came from. |
+| `default_page_id` | `string` \| `null` | no | The page shown when the schedule has a gap. |
+| `override_expires_at` | `string` \| `null` | no | When the active timed message expires (ISO 8601), or null if none is running. |
+
+### `BoardListResponse` {#schema-boardlistresponse}
+
+`GET /v1/boards`.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `boards` | array of [`BoardSummary`](#schema-boardsummary) | yes | — |
+| `total` | `integer` | yes | — |
+
+### `BoardStatus` {#schema-boardstatus}
+
+Per-board runtime state (issue #1244).
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `configured` | `boolean` | yes | — |
+| `paused` | `boolean` | yes | — |
+| `active_page_id` | `string` \| `null` | no | — |
+| `error` | `string` \| `null` | no | — |
+
+### `BoardSummary` {#schema-boardsummary}
+
+One board, as a consumer needs to see it.
+
+A deliberate projection, not the stored entry: `GET /settings/board`
+serves connection credentials (masked) and per-tile wiring, none of which
+a consumer writing to a board has any use for.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | yes | The board's stable id. Usable anywhere `{board}` appears in a v1 path. |
+| `name` | `string` | yes | Human-readable board name, as set in Settings. |
+| `device_type` | `string` | yes | Board hardware: "flagship", "note", or "note_array". |
+| `rows` | `integer` | yes | Grid height in flaps. |
+| `cols` | `integer` | yes | Grid width in flaps. |
+| `is_primary` | `boolean` | yes | True for the board that the alias "primary" resolves to. |
+| `paused` | `boolean` | yes | While true, FiestaBoard writes nothing to this board from any code path. |
+| `schedule_enabled` | `boolean` | yes | Whether this board follows its schedule rather than a fixed page. |
+
+### `BoardUpdate` {#schema-boardupdate}
+
+`PATCH /v1/boards/{board}` — every field optional, only what you send is applied.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | `string` \| `null` | no | Rename the board. (min length 1; max length 100) |
+| `paused` | `boolean` \| `null` | no | Pause or resume the board. While paused nothing is written to it from any code path. |
+| `schedule_enabled` | `boolean` \| `null` | no | Turn this board's schedule on or off. |
+| `default_page_id` | `string` \| `null` | no | Page shown when the schedule has a gap. Send null to clear it. |
+
+### `Collection` {#schema-collection}
+
+A collection – an ordered set of pages plus a selection mode.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | no | — |
+| `name` | `string` | yes | min length 1; max length 100 |
+| `page_ids` | array of `string` | yes | — |
+| `selection_mode` | `"time"` \| `"variable"` \| `"random"` | no | default `"time"` |
+| `time` | [`TimeModeConfig`](#schema-timemodeconfig) | no | — |
+| `variable` | [`VariableModeConfig`](#schema-variablemodeconfig) \| `null` | no | — |
+| `random` | [`RandomModeConfig`](#schema-randommodeconfig) \| `null` | no | — |
+| `created_at` | `date-time` | no | — |
+| `updated_at` | `date-time` \| `null` | no | — |
+
+### `CollectionCreate` {#schema-collectioncreate}
+
+Request model for creating a new collection.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | `string` | yes | min length 1; max length 100 |
+| `page_ids` | array of `string` | yes | — |
+| `selection_mode` | `"time"` \| `"variable"` \| `"random"` | no | default `"time"` |
+| `time` | [`TimeModeConfig`](#schema-timemodeconfig) | no | — |
+| `variable` | [`VariableModeConfig`](#schema-variablemodeconfig) \| `null` | no | — |
+| `random` | [`RandomModeConfig`](#schema-randommodeconfig) \| `null` | no | — |
+
+### `CollectionDeleteResponse` {#schema-collectiondeleteresponse}
+
+Body of `DELETE /collections/{collection_id}`.
+
+Per `docs/internal/reference/API_CONVENTIONS.md` a delete answers 200
+with the deleted resource id (this domain's choice) — not a
+`{"status": "success"}` envelope.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | yes | — |
+
+### `CollectionListResponse` {#schema-collectionlistresponse}
+
+Body of `GET /collections`.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `collections` | array of [`Collection`](#schema-collection) | yes | — |
+| `total` | `integer` | yes | — |
+
+### `CollectionUpdate` {#schema-collectionupdate}
+
+Request model for updating an existing collection.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | `string` \| `null` | no | min length 1; max length 100 |
+| `page_ids` | array of `string` \| `null` | no | — |
+| `selection_mode` | `"time"` \| `"variable"` \| `"random"` \| `null` | no | — |
+| `time` | [`TimeModeConfig`](#schema-timemodeconfig) \| `null` | no | — |
+| `variable` | [`VariableModeConfig`](#schema-variablemodeconfig) \| `null` | no | — |
+| `random` | [`RandomModeConfig`](#schema-randommodeconfig) \| `null` | no | — |
+
+### `ErrorResponse` {#schema-errorresponse}
+
+The single error body the API serves.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `detail` | `string` | yes | — |
+
+### `FormulaFunctionEntry` {#schema-formulafunctionentry}
+
+One built-in formula function, as the function picker lists it.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `category` | `string` | yes | — |
+| `signature` | `string` | yes | — |
+| `summary` | `string` | yes | — |
+
+### `FormulaFunctionsResponse` {#schema-formulafunctionsresponse}
+
+`GET /templates/formula-functions`.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `functions` | object of [`FormulaFunctionEntry`](#schema-formulafunctionentry) | yes | — |
+
+### `HealthResponse` {#schema-healthresponse}
+
+`GET|HEAD /health` — the liveness probe nginx, Docker and the boot
+gate all use.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `status` | `string` | yes | — |
+| `service_running` | `boolean` | yes | — |
+| `version` | `string` | yes | — |
+
+### `HTTPValidationError` {#schema-httpvalidationerror}
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `detail` | array of [`ValidationError`](#schema-validationerror) | no | — |
+
+### `IncompatibleReference` {#schema-incompatiblereference}
+
+A reference left pointing this page at a board it no longer fits.
+
+Produced by a device/size retarget (issue #1250, extended by #1788).
+Warn-only: the backend never mutates or removes the reference.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `board_id` | `string` | yes | — |
+| `board_name` | `string` | yes | — |
+| `surface` | `"schedule"` \| `"active_page"` \| `"silence"` | yes | — |
+| `schedule_id` | `string` \| `null` | no | — |
+
+### `LineMetadata` {#schema-linemetadata}
+
+Per-line formatting metadata for template pages.
+
+Stores alignment and wrap settings that were previously encoded as
+inline prefixes (`{center}`, `{wrap}`, etc.) in the template strings.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `alignment` | `"left"` \| `"center"` \| `"right"` | no | default `"left"` |
+| `wrap` | `boolean` | no | default `false` |
+
+### `MessageRequest (board_api)` {#schema-src-board-api-models-messagerequest}
+
+Body of `POST /send-message`.
+
+`board_id` closes the gap that made board 2 unreachable over HTTP: the
+MCP executor (`src.ops.executors.send_message`) has taken one since
+issue #1765, and this endpoint — the one the published docs recommend —
+had no spelling for it. Omitted → the primary board, which is exactly
+what every existing caller gets today.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `text` | `string` | yes | — |
+| `board_id` | `string` \| `null` | no | — |
+
+### `MessageRequest (v1)` {#schema-src-v1-models-messagerequest}
+
+`POST /v1/boards/{board}/message` — the front door.
+
+Exactly one of `text`, `lines`, `characters`, `page_id` or
+`fill` says _what_ to show. Everything else says how long and how.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `text` | `string` \| `null` | no | Plain text, word-wrapped to the board. Colour and character markers (`{red}`, `{63}`) work here. |
+| `lines` | array of `string` \| `null` | no | One string per board row, laid out without re-wrapping across rows. |
+| `characters` | array of array of `integer` \| `null` | no | A raw flap grid, sized exactly to the board. Codes are 0-71. |
+| `page_id` | `string` \| `null` | no | Render a saved page (or collection) and send the result. |
+| `fill` | `integer` \| `null` | no | Fill the whole board with one flap code (0-71). 0 blanks it. (0–71) |
+| `duration_minutes` | `integer` \| `null` | no | Show this for N minutes, then revert. Omit for a message that stays until something else replaces it. (1–480) |
+| `revert_mode` | `"schedule"` \| `"page"` \| `"blank"` \| `null` | no | What to show when a timed message expires. Requires duration_minutes. Defaults to "schedule". |
+| `revert_page_id` | `string` \| `null` | no | The page to revert to. Required when revert_mode is "page". |
+| `transition` | [`TransitionOverride`](#schema-transitionoverride) \| `null` | no | Override the install's transition animation for this one send. |
+| `force` | `boolean` | no | Send even when the board already shows this exact content, which is normally skipped. (default `false`) |
+
+### `MessageResponse` {#schema-messageresponse}
+
+What a v1 board write actually did.
+
+`sent` is the honest answer, not an acknowledgement: it is false when
+the install's output target is UI-only, when the board already showed
+this exact content, and when a timed message was queued for the display
+loop rather than written on the spot. `reason` names which.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `sent` | `boolean` | yes | True only when flaps were written to the physical board by this request. |
+| `board_id` | `string` | yes | The board this went to, with the 'primary' alias already resolved. |
+| `characters` | array of array of `integer` | yes | The flap grid this request produced, sent or not. |
+| `text` | `string` | yes | `characters` decoded back to text, for logs and confirmations. |
+| `expires_at` | `string` \| `null` | no | When a timed message reverts (ISO 8601). Null for a message with no duration. |
+| `reason` | `string` \| `null` | no | Why nothing was written, when sent is false. Null when sent is true. |
+
+### `Page` {#schema-page}
+
+A saved page configuration.
+
+Pages can be one of three types:
+
+- single: Displays a single source type
+- composite: Combines specific rows from multiple sources
+- template: Custom content with templated variables
+
+Each page targets a specific device type (flagship: 22x6, note: 15x3).
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | no | — |
+| `name` | `string` | yes | min length 1; max length 100 |
+| `type` | `"single"` \| `"composite"` \| `"template"` | yes | — |
+| `device_type` | `"flagship"` \| `"note"` \| `"note_array"` | no | default `"flagship"` |
+| `display_type` | `string` \| `null` | no | — |
+| `rows` | array of [`RowConfig`](#schema-rowconfig) \| `null` | no | — |
+| `template` | array of `string` \| `null` | no | — |
+| `line_metadata` | array of [`LineMetadata`](#schema-linemetadata) \| `null` | no | — |
+| `duration_seconds` | `integer` | no | 10–3600; default `300` |
+| `transition_strategy` | `string` \| `null` | no | — |
+| `transition_interval_ms` | `integer` \| `null` | no | 0–5000 |
+| `transition_step_size` | `integer` \| `null` | no | min 1 |
+| `demo_plugin_id` | `string` \| `null` | no | — |
+| `notes_wide` | `integer` | no | 1–8; default `1` |
+| `notes_tall` | `integer` | no | 1–8; default `1` |
+| `created_at` | `date-time` | no | — |
+| `updated_at` | `date-time` \| `null` | no | — |
+
+### `PageCreate` {#schema-pagecreate}
+
+Request model for creating a new page.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | `string` | yes | min length 1; max length 100 |
+| `type` | `"single"` \| `"composite"` \| `"template"` | yes | — |
+| `device_type` | `"flagship"` \| `"note"` \| `"note_array"` | no | default `"flagship"` |
+| `display_type` | `string` \| `null` | no | — |
+| `rows` | array of [`RowConfig`](#schema-rowconfig) \| `null` | no | — |
+| `template` | array of `string` \| `null` | no | — |
+| `line_metadata` | array of [`LineMetadata`](#schema-linemetadata) \| `null` | no | — |
+| `duration_seconds` | `integer` | no | 10–3600; default `300` |
+| `transition_strategy` | `string` \| `null` | no | — |
+| `transition_interval_ms` | `integer` \| `null` | no | 0–5000 |
+| `transition_step_size` | `integer` \| `null` | no | min 1 |
+| `demo_plugin_id` | `string` \| `null` | no | — |
+| `notes_wide` | `integer` \| `null` | no | 1–8 |
+| `notes_tall` | `integer` \| `null` | no | 1–8 |
+
+### `PageDeleteResponse` {#schema-pagedeleteresponse}
+
+`DELETE /pages/{page_id}` — the deleted id plus what else moved.
+
+Deleting the last page auto-creates a default welcome page, and deleting
+the active page re-points the active reference; both are reported here so
+the client can follow without re-fetching everything.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | yes | — |
+| `message` | `string` | yes | — |
+| `default_page_created` | `boolean` | no | default `false` |
+| `new_page_id` | `string` \| `null` | no | — |
+| `active_page_updated` | `boolean` | no | default `false` |
+| `new_active_page_id` | `string` \| `null` | no | — |
+
+### `PageListResponse` {#schema-pagelistresponse}
+
+`GET /pages` — every saved page, plus the count.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `pages` | array of [`Page`](#schema-page) | yes | — |
+| `total` | `integer` | yes | — |
+
+### `PageUpdate` {#schema-pageupdate}
+
+Request model for updating an existing page.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | `string` \| `null` | no | min length 1; max length 100 |
+| `device_type` | `"flagship"` \| `"note"` \| `"note_array"` \| `null` | no | — |
+| `display_type` | `string` \| `null` | no | — |
+| `rows` | array of [`RowConfig`](#schema-rowconfig) \| `null` | no | — |
+| `template` | array of `string` \| `null` | no | — |
+| `line_metadata` | array of [`LineMetadata`](#schema-linemetadata) \| `null` | no | — |
+| `duration_seconds` | `integer` \| `null` | no | 10–3600 |
+| `transition_strategy` | `string` \| `null` | no | — |
+| `transition_interval_ms` | `integer` \| `null` | no | 0–5000 |
+| `transition_step_size` | `integer` \| `null` | no | min 1 |
+| `notes_wide` | `integer` \| `null` | no | 1–8 |
+| `notes_tall` | `integer` \| `null` | no | 1–8 |
+
+### `PageUpdateResponse` {#schema-pageupdateresponse}
+
+`PUT /pages/{page_id}` — the updated page and its stale references.
+
+Not a bare `Page` because the retarget warning is genuine payload, not
+an envelope: the editor shows it to the user after a size change.
+`incompatible_references` is always present and empty when the update
+did not change the page's size.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `page` | [`Page`](#schema-page) | yes | — |
+| `incompatible_references` | array of [`IncompatibleReference`](#schema-incompatiblereference) | no | — |
+
+### `PluginData` {#schema-plugindata}
+
+`GET /v1/plugins/{plugin}/data` — the merge of the raw and formatted reads.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `plugin_id` | `string` | yes | — |
+| `available` | `boolean` | yes | False when the plugin is disabled, unconfigured, or its fetch failed. |
+| `data` | `object` \| `null` | no | The plugin's own variable payload. |
+| `lines` | array of `string` | no | The plugin's board-ready lines, as GET /displays/`{type}` served them. |
+| `text` | `string` | no | `lines` joined with newlines. (default `""`) |
+| `error` | `string` \| `null` | no | Why the data is unavailable, when it is. |
+
+### `PluginDetail` {#schema-plugindetail}
+
+`GET /plugins/{plugin_id}` — derived, masked, and its own model.
+
+`config` is the **stored** configuration with sensitive values masked,
+deliberately _without_ the env-var overlay: this response feeds the
+settings form, and any value baked in here comes straight back in the next
+save, so serving the overlay would freeze env values into `config.json`
+(#1864 review). Which keys the environment currently controls is reported
+separately in `env_overridden_keys`, values excluded.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | yes | — |
+| `name` | `string` | yes | — |
+| `version` | `string` | yes | — |
+| `description` | `string` | no | default `""` |
+| `author` | `string` | no | default `""` |
+| `icon` | `string` \| `null` | no | — |
+| `category` | `string` \| `null` | no | — |
+| `plugin_type` | `string` | no | default `"data"` |
+| `enabled` | `boolean` | yes | — |
+| `config` | `object` | yes | — |
+| `env_overridden_keys` | array of `string` | yes | — |
+| `settings_schema` | `object` | yes | — |
+| `variables` | `object` | yes | — |
+| `max_lengths` | `object` | yes | — |
+| `env_vars` | array of `any` | yes | — |
+| `documentation` | `string` \| `null` | no | — |
+| `has_demo` | `boolean` | yes | — |
+| `demo_page_id` | `string` \| `null` | no | — |
+| `instance_label` | `string` \| `null` | no | — |
+| `base_plugin_id` | `string` \| `null` | no | — |
+| `instances` | array of [`PluginInstanceInfo`](#schema-plugininstanceinfo) | yes | — |
+
+### `PluginEntry` {#schema-pluginentry}
+
+One plugin in the merged catalogue.
+
+`GET /plugins` and `GET /displays` are the same registry listing seen
+twice — `/displays` is a four-field projection of it. v1 publishes one
+catalogue, with the display projection's `available` folded in.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | yes | Plugin id. Usable anywhere `{plugin}` appears in a v1 path. |
+| `name` | `string` | yes | — |
+| `version` | `string` | yes | — |
+| `description` | `string` | no | default `""` |
+| `author` | `string` | no | default `""` |
+| `category` | `string` \| `null` | no | — |
+| `plugin_type` | `string` | no | "data" for a content source, "transition" for an animation. (default `"data"`) |
+| `icon` | `string` \| `null` | no | — |
+| `enabled` | `boolean` | yes | Whether this plugin runs and contributes template variables. |
+| `configured` | `boolean` | yes | Whether its required settings have been filled in. |
+
+### `PluginInstanceInfo` {#schema-plugininstanceinfo}
+
+One named instance of a plugin.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `label` | `string` | yes | — |
+| `key` | `string` \| `null` | no | — |
+| `enabled` | `boolean` | no | default `false` |
+| `has_config` | `boolean` | no | default `false` |
+
+### `PluginListResponse` {#schema-pluginlistresponse}
+
+`GET /v1/plugins`.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `plugins` | array of [`PluginEntry`](#schema-pluginentry) | yes | — |
+| `total` | `integer` | yes | — |
+| `enabled_count` | `integer` | yes | — |
+
+### `PluginReceiveResponse` {#schema-pluginreceiveresponse}
+
+`POST /plugins/{plugin_id}/receive`.
+
+The `status` key survives the conventions pass on purpose: this endpoint
+is a **webhook target for third-party systems** (CI pipelines, home
+automations) that this repo does not control and cannot update in lockstep.
+"Deprecation, never deletion" applies to it more literally than to any
+browser-facing route. `plugin_id` is added so the ack names what it
+acked.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `status` | `string` | no | default `"ok"` |
+| `plugin_id` | `string` | yes | — |
+
+### `PluginUpdate` {#schema-pluginupdate}
+
+`PATCH /v1/plugins/{plugin}`.
+
+Collapses `POST /plugins/{plugin_id}/enable`,
+`POST /plugins/{plugin_id}/disable` and `PUT /plugins/{plugin_id}/config`
+into one call. `config` stays a free-form map on purpose: a typed body would
+reject the `"***"` sentinel the API serves in place of a stored secret,
+which is what a client round-trips when it edits one field of a form.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `enabled` | `boolean` \| `null` | no | Enable or disable the plugin. |
+| `config` | `object` \| `null` | no | Replace the plugin's settings. Send "***" for a secret you do not want to change. |
+
+### `RandomModeConfig` {#schema-randommodeconfig}
+
+Settings for random page selection.
+
+`interval_seconds` is the page duration — how long each randomly chosen
+page is shown before a new one is selected.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `interval_seconds` | `integer` | no | 5–86400; default `30` |
+
+### `RefreshRequest` {#schema-refreshrequest}
+
+Optional body of `POST /refresh`.
+
+`board_id` may also arrive as a query parameter; the query wins when
+both are present, which is what the pre-conversion handler did.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `board_id` | `string` \| `null` | no | — |
+
+### `RefreshResponse` {#schema-refreshresponse}
+
+`POST /refresh` — what the refresh pass did.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `message` | `string` | yes | — |
+| `board_id` | `string` \| `null` | no | — |
+| `sent` | `boolean` | yes | — |
+
+### `RenderRequest` {#schema-renderrequest}
+
+`POST /v1/render` — render a template without saving or sending it.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `template` | `string` \| array of `string` | yes | A template string, or one string per board row. A list is padded to the board's height. |
+| `line_metadata` | array of `object` \| `null` | no | Per-line alignment and wrap options, one entry per line. |
+
+### `RowConfig` {#schema-rowconfig}
+
+Configuration for a single row in a composite page.
+
+Specifies which row from which source should be placed at which position.
+Row limits depend on the device type of the parent page.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `source` | `string` | yes | — |
+| `row_index` | `integer` | yes | min 0 |
+| `target_row` | `integer` | yes | min 0 |
+
+### `ScheduleCreate` {#schema-schedulecreate}
+
+Request model for creating a new schedule entry.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `board_id` | `string` | no | min length 0; default `""` |
+| `page_id` | `string` | yes | min length 1 |
+| `start_time` | `string` | yes | — |
+| `end_time` | `string` \| `null` | no | — |
+| `day_pattern` | `"all"` \| `"weekdays"` \| `"weekends"` \| `"custom"` | no | default `"all"` |
+| `custom_days` | array of `string` \| `null` | no | — |
+| `enabled` | `boolean` | no | default `true` |
+| `recurrence_type` | `"weekly"` \| `"annual_date"` \| `"one_off_date"` | no | default `"weekly"` |
+| `annual_date` | `string` \| `null` | no | — |
+| `annual_end_date` | `string` \| `null` | no | — |
+| `one_off_date` | `string` \| `null` | no | — |
+| `one_off_end_date` | `string` \| `null` | no | — |
+| `start_type` | `"fixed"` \| `"sunrise"` \| `"sunset"` | no | default `"fixed"` |
+| `start_sun_offset` | `integer` | no | default `0` |
+| `end_type` | `"fixed"` \| `"sunrise"` \| `"sunset"` | no | default `"fixed"` |
+| `end_sun_offset` | `integer` | no | default `0` |
+
+### `ScheduleDeleteResponse` {#schema-scheduledeleteresponse}
+
+The id of the schedule that was deleted.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | yes | — |
+
+### `ScheduleListResponse` {#schema-schedulelistresponse}
+
+What `GET /schedules` answers with.
+
+`default_page_id` and `enabled` are per-board, so both are `null` on
+the cross-board listing (`board_id=*`) — that listing has no single board
+to answer for.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `schedules` | array of [`ScheduleResponse`](#schema-scheduleresponse) | yes | — |
+| `total` | `integer` | yes | — |
+| `default_page_id` | `string` \| `null` | no | — |
+| `enabled` | `boolean` \| `null` | no | — |
+
+### `ScheduleResponse` {#schema-scheduleresponse}
+
+A schedule as the API serves it: the stored entry plus today's times.
+
+`resolved_*` equals the stored time for fixed schedules and the computed
+sunrise/sunset time for sun-based ones, so a client never has to know the
+install's location to render the window.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | no | — |
+| `board_id` | `string` | no | min length 0; default `""` |
+| `page_id` | `string` | yes | min length 1 |
+| `start_time` | `string` | yes | — |
+| `end_time` | `string` \| `null` | no | — |
+| `day_pattern` | `"all"` \| `"weekdays"` \| `"weekends"` \| `"custom"` | no | default `"all"` |
+| `custom_days` | array of `string` \| `null` | no | — |
+| `enabled` | `boolean` | no | default `true` |
+| `recurrence_type` | `"weekly"` \| `"annual_date"` \| `"one_off_date"` | no | default `"weekly"` |
+| `annual_date` | `string` \| `null` | no | — |
+| `annual_end_date` | `string` \| `null` | no | — |
+| `one_off_date` | `string` \| `null` | no | — |
+| `one_off_end_date` | `string` \| `null` | no | — |
+| `start_type` | `"fixed"` \| `"sunrise"` \| `"sunset"` | no | default `"fixed"` |
+| `start_sun_offset` | `integer` | no | default `0` |
+| `end_type` | `"fixed"` \| `"sunrise"` \| `"sunset"` | no | default `"fixed"` |
+| `end_sun_offset` | `integer` | no | default `0` |
+| `created_at` | `date-time` | no | — |
+| `updated_at` | `date-time` \| `null` | no | — |
+| `resolved_start_time` | `string` | yes | — |
+| `resolved_end_time` | `string` \| `null` | no | — |
+
+### `ScheduleUpdate` {#schema-scheduleupdate}
+
+Request model for updating an existing schedule entry.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `board_id` | `string` \| `null` | no | min length 0 |
+| `page_id` | `string` \| `null` | no | min length 1 |
+| `start_time` | `string` \| `null` | no | — |
+| `end_time` | `string` \| `null` | no | — |
+| `day_pattern` | `"all"` \| `"weekdays"` \| `"weekends"` \| `"custom"` \| `null` | no | — |
+| `custom_days` | array of `string` \| `null` | no | — |
+| `enabled` | `boolean` \| `null` | no | — |
+| `recurrence_type` | `"weekly"` \| `"annual_date"` \| `"one_off_date"` \| `null` | no | — |
+| `annual_date` | `string` \| `null` | no | — |
+| `annual_end_date` | `string` \| `null` | no | — |
+| `one_off_date` | `string` \| `null` | no | — |
+| `one_off_end_date` | `string` \| `null` | no | — |
+| `start_type` | `"fixed"` \| `"sunrise"` \| `"sunset"` \| `null` | no | — |
+| `start_sun_offset` | `integer` \| `null` | no | — |
+| `end_type` | `"fixed"` \| `"sunrise"` \| `"sunset"` \| `null` | no | — |
+| `end_sun_offset` | `integer` \| `null` | no | — |
+
+### `ScheduleWriteResponse` {#schema-schedulewriteresponse}
+
+What create and update answer with.
+
+`warnings` carries the non-fatal page&lt;->board size mismatches of issue
+\#1245 — a collection may mix page sizes, and the write is allowed as long
+as one member fits. The key was previously _omitted_ when there was nothing
+to warn about, so a client could not tell "no warnings" from "this server
+doesn't report warnings"; it is now always present and empty when clean.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | no | — |
+| `board_id` | `string` | no | min length 0; default `""` |
+| `page_id` | `string` | yes | min length 1 |
+| `start_time` | `string` | yes | — |
+| `end_time` | `string` \| `null` | no | — |
+| `day_pattern` | `"all"` \| `"weekdays"` \| `"weekends"` \| `"custom"` | no | default `"all"` |
+| `custom_days` | array of `string` \| `null` | no | — |
+| `enabled` | `boolean` | no | default `true` |
+| `recurrence_type` | `"weekly"` \| `"annual_date"` \| `"one_off_date"` | no | default `"weekly"` |
+| `annual_date` | `string` \| `null` | no | — |
+| `annual_end_date` | `string` \| `null` | no | — |
+| `one_off_date` | `string` \| `null` | no | — |
+| `one_off_end_date` | `string` \| `null` | no | — |
+| `start_type` | `"fixed"` \| `"sunrise"` \| `"sunset"` | no | default `"fixed"` |
+| `start_sun_offset` | `integer` | no | default `0` |
+| `end_type` | `"fixed"` \| `"sunrise"` \| `"sunset"` | no | default `"fixed"` |
+| `end_sun_offset` | `integer` | no | default `0` |
+| `created_at` | `date-time` | no | — |
+| `updated_at` | `date-time` \| `null` | no | — |
+| `resolved_start_time` | `string` | yes | — |
+| `resolved_end_time` | `string` \| `null` | no | — |
+| `warnings` | array of `string` | no | — |
+
+### `SendResponse` {#schema-sendresponse}
+
+The outcome of an out-of-band write.
+
+`sent` is False when the content was identical to what the board
+already shows — the write was correctly skipped, not refused. Every other
+non-delivery (paused board, silence window, send floor, board failure) is
+a status code, not a flag.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `message` | `string` | yes | — |
+| `sent` | `boolean` | yes | — |
+
+### `StatusResponse` {#schema-statusresponse}
+
+`GET /status` — the display loop's state plus a per-board breakdown.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `running` | `boolean` | yes | — |
+| `initialized` | `boolean` | yes | — |
+| `config_summary` | `object` | yes | — |
+| `boards` | object of [`BoardStatus`](#schema-boardstatus) | no | default `{}` |
+
+### `TemplateRenderResponse` {#schema-templaterenderresponse}
+
+`POST /templates/render`.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `rendered` | `string` | yes | — |
+| `lines` | array of `string` | yes | — |
+| `line_count` | `integer` | yes | — |
+
+### `TimeModeConfig` {#schema-timemodeconfig}
+
+Settings for time-based rotation (classic carousel).
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `interval_seconds` | `integer` | no | 5–86400; default `30` |
+
+### `TransitionOverride` {#schema-transitionoverride}
+
+Per-send transition animation, overriding the install's settings.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `strategy` | `string` \| `null` | no | Transition strategy name, e.g. "instant" or "wipe". |
+| `interval_ms` | `integer` \| `null` | no | Milliseconds between animation steps. (0–5000) |
+| `step_size` | `integer` \| `null` | no | Flaps advanced per animation step. (min 1) |
+
+### `ValidationError` {#schema-validationerror}
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `loc` | array of `string` \| `integer` | yes | — |
+| `msg` | `string` | yes | — |
+| `type` | `string` | yes | — |
+| `input` | `any` | no | — |
+| `ctx` | `object` | no | — |
+
+### `VariableCatalog` {#schema-variablecatalog}
+
+`GET /v1/variables` — every name a template may use, from both sources.
+
+Merges `GET /templates/variables` (the engine's vocabulary plus the
+static colour, symbol and filter tables) with `GET
+/plugins/variables/all` (what installed plugins contribute). They were
+two endpoints answering one question.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `variables` | object of array of `string` | yes | Variable names grouped by their source namespace. |
+| `max_lengths` | object of `integer` | yes | Longest value each variable can render to, for layout. |
+| `variable_metadata` | `object` | no | Per-variable descriptions and types. |
+| `variable_groups` | `object` | no | Display grouping for editors. |
+| `colors` | object of `integer` | yes | Colour names to flap codes, e.g. &#123;"red": 63&#125;. |
+| `symbols` | array of `string` | yes | Symbol names usable as `{sun}`, `{star}` and so on. |
+| `filters` | array of `string` | yes | Filters usable after a variable, e.g. &#123;&#123;x\|pad:5&#125;&#125;. |
+| `formatting` | `object` | yes | Layout helpers such as fill_space. |
+| `syntax_examples` | object of `string` | yes | Worked examples of the template syntax. |
+| `plugin_system_enabled` | `boolean` | yes | False when the plugin subsystem is unavailable on this install. |
+
+### `VariableModeConfig` {#schema-variablemodeconfig}
+
+Settings for variable-driven page selection.
+
+`rules` are evaluated in order; the first one whose expression returns
+a truthy non-error value wins. If no rule matches (or all error), the
+collection falls back to `default_page_id`.
+
+`poll_seconds` controls how often the active-page loop re-evaluates
+the rules.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `rules` | array of [`VariableRule`](#schema-variablerule) | no | — |
+| `default_page_id` | `string` | yes | min length 1 |
+| `poll_seconds` | `integer` | no | 2–600; default `10` |
+
+### `VariableRule` {#schema-variablerule}
+
+A single (expression, page_id) selection rule.
+
+The `expression` is evaluated by the template expression engine. A
+truthy non-error result selects `page_id` as the active page.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `expression` | `string` | yes | min length 1 |
+| `page_id` | `string` | yes | min length 1 |
+
+## Where the rest of the API went
+
+This page documents the 33 operations the app publishes. The other
+~200 paths the app serves are the web UI's private RPC channel: they still
+answer exactly as they always have, but they are undocumented on purpose,
+carry no compatibility promise, and may change in any release. They are
+published separately at `/api/internal/openapi.json` so the UI keeps a
+contract to check itself against.
+
+## Next steps
+
+- [Docker Setup](/docs/setup/docker-setup) — how the API is served and proxied
+- [Plugin Configuration](/docs/plugins/configuration) — configuring plugins over the API
+- `/api/docs` — the same operations as a Swagger explorer you can send requests from

--- a/scripts/generate_api_reference.py
+++ b/scripts/generate_api_reference.py
@@ -1,0 +1,761 @@
+#!/usr/bin/env python3
+"""Generate ``docs/reference/api-endpoints.md`` from the published OpenAPI document.
+
+Why this exists
+---------------
+``docs/reference/api-endpoints.md`` is what fiestaboard.app publishes as the API
+reference, and until this script it was 324 hand-written lines describing ~51
+operations as markdown tables. It had already drifted: it told consumers to call
+``POST /send-message`` and ``POST /refresh``, the two endpoints the product's own
+web UI never calls and which are now deprecated aliases, while saying nothing
+about ``/v1`` — the surface a consumer should actually build against — and
+nothing at all about how a script authenticates.
+
+A hand-maintained API reference rots. This project already learned that once:
+the MCP teaching text advertised two template filters that never existed and
+froze a fifteen-function formula roster, and the fix was to generate it from the
+modules that define the behaviour. This is the same fix, applied to the same
+failure mode.
+
+What it reads
+-------------
+The **published** document — ``app.openapi()``, 33 operations — not the internal
+one at ``/api/internal/openapi.json``. The internal document is the web UI's
+private RPC contract with no compatibility promise (see ``src/v1/visibility.py``);
+publishing it as a consumer reference is the problem this whole surface removed.
+
+The introduction is **not written here**. It is ``src.api_server.API_DESCRIPTION``,
+the same text ``/api/docs`` renders as its front page, mechanically normalised for
+markdownlint and MDX. Two hand-written introductions is exactly the drift this
+script exists to remove, so there is only one, and it lives next to the app.
+
+Usage
+-----
+::
+
+    python scripts/generate_api_reference.py           # write the file
+    python scripts/generate_api_reference.py --check    # fail if it is stale
+
+``--check`` is what CI runs, the way a formatter's ``--check`` runs: it prints a
+unified diff and exits 1 when the committed file differs from what the current
+schema produces. Without it this script is something somebody ran once, and the
+page starts rotting again the same day.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+#: Where the generated page lands, relative to the repository root.
+OUTPUT_PATH = Path("docs/reference/api-endpoints.md")
+
+#: Frontmatter the Docusaurus site build depends on. ``sidebar_position`` and
+#: ``description`` are load-bearing (``scripts/lint-docs-frontmatter.mjs``
+#: fails a page with no non-empty ``description``); ``keywords`` feeds the
+#: page's meta tags. Carried over verbatim from the hand-written page so the
+#: published page's identity and search ranking do not move.
+FRONTMATTER = {
+    "sidebar_position": "1",
+    "description": (
+        '"The generated FiestaBoard REST API reference: every published '
+        'operation, its parameters, request body, responses and errors."'
+    ),
+    "keywords": ("[FiestaBoard API, REST API, API endpoints, API reference, display API, split-flap API]"),
+}
+
+PAGE_TITLE = "API Endpoints"
+
+#: The operation the page has to lead with. A consumer who reads nothing else
+#: should still be able to put text on a board. Looked up in the schema rather
+#: than described here, so this constant cannot outlive the route.
+FRONT_DOOR = ("post", "/v1/boards/{board}/message")
+
+#: The field the quick-start body sets. Asserted against the front door's own
+#: request schema at generation time, so the worked example cannot drift into
+#: naming a field the API does not accept.
+FRONT_DOOR_BODY_FIELD = "text"
+
+#: HTTP methods an OpenAPI path item may carry. Anything else in a path item
+#: (``parameters``, ``summary``, vendor extensions) is not an operation.
+HTTP_METHODS = ("get", "put", "post", "delete", "options", "head", "patch", "trace")
+
+#: Status classes, for splitting a responses map into "what you get" and
+#: "what can go wrong".
+SUCCESS_STATUSES = {"200", "201", "202", "204"}
+
+
+# ---------------------------------------------------------------------------
+# Text normalisation
+#
+# Three consumers have to be satisfied by every line this script emits, and
+# each of them fails differently:
+#
+#   * markdownlint-cli2 — MD004 wants `-` list markers, and the reused
+#     API description uses `*`;
+#   * MDX — the site compiles .md as MDX, where a bare `{` opens a JS
+#     expression and a bare `<` opens a tag. Schema descriptions are full of
+#     `{red}`, `{board}` and `plugin:<id>`;
+#   * markdown tables — a `|` in a cell ends the cell, and a newline ends
+#     the row.
+# ---------------------------------------------------------------------------
+
+#: A ``{...}`` run with no whitespace inside: `{board}`, `{red}`, `{{var}}`.
+#: Wrapped in backticks rather than escaped, because every one of them is a
+#: path placeholder or a template marker and reads better as code anyway.
+_BRACE_TOKEN = re.compile(r"\{+[^{}\s|]*\}+")
+
+#: Splits text on inline code spans so the escaping below leaves them alone —
+#: MDX does not interpret braces or angle brackets inside code.
+_CODE_SPAN = re.compile(r"`[^`]*`")
+
+
+def _map_outside_code(text: str, transform) -> str:
+    """Apply ``transform`` to the parts of ``text`` that are not code spans."""
+    out: list[str] = []
+    cursor = 0
+    for match in _CODE_SPAN.finditer(text):
+        out.append(transform(text[cursor : match.start()]))
+        out.append(match.group(0))
+        cursor = match.end()
+    out.append(transform(text[cursor:]))
+    return "".join(out)
+
+
+def _mdx_safe(text: str) -> str:
+    """Make prose safe for the MDX compiler without mangling how it reads."""
+
+    def harden(chunk: str) -> str:
+        # Any brace or angle bracket left outside a code span is not a tidy
+        # token (an unbalanced brace, an inline JSON fragment, `plugin:<id>`);
+        # it still has to stop being JSX.
+        return chunk.replace("{", "&#123;").replace("}", "&#125;").replace("<", "&lt;")
+
+    def escape(chunk: str) -> str:
+        # Wrap first, then re-split: the backticks this adds have to protect
+        # what they wrap from the escaping below, or `{red}` renders as
+        # `&#123;red&#125;`.
+        wrapped = _BRACE_TOKEN.sub(lambda m: f"`{m.group(0)}`", chunk)
+        return _map_outside_code(wrapped, harden)
+
+    return _map_outside_code(text, escape)
+
+
+#: ``*emphasis*``, but not ``**strong**``. markdownlint's MD049 wants
+#: underscores in this repository, and Python docstrings do not.
+_EMPHASIS = re.compile(r"(?<!\*)\*([^*\n]+)\*(?!\*)")
+
+#: A list item at the start of a line, in either marker style.
+_LIST_ITEM = re.compile(r"^\s*(?:[-*+]|\d+\.)\s")
+
+
+def _house_style(text: str) -> str:
+    """Bring a Python docstring in line with the repository's markdown rules.
+
+    Every one of these is a markdownlint rule this repository already enforces
+    on hand-written prose, and every one of them fired on the first generated
+    draft. Fixing them at the source is what lets the generated page go through
+    the same gate as the rest of the docs rather than being exempted from it.
+    """
+    lines: list[str] = []
+    for raw in text.split("\n"):
+        # MD004: `-` is the list marker here; docstrings use `*`.
+        line = re.sub(r"^(\s*)\*(\s)", r"\1-\2", raw)
+        # MD018: a line opening with an issue reference (`#1245 — ...`) reads
+        # as a malformed ATX heading.
+        line = re.sub(r"^(#+)(?![# ])", r"\\\1", line)
+        # MD032: a list has to be separated from the paragraph above it.
+        if _LIST_ITEM.match(line) and lines and lines[-1].strip() and not _LIST_ITEM.match(lines[-1]):
+            lines.append("")
+        lines.append(line)
+
+    # MD049, outside code spans so `*` inside inline code survives.
+    return _map_outside_code("\n".join(lines), lambda chunk: _EMPHASIS.sub(r"_\1_", chunk))
+
+
+#: A fenced code block. Everything inside one is already exempt from MDX and
+#: from markdownlint's list-marker rule, and rewriting it would corrupt the
+#: worked example the API description carries.
+_FENCE = re.compile(r"^```.*?^```", re.MULTILINE | re.DOTALL)
+
+
+def normalise(text: str | None) -> str:
+    """A schema/docstring description, rendered as repository markdown.
+
+    Pydantic and FastAPI descriptions come from Python docstrings, which this
+    codebase writes in reStructuredText: ``like this`` for code. Left alone
+    that renders as a literal pair of backticks on the site. Bullets come
+    through as ``*``, which markdownlint's MD004 rejects here.
+    """
+    if not text:
+        return ""
+
+    def prose(chunk: str) -> str:
+        return _mdx_safe(_house_style(chunk.replace("``", "`")))
+
+    out: list[str] = []
+    cursor = 0
+    for fence in _FENCE.finditer(text):
+        out.append(prose(text[cursor : fence.start()]))
+        out.append(fence.group(0))
+        cursor = fence.end()
+    out.append(prose(text[cursor:]))
+    return "".join(out).strip()
+
+
+def cell(text: str | None) -> str:
+    """``normalise`` for a table cell: one line, pipes escaped."""
+    flattened = " ".join(normalise(text).split())
+    return flattened.replace("|", "\\|")
+
+
+def reseat_headings(markdown: str, top: int = 2) -> str:
+    """Shift every ATX heading so the shallowest one sits at level ``top``.
+
+    The API description is the whole document on ``/api/docs``, where its
+    sections are ``###``. Here it sits under this page's single ``#``, so its
+    sections have to become ``##`` — otherwise the page opens with an
+    ``h1``/``h4`` jump, which is both a markdownlint MD001 failure and a real
+    problem for anyone navigating by headings.
+    """
+    levels = [len(m) for m in re.findall(r"^(#{1,6}) ", markdown, flags=re.MULTILINE)]
+    if not levels:
+        return markdown
+    shift = top - min(levels)
+    if shift == 0:
+        return markdown
+
+    def move(match: re.Match[str]) -> str:
+        return "#" * max(1, min(6, len(match.group(1)) + shift)) + " "
+
+    return re.sub(r"^(#{1,6}) ", move, markdown, flags=re.MULTILINE)
+
+
+def slug(text: str) -> str:
+    """A stable, explicit Docusaurus heading id.
+
+    Generated headings carry backticks, braces and slashes; leaving the site
+    to slugify them would make every deep link into this page a hostage to how
+    a path is punctuated.
+    """
+    return re.sub(r"-+", "-", re.sub(r"[^a-z0-9]+", "-", text.lower())).strip("-")
+
+
+# ---------------------------------------------------------------------------
+# Schema rendering
+# ---------------------------------------------------------------------------
+
+
+def schema_display_name(ref_name: str) -> str:
+    """``src__v1__models__MessageRequest`` -> ``MessageRequest (v1)``.
+
+    FastAPI qualifies a component name only when two models collide, and it
+    does it with the full dotted module path. Both colliding names here are
+    ``MessageRequest``; the module tail is what actually distinguishes them.
+    """
+    if "__" not in ref_name:
+        return ref_name
+    parts = ref_name.split("__")
+    return f"{parts[-1]} ({parts[-3]})" if len(parts) >= 3 else parts[-1]
+
+
+def schema_anchor(ref_name: str) -> str:
+    return f"schema-{slug(ref_name)}"
+
+
+def schema_link(ref_name: str) -> str:
+    return f"[`{schema_display_name(ref_name)}`](#{schema_anchor(ref_name)})"
+
+
+def ref_name_of(schema: dict[str, Any] | None) -> str | None:
+    """The component name a ``$ref`` points at, if this schema is one."""
+    if isinstance(schema, dict) and "$ref" in schema:
+        return schema["$ref"].rsplit("/", 1)[-1]
+    return None
+
+
+def render_type(schema: dict[str, Any] | None) -> str:
+    """A one-line, linked rendering of a JSON Schema type."""
+    if not schema:
+        return "`any`"
+
+    ref = ref_name_of(schema)
+    if ref:
+        return schema_link(ref)
+
+    for combinator in ("anyOf", "oneOf"):
+        if combinator in schema:
+            members = [m for m in schema[combinator] if m.get("type") != "null"]
+            nullable = len(members) != len(schema[combinator])
+            rendered = " \\| ".join(render_type(m) for m in members) or "`any`"
+            return f"{rendered} \\| `null`" if nullable else rendered
+
+    if "allOf" in schema and len(schema["allOf"]) == 1:
+        return render_type(schema["allOf"][0])
+
+    if "enum" in schema:
+        return " \\| ".join(f"`{value!r}`".replace("'", '"') for value in schema["enum"])
+
+    kind = schema.get("type")
+    if kind == "array":
+        return f"array of {render_type(schema.get('items'))}"
+    if kind == "object":
+        extra = schema.get("additionalProperties")
+        if isinstance(extra, dict) and extra:
+            return f"object of {render_type(extra)}"
+        return "`object`"
+    if kind:
+        return f"`{schema.get('format') or kind}`"
+    return "`any`"
+
+
+def render_constraints(schema: dict[str, Any]) -> str:
+    """Bounds, defaults and formats, as a trailing sentence for a table cell.
+
+    These live in the schema because a Pydantic ``Field`` put them there, so a
+    reference that drops them is telling the reader less than the API knows.
+    """
+    inner = schema
+    for combinator in ("anyOf", "oneOf"):
+        if combinator in schema:
+            members = [m for m in schema[combinator] if m.get("type") != "null"]
+            if len(members) == 1:
+                inner = members[0]
+
+    notes: list[str] = []
+    low, high = inner.get("minimum"), inner.get("maximum")
+    if low is not None and high is not None:
+        notes.append(f"{_number(low)}–{_number(high)}")
+    elif low is not None:
+        notes.append(f"min {_number(low)}")
+    elif high is not None:
+        notes.append(f"max {_number(high)}")
+    if inner.get("minLength") is not None:
+        notes.append(f"min length {inner['minLength']}")
+    if inner.get("maxLength") is not None:
+        notes.append(f"max length {inner['maxLength']}")
+    if "default" in schema and schema["default"] is not None:
+        notes.append(f"default `{_json_literal(schema['default'])}`")
+    return "; ".join(notes)
+
+
+def _number(value: Any) -> str:
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def _json_literal(value: Any) -> str:
+    import json
+
+    return json.dumps(value)
+
+
+def render_field_table(schema: dict[str, Any]) -> list[str]:
+    """The properties of an object schema, as a markdown table."""
+    properties: dict[str, Any] = schema.get("properties") or {}
+    if not properties:
+        described = normalise(schema.get("description"))
+        return [described] if described else ["_No fields._"]
+
+    required = set(schema.get("required") or [])
+    lines = [
+        "| Field | Type | Required | Description |",
+        "|-------|------|----------|-------------|",
+    ]
+    for name, field in properties.items():
+        description = cell(field.get("description"))
+        constraints = render_constraints(field)
+        if constraints:
+            description = f"{description} ({constraints})" if description else constraints
+        lines.append(
+            f"| `{name}` | {render_type(field)} | {'yes' if name in required else 'no'} | {description or '—'} |"
+        )
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Operation rendering
+# ---------------------------------------------------------------------------
+
+
+def response_schema_name(response: dict[str, Any]) -> str:
+    """What a response body is, as a linked name or an inline type."""
+    content = response.get("content") or {}
+    media = content.get("application/json")
+    if not media or not media.get("schema"):
+        return "no body" if not content else "—"
+    return render_type(media["schema"])
+
+
+#: ``POST /send-message`` and ``POST /refresh`` stay published because earlier
+#: documentation named them; both open their description with the line below,
+#: which is where the successor comes from. Generated from the description
+#: rather than a table here, so the two cannot disagree.
+_SUCCESSOR = re.compile(r"^Deprecated:\s*use\s+`+(?P<successor>[^`]+)`+\s*instead\.?", re.MULTILINE)
+
+
+def successor_of(operation: dict[str, Any]) -> str | None:
+    match = _SUCCESSOR.search((operation.get("description") or "").replace("``", "`"))
+    return match.group("successor").strip() if match else None
+
+
+def strip_successor_line(description: str) -> str:
+    """The description without its ``Deprecated: use X instead.`` opener.
+
+    The opener is rendered as an admonition instead, so leaving it in the body
+    says the same thing twice.
+    """
+    return _SUCCESSOR.sub("", description.replace("``", "`"), count=1).strip()
+
+
+def render_operation(
+    method: str,
+    path: str,
+    operation: dict[str, Any],
+    *,
+    schemas: dict[str, Any],
+) -> list[str]:
+    signature = f"{method.upper()} {path}"
+    heading_id = slug(signature)
+    summary = operation.get("summary") or signature
+    lines = [f"### `{signature}` {{#{heading_id}}}", ""]
+
+    if operation.get("deprecated"):
+        successor = successor_of(operation)
+        replacement = f" Use `{successor}` instead." if successor else ""
+        lines += [
+            ":::warning Deprecated",
+            "",
+            f"`{signature}` is deprecated and answers with `Deprecation`, `Sunset` and",
+            f'`Link: rel="successor-version"` headers.{replacement}',
+            "",
+            ":::",
+            "",
+        ]
+
+    lines += [f"**{cell(summary)}**", ""]
+
+    description = operation.get("description") or ""
+    if operation.get("deprecated"):
+        description = strip_successor_line(description)
+    body = normalise(description)
+    if body:
+        lines += [body, ""]
+
+    parameters = operation.get("parameters") or []
+    if parameters:
+        lines += ["**Parameters**", ""]
+        lines += [
+            "| Name | In | Type | Required | Description |",
+            "|------|----|------|----------|-------------|",
+        ]
+        for parameter in parameters:
+            description_cell = cell(parameter.get("description"))
+            constraints = render_constraints(parameter.get("schema") or {})
+            if constraints:
+                description_cell = f"{description_cell} ({constraints})" if description_cell else constraints
+            lines.append(
+                f"| `{parameter['name']}` | {parameter.get('in', '—')} | "
+                f"{render_type(parameter.get('schema'))} | "
+                f"{'yes' if parameter.get('required') else 'no'} | {description_cell or '—'} |"
+            )
+        lines.append("")
+
+    request_body = operation.get("requestBody")
+    if request_body:
+        media = (request_body.get("content") or {}).get("application/json") or {}
+        body_schema = media.get("schema") or {}
+        ref = ref_name_of(body_schema)
+        required = "required" if request_body.get("required") else "optional"
+        label = schema_link(ref) if ref else render_type(body_schema)
+        lines += [f"**Request body** ({required}) — {label}", ""]
+        if ref and ref in schemas:
+            lines += render_field_table(schemas[ref])
+        else:
+            lines += render_field_table(body_schema)
+        lines.append("")
+
+    responses = operation.get("responses") or {}
+    successes = {code: r for code, r in responses.items() if code in SUCCESS_STATUSES}
+    failures = {code: r for code, r in responses.items() if code not in SUCCESS_STATUSES}
+
+    if successes:
+        lines += ["**Responses**", ""]
+        lines += ["| Status | Body | Description |", "|--------|------|-------------|"]
+        for code in sorted(successes):
+            response = successes[code]
+            lines.append(
+                f"| `{code}` | {response_schema_name(response)} | {cell(response.get('description')) or '—'} |"
+            )
+        lines.append("")
+
+    if failures:
+        lines += ["**Errors**", ""]
+        lines += ["| Status | Body | Meaning |", "|--------|------|---------|"]
+        for code in sorted(failures):
+            response = failures[code]
+            lines.append(
+                f"| `{code}` | {response_schema_name(response)} | {cell(response.get('description')) or '—'} |"
+            )
+        lines.append("")
+
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Page assembly
+# ---------------------------------------------------------------------------
+
+
+def iter_operations(schema: dict[str, Any]):
+    """``(method, path, operation)`` for every operation, in document order."""
+    for path, path_item in schema.get("paths", {}).items():
+        for method, operation in path_item.items():
+            if method in HTTP_METHODS and isinstance(operation, dict):
+                yield method, path, operation
+
+
+def render_front_matter() -> list[str]:
+    return [
+        "---",
+        *(f"{key}: {value}" for key, value in FRONTMATTER.items()),
+        "---",
+        "",
+        "<!--",
+        "  GENERATED FILE — DO NOT EDIT BY HAND.",
+        "",
+        "  Produced by scripts/generate_api_reference.py from the published OpenAPI",
+        "  document (`app.openapi()`), so it cannot drift from the API it describes.",
+        "  Edit the route, the Pydantic model or src/api_server.py::API_DESCRIPTION,",
+        "  then regenerate:",
+        "",
+        "      python scripts/generate_api_reference.py",
+        "",
+        "  CI (`Lint Markdown` -> `Check the generated API reference is current`)",
+        "  fails when this file differs from what the generator produces.",
+        "-->",
+        "",
+    ]
+
+
+def render_authentication(schema: dict[str, Any]) -> list[str]:
+    """The security schemes, from the document rather than from memory.
+
+    A script could not authenticate against this API at all before ``/v1``
+    landed, and the hand-written page never said so. It is declared in
+    ``src/v1/openapi.py`` now, which makes it generatable.
+    """
+    schemes = ((schema.get("components") or {}).get("securitySchemes") or {}).items()
+    if not schemes:
+        return []
+    lines = [
+        "## Credentials",
+        "",
+        "Either credential satisfies any request; which one you hold depends on whether",
+        "you are a script or the web UI. Both are declared in the OpenAPI document, so a",
+        "client generator picks them up.",
+        "",
+        "| Scheme | How it is sent | Notes |",
+        "|--------|----------------|-------|",
+    ]
+    for name, scheme in schemes:
+        if scheme.get("type") == "http":
+            how = f"`Authorization: {str(scheme.get('scheme', '')).title()} <token>`"
+        elif scheme.get("type") == "apiKey":
+            how = f"`{scheme.get('name')}` ({scheme.get('in')})"
+        else:
+            how = scheme.get("type", "—")
+        lines.append(f"| `{name}` | {how} | {cell(scheme.get('description'))} |")
+    lines.append("")
+    return lines
+
+
+def render_quick_start(schema: dict[str, Any]) -> list[str]:
+    """One runnable, authenticated request against the front door.
+
+    Raises rather than degrades if the front door moved: a quick start that
+    silently drops to "here are some endpoints" is how the old page ended up
+    recommending two deprecated aliases.
+    """
+    method, path = FRONT_DOOR
+    operation = (schema.get("paths") or {}).get(path, {}).get(method)
+    if operation is None:
+        raise SystemExit(
+            f"the front door {method.upper()} {path} is not in the published schema; "
+            "update FRONT_DOOR in scripts/generate_api_reference.py"
+        )
+
+    body_ref = ref_name_of(
+        ((operation.get("requestBody") or {}).get("content") or {}).get("application/json", {}).get("schema") or {}
+    )
+    body_schema = ((schema.get("components") or {}).get("schemas") or {}).get(body_ref or "", {})
+    if FRONT_DOOR_BODY_FIELD not in (body_schema.get("properties") or {}):
+        raise SystemExit(f"the quick-start body sets `{FRONT_DOOR_BODY_FIELD}`, which {body_ref} no longer accepts")
+
+    example_path = path.replace("{board}", "primary")
+    return [
+        "## Quick start",
+        "",
+        f"`{method.upper()} {path}` is the front door. `primary` works as a board id on",
+        "every `/v1/boards/...` path, so a single-board install never has to look one up.",
+        "",
+        "```bash",
+        f"curl -X {method.upper()} http://fiestaboard.local:4420/api{example_path} \\",
+        '  -H "Authorization: Bearer $FIESTABOARD_TOKEN" \\',
+        '  -H "Content-Type: application/json" \\',
+        f'  -d \'{{"{FRONT_DOOR_BODY_FIELD}": "HELLO WORLD"}}\'',
+        "```",
+        "",
+        "Drop the `Authorization` header on an install that has not turned",
+        "authentication on — it is off by default.",
+        "",
+    ]
+
+
+def render_page(schema: dict[str, Any], *, description: str) -> str:
+    schemas: dict[str, Any] = (schema.get("components") or {}).get("schemas") or {}
+
+    lines = render_front_matter()
+    lines += [f"# {PAGE_TITLE}", ""]
+    lines += [normalise(reseat_headings(description)), ""]
+    lines += render_authentication(schema)
+    lines += render_quick_start(schema)
+
+    # Tag order is the document's own — `src/v1/openapi.py` prepends `v1`
+    # deliberately, so the consumer surface leads here for the same reason it
+    # leads in Swagger.
+    tag_descriptions = {tag["name"]: tag.get("description", "") for tag in schema.get("tags", [])}
+    grouped: dict[str, list[tuple[str, str, dict[str, Any]]]] = {name: [] for name in tag_descriptions}
+    untagged: list[tuple[str, str, dict[str, Any]]] = []
+    for method, path, operation in iter_operations(schema):
+        tags = operation.get("tags") or []
+        if tags and tags[0] in grouped:
+            grouped[tags[0]].append((method, path, operation))
+        else:
+            untagged.append((method, path, operation))
+
+    total = 0
+    for tag, operations in grouped.items():
+        if not operations:
+            continue
+        total += len(operations)
+        lines += [f"## `{tag}` {{#tag-{slug(tag)}}}", ""]
+        tag_description = normalise(tag_descriptions.get(tag))
+        if tag_description:
+            lines += [tag_description, ""]
+        for method, path, operation in operations:
+            lines += render_operation(method, path, operation, schemas=schemas)
+    if untagged:
+        total += len(untagged)
+        lines += ["## Other operations {#tag-other}", ""]
+        for method, path, operation in untagged:
+            lines += render_operation(method, path, operation, schemas=schemas)
+
+    if schemas:
+        lines += [
+            "## Schemas",
+            "",
+            "Every model the operations above name, expanded once.",
+            "",
+        ]
+        for name in sorted(schemas, key=lambda n: (schema_display_name(n).lower(), n)):
+            model = schemas[name]
+            lines += [f"### `{schema_display_name(name)}` {{#{schema_anchor(name)}}}", ""]
+            model_description = normalise(model.get("description"))
+            if model_description:
+                lines += [model_description, ""]
+            lines += render_field_table(model)
+            lines.append("")
+
+    lines += [
+        "## Where the rest of the API went",
+        "",
+        f"This page documents the {total} operations the app publishes. The other",
+        "~200 paths the app serves are the web UI's private RPC channel: they still",
+        "answer exactly as they always have, but they are undocumented on purpose,",
+        "carry no compatibility promise, and may change in any release. They are",
+        "published separately at `/api/internal/openapi.json` so the UI keeps a",
+        "contract to check itself against.",
+        "",
+        "## Next steps",
+        "",
+        "- [Docker Setup](/docs/setup/docker-setup) — how the API is served and proxied",
+        "- [Plugin Configuration](/docs/plugins/configuration) — configuring plugins over the API",
+        "- `/api/docs` — the same operations as a Swagger explorer you can send requests from",
+        "",
+    ]
+
+    rendered = "\n".join(lines)
+    # Collapse the runs of blank lines the section-by-section assembly leaves
+    # behind (markdownlint MD012), and end with exactly one newline.
+    rendered = re.sub(r"\n{3,}", "\n\n", rendered)
+    return rendered.rstrip("\n") + "\n"
+
+
+def build() -> str:
+    """The page, rendered from the app the repository actually defines."""
+    # The schema must not depend on how the generating machine is configured;
+    # an auth-enabled run and an auth-disabled run have to produce the same
+    # document, or `--check` fails for a reason that is not drift.
+    os.environ.setdefault("BOARD_READ_WRITE_KEY", "generator")
+
+    from src.api_server import API_DESCRIPTION, app
+
+    return render_page(app.openapi(), description=API_DESCRIPTION)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="do not write; exit 1 with a diff if the committed page is stale",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=REPO_ROOT / OUTPUT_PATH,
+        help=f"where to write (default: {OUTPUT_PATH})",
+    )
+    args = parser.parse_args(argv)
+
+    generated = build()
+
+    if args.check:
+        current = args.output.read_text(encoding="utf-8") if args.output.exists() else ""
+        if current == generated:
+            print(f"✅ {OUTPUT_PATH} is up to date")
+            return 0
+        diff = difflib.unified_diff(
+            current.splitlines(keepends=True),
+            generated.splitlines(keepends=True),
+            fromfile=f"{OUTPUT_PATH} (committed)",
+            tofile=f"{OUTPUT_PATH} (generated)",
+        )
+        sys.stdout.writelines(diff)
+        print(
+            f"\n❌ {OUTPUT_PATH} is stale — the API changed and the reference did not.\n"
+            "   Regenerate it and commit the result:\n"
+            "       python scripts/generate_api_reference.py",
+            file=sys.stderr,
+        )
+        return 1
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(generated, encoding="utf-8")
+    print(f"✅ wrote {OUTPUT_PATH} ({generated.count(chr(10))} lines)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/v1/models.py
+++ b/src/v1/models.py
@@ -296,8 +296,9 @@ class PluginListResponse(BaseModel):
 class PluginUpdate(BaseModel):
     """``PATCH /v1/plugins/{plugin}``.
 
-    Collapses ``POST /enable``, ``POST /disable`` and ``PUT /config`` into
-    one call. ``config`` stays a free-form map on purpose: a typed body would
+    Collapses ``POST /plugins/{plugin_id}/enable``,
+    ``POST /plugins/{plugin_id}/disable`` and ``PUT /plugins/{plugin_id}/config``
+    into one call. ``config`` stays a free-form map on purpose: a typed body would
     reject the ``"***"`` sentinel the API serves in place of a stored secret,
     which is what a client round-trips when it edits one field of a form.
     """

--- a/src/v1/routes_plugins.py
+++ b/src/v1/routes_plugins.py
@@ -3,7 +3,8 @@
 The internal API publishes the plugin registry twice: ``GET /plugins`` with
 eighteen fields and ``GET /displays`` with four, both built from the same
 ``registry.list_plugins()`` call. It also splits one write — "change this
-plugin" — across ``POST /enable``, ``POST /disable`` and ``PUT /config``.
+plugin" — across ``POST /plugins/{plugin_id}/enable``,
+``POST /plugins/{plugin_id}/disable`` and ``PUT /plugins/{plugin_id}/config``.
 v1 serves one catalogue and one ``PATCH``.
 """
 

--- a/tests/test_generated_api_reference.py
+++ b/tests/test_generated_api_reference.py
@@ -1,0 +1,181 @@
+"""The published API reference has to describe the API that exists.
+
+``docs/reference/api-endpoints.md`` is what fiestaboard.app publishes, and
+before ``scripts/generate_api_reference.py`` it was 324 hand-written lines that
+had already drifted: they told consumers to call ``POST /send-message`` and
+``POST /refresh`` — the two endpoints the product's own web UI never calls —
+and said nothing about ``/v1`` or about how a script authenticates.
+
+Generating it is only half the fix. These tests hold the failure modes a
+generator can still have:
+
+* the committed page falls behind the schema (the same check CI runs as
+  ``--check``, kept here so it fails locally in the same run as the change
+  that caused it);
+* the page names a route that does not exist, which is worse than no page:
+  a reader following it gets a 404 and concludes the product is broken;
+* the worked ``curl`` stops being runnable — the exact failure
+  ``tests/test_openapi_front_page.py`` already holds for the API description,
+  which this page now reuses;
+* an operation is published but silently missing from the page, or a
+  deprecated alias loses the pointer to its successor.
+
+The route-existence check deliberately mirrors ``_schema_path_for`` from
+``tests/test_openapi_front_page.py``: ``/v1/boards/primary/message`` is served
+by ``/v1/boards/{board}/message``, so a literal lookup would report the page's
+own quick start as a route that does not exist.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from scripts.generate_api_reference import OUTPUT_PATH, build, iter_operations
+from src.api_server import app
+from src.v1.visibility import build_internal_openapi
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PAGE = REPO_ROOT / OUTPUT_PATH
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict:
+    """The published document — the 33 consumer-facing operations."""
+    return app.openapi()
+
+
+@pytest.fixture(scope="module")
+def internal_schema() -> dict:
+    """Every route the app actually serves, published or not.
+
+    The page's prose deliberately names internal routes — ``POST
+    /auth/mcp-token`` is how you get the token the quick start uses, and the
+    v1 descriptions say which internal endpoints they replace. Those mentions
+    are correct and useful; what would be wrong is naming a path that answers
+    404. So route existence is checked here, and *publication* is checked
+    against the published document, per heading.
+    """
+    return build_internal_openapi(app)
+
+
+@pytest.fixture(scope="module")
+def page() -> str:
+    return PAGE.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def published_operations(schema) -> set[tuple[str, str]]:
+    return {(method.upper(), path) for method, path, _ in iter_operations(schema)}
+
+
+def _schema_path_for(concrete_path: str, schema: dict) -> str | None:
+    """The templated schema path a concrete URL path resolves to."""
+    if concrete_path in schema["paths"]:
+        return concrete_path
+    concrete_segments = concrete_path.strip("/").split("/")
+    for candidate in schema["paths"]:
+        segments = candidate.strip("/").split("/")
+        if len(segments) != len(concrete_segments):
+            continue
+        if all(
+            template.startswith("{") or template == actual
+            for template, actual in zip(segments, concrete_segments, strict=True)
+        ):
+            return candidate
+    return None
+
+
+#: Every ``METHOD /path`` the page renders as inline code. The generator emits
+#: operation headings in exactly this shape, and prose picks the same shape up
+#: when it names a route.
+_SIGNATURE = re.compile(r"`(?P<method>GET|PUT|POST|DELETE|PATCH|HEAD|OPTIONS) (?P<path>/[^`\s]*)`")
+
+
+def test_the_committed_page_matches_the_generator(page):
+    """A stale page is the failure this whole surface exists to prevent."""
+    assert page == build(), f"{OUTPUT_PATH} is stale. Regenerate it: python scripts/generate_api_reference.py"
+
+
+def test_every_route_the_page_names_is_a_route_the_app_serves(page, internal_schema):
+    """A reference naming a path that 404s is worse than no reference."""
+    named = {(m.group("method"), m.group("path")) for m in _SIGNATURE.finditer(page)}
+    assert len(named) >= 33, f"only found {len(named)} route mentions — the extraction broke"
+
+    missing = [
+        f"{method} {path}"
+        for method, path in sorted(named)
+        if (resolved := _schema_path_for(path, internal_schema)) is None
+        or method.lower() not in internal_schema["paths"][resolved]
+    ]
+    assert not missing, f"the page names routes the app does not serve: {missing}"
+
+
+def test_the_page_documents_every_published_operation(page, published_operations):
+    """33 published operations, 33 documented ones — no silent omissions."""
+    documented = {
+        (match.group("method"), match.group("path"))
+        for line in page.splitlines()
+        if line.startswith("### ")
+        for match in [_SIGNATURE.match(line.removeprefix("### "))]
+        if match
+    }
+    assert documented == published_operations
+
+
+def test_the_quick_start_curl_calls_a_route_that_exists(page, schema):
+    """The hello-world curl must stay executable, not become folklore."""
+    match = re.search(r"curl -X (?P<method>[A-Z]+) https?://[^/]+/api(?P<path>/\S+)", page)
+    assert match, "the page must carry a runnable curl example"
+    path, method = match.group("path"), match.group("method").lower()
+    schema_path = _schema_path_for(path, schema)
+    assert schema_path is not None, f"the curl example calls {path}, which is not a published route"
+    assert method in schema["paths"][schema_path], (
+        f"the curl example uses {method.upper()} {path}; {schema_path} offers {sorted(schema['paths'][schema_path])}"
+    )
+
+
+def test_the_quick_start_curl_authenticates(page):
+    """A script could not authenticate at all before /v1, and the old page never said so."""
+    quick_start = page.split("## Quick start", 1)[1].split("\n## ", 1)[0]
+    assert "Authorization: Bearer" in quick_start
+
+
+def test_the_page_leads_with_the_front_door(page, schema):
+    """`/v1` is the surface a consumer should build against, so it goes first."""
+    first_curl = re.search(r"curl -X [A-Z]+ https?://[^/]+/api(?P<path>/\S+)", page)
+    assert first_curl and first_curl.group("path").startswith("/v1/")
+    # `primary` is the whole reason a single-board install never learns board ids.
+    assert "/v1/boards/primary/message" in first_curl.group("path")
+
+
+def test_every_deprecated_operation_names_its_successor(page, schema):
+    """A deprecation with no forward pointer just strands the reader."""
+    deprecated = [
+        f"{method.upper()} {path}" for method, path, operation in iter_operations(schema) if operation.get("deprecated")
+    ]
+    assert deprecated, "expected the two published legacy aliases to be flagged deprecated"
+
+    for signature in deprecated:
+        section = page.split(f"### `{signature}`", 1)
+        assert len(section) == 2, f"{signature} has no section on the page"
+        body = section[1].split("\n### ", 1)[0]
+        assert ":::warning Deprecated" in body, f"{signature} is not marked deprecated on the page"
+        assert "Use `" in body and "` instead." in body, f"{signature} is marked deprecated but names no successor"
+
+
+def test_the_page_reuses_the_api_description_rather_than_restating_it(page):
+    """Two hand-written introductions is the drift this generator removes."""
+    from src.api_server import API_DESCRIPTION
+
+    # The first line of the front page, verbatim: the page's introduction is
+    # that text, not a second one written next to it.
+    assert API_DESCRIPTION.splitlines()[0] in page
+
+
+def test_the_page_says_it_is_generated(page):
+    """Without the banner the next person edits it by hand and CI rejects them."""
+    assert "GENERATED FILE — DO NOT EDIT BY HAND" in page
+    assert "scripts/generate_api_reference.py" in page


### PR DESCRIPTION
## The problem

`docs/reference/api-endpoints.md` was **324 hand-written lines** documenting
roughly 51 operations as markdown tables, published on fiestaboard.app — and it
had already drifted. It told consumers to call `POST /send-message` and
`POST /refresh`: precisely the two endpoints the product's own web UI never
calls, and which #1935 turned into deprecated aliases. It said nothing about how
a script authenticates, which is the single most important thing that changed
when `/v1` landed.

Meanwhile the API moved underneath it: `/v1` shipped, and the published schema
went from 230 operations to **33** because the internal surface is now
`include_in_schema=False`.

A hand-maintained API reference rots. This project already learned that once —
the MCP teaching text advertised two template filters that never existed and
froze a fifteen-function formula roster, and the fix was to generate it from the
modules that define the behaviour. Same fix here.

## What this does

### 1. A generator — `scripts/generate_api_reference.py`

Reads the **published** document (`app.openapi()`, 33 operations — not the
internal one at `/api/internal/openapi.json`) and emits the page.

Per operation: method, path, summary, description, parameters, request-body
schema as a field table, success responses, and the error statuses it declares.
Grouped by tag in **schema tag order**, so `v1` leads deliberately. The two
deprecated aliases carry a `:::warning Deprecated` admonition naming their
successor, extracted from the operation's own description rather than restated
in a table here. Every component schema is expanded once in a `## Schemas`
section that the operation tables link into.

`--check` behaves like a formatter's `--check`: it prints a unified diff and
exits 1 when the committed page differs from what the current schema produces.

**The introduction is not written here.** It is
`src/api_server.py::API_DESCRIPTION` — the same text `/api/docs` renders as its
front page — mechanically normalised for markdownlint (MD004/MD018/MD032/MD049)
and MDX (bare `{` opens a JS expression, bare `<` opens a tag). Two hand-written
introductions is exactly the drift this PR removes, so there is one, and it
lives next to the app.

The two things that are genuinely generated and new: a **Credentials** table
built from the document's own `components.securitySchemes`, and a **Quick start**
`curl` against the front door carrying `Authorization: Bearer $FIESTABOARD_TOKEN`.
The generator refuses to run if `POST /v1/boards/{board}/message` is not in the
schema, or if its request model no longer accepts `text` — the example cannot
degrade into folklore.

Frontmatter conventions (`sidebar_position`, `description`, `keywords`) are
preserved; the site build depends on them.

### 2. A CI check that fails when the page is stale

Wired into the existing docs lane (`lint-markdown`), following how
`docs:lint:markdown` / `:spell` are wired, using the existing
`.github/actions/setup-python-deps` composite action.

`lint-markdown` now also runs when **`api`** paths change. That is the load-bearing
part: the API reference goes stale when a *route* changes, not when markdown
changes, so gating this job on `markdown` alone would have let every schema
change through unchecked. Timeout raised 5 → 10 minutes for the pip install.

### 3. Tests — `tests/test_generated_api_reference.py`

- the committed page matches the generator;
- **every route the page names is a route the app serves** (resolved against the
  internal document with template matching, since `/v1/boards/primary/message`
  is served by `/v1/boards/{board}/message`) — a docs page naming a route that
  404s is worse than no page;
- every published operation has a section (33 == 33), and only published ones do;
- the `curl` example resolves to a real published route, same approach as
  `tests/test_openapi_front_page.py::test_the_front_page_worked_example_calls_a_route_that_exists`;
- the quick start authenticates;
- every deprecated operation names a successor;
- the page reuses `API_DESCRIPTION` verbatim rather than restating it.

## Two minimal `src/v1` changes

The route-existence test found a real defect it had to be allowed to fail on.
`PluginUpdate`'s description (`src/v1/models.py`) named `POST /enable`,
`POST /disable` and `PUT /config` — shorthand for endpoints that do not exist at
those paths, which the generator faithfully published. Those are now the real
paths (`POST /plugins/{plugin_id}/enable`, etc.). Same one-line fix to the module
docstring in `src/v1/routes_plugins.py`. Description text only; no behaviour.

## Numbers

| | Before | After |
|---|---|---|
| Lines | 324, hand-written | 1,924, generated |
| Operations documented | ~51, of a 230-operation schema | **33** — every published operation |
| Operations that do not exist in the published schema | several (`/settings/*`, `/transitions/*`, `/displays/*` …) | 0 |
| Request/response schemas documented | 0 | 56 |
| Says how a script authenticates | no | yes, with a runnable `curl` |
| Can it go stale silently | yes | no |

## Proof the staleness check is load-bearing

Changed one summary in `src/v1/routes_meta.py` and ran the check:

```
$ python scripts/generate_api_reference.py --check
❌ docs/reference/api-endpoints.md is stale — the API changed and the reference did not.
   Regenerate it and commit the result:
       python scripts/generate_api_reference.py
--- docs/reference/api-endpoints.md (committed)
+++ docs/reference/api-endpoints.md (generated)
@@ -747,7 +747,7 @@

 ### `GET /v1/variables` {#get-v1-variables}

-**List every name a template can use**
+**Check that the instance is up and reachable**

 The whole template vocabulary in one answer: ...
$ echo $?
1
```

The pytest twin fails on the same change:

```
FAILED tests/test_generated_api_reference.py::test_the_committed_page_matches_the_generator
```

It also fired for real during this PR: rebasing onto #1936 (which added
`expected_characters`, `resolved_next_check_seconds` and an `error` field)
made the page stale, and `--check` caught it before push.

## Proof the route-existence test is load-bearing

Reverted the `src/v1/models.py` description fix, regenerated, ran the test:

```
E   AssertionError: the page names routes the app does not serve: ['POST /disable', 'POST /enable', 'PUT /config']
E   assert not ['POST /disable', 'POST /enable', 'PUT /config']
FAILED tests/test_generated_api_reference.py::test_every_route_the_page_names_is_a_route_the_app_serves
```

## Verification

- Full suite, `origin/next` baseline (`21fc9163c`): **3 failed, 6851 passed, 1 skipped**
- Full suite, this branch: **3 failed, 6860 passed, 1 skipped** — +9, exactly the new tests
- The 3 failures are identical on both and unrelated: `test_check_image_formats`
  shells out to `git ls-files` which cannot read a worktree's `.git` file from
  inside the container, and the other two are known xdist flakes (both pass
  serially).
- `ruff==0.16.5`: `ruff check src tests scripts` and `ruff format --check` clean
- Docs lint clean: frontmatter (63 files), contract (63 pages, 6 categories),
  markdownlint (102 files, 0 issues), cspell (0 issues — `acked` and `retarget`
  added, both from schema descriptions)
- lychee: 0 errors
- Output is deterministic across `FIESTABOARD_AUTH_ENABLED` true/false and the
  transition-plugins beta flag

## Also

`docs/features/transitions.md` linked to
`/docs/reference/api-endpoints#transition-plugin-endpoints`, an anchor that no
longer exists — `/transitions/*` is internal now. It points at
`/api/internal/openapi.json` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mYPdfxvAKCmztHasToHzH
