### PR TITLE
refactor(arch): move ~790 lines of domain logic out of three routers, and opt them into the layering ratchet

### DIFF
--- a/docs/internal/reference/API_CONVENTIONS.md
+++ b/docs/internal/reference/API_CONVENTIONS.md
@@ -118,6 +118,16 @@ manifest entry; the cost of a false negative is a shipped 200-on-failure.
   of schedules is the verdict the caller asked for, served 200 as a declared
   `ScheduleValidationResult`.
 
+  The two `/config` probes no longer carry a `no_200_on_failure` exception.
+  `no_200_on_failure` walks the **handler's own AST**, and when the layering
+  ratchet moved these verdict bodies into `src/config_api/service.py` the rule
+  stopped seeing them — a dead exception, which `validate_manifest` fails the
+  build on. Nothing about the contract changed, and nothing is unguarded: the
+  status/verdict pairs are pinned by value in `tests/test_config_contract.py`
+  and `tests/test_status_code_correctness.py`. Note the general lesson — moving
+  logic *out* of a handler silently retires this ratchet's coverage of it, so
+  the value pins have to exist first.
+
   Without (1) a generic client cannot tell the verdict from a success, which
   is exactly the masking bug this rule replaced (#1887). `POST
   /debug/test-connection` deliberately does *not* qualify: it has no verdict

--- a/docs/internal/reference/ARCHITECTURE.md
+++ b/docs/internal/reference/ARCHITECTURE.md
@@ -41,13 +41,20 @@ in `tests/layering_manifest.json`, and only those**:
 | A router may not open a file | `router_no_file_io` | No `open()`, `Path.read_*`/`write_*`, `json.load`/`dump`, `os`/`shutil` filesystem verb, or import of a storage module / `src.atomic_io` / `src.paths` in a transport module |
 | A router may not hold domain logic | `router_no_domain_logic` | A **size proxy**: every module-level function in a transport module stays within 15 body statements and cyclomatic complexity 8 |
 
-Enforced today: **`auth`, `backup`, `mqtt`, `network`, `schedules`,
-`triggers`**. Everything else — including `pages`, `collections`, `panels`,
-`config_api`, `settings`, `transitions`, `board_api`, `system` — is
+Enforced today: **`auth`, `backup`, `config_api`, `mqtt`, `network`,
+`schedules`, `system`, `transitions`, `triggers`**. Everything else —
+including `pages`, `collections`, `panels`, `settings`, `board_api` — is
 **unenforced**, and most of it does not currently comply: the 2026-09 audit
 counted ~1,600 lines of domain logic living in thirteen routers. A domain
 joins the list in the PR that makes it comply, never by loosening a rule
 until it passes. The ratchet is a floor that only moves up.
+
+`config_api`, `system` and `transitions` joined by moving ~790 lines out of
+their routers: `src/config_api/service.py` is new (the domain had no service
+module at all), the transition frame loops and board routing went to
+`src/transitions/service.py`, and the update-apply and rollback workflows went
+to `src/system/update_service.py`, which also stopped importing `fastapi`.
+No rule was loosened and no exception was recorded to admit any of them.
 
 The third rule is a proxy and its docstring says plainly what it does and
 does not catch — logic sharded across ten small helpers passes; a dense

--- a/src/config_api/routes.py
+++ b/src/config_api/routes.py
@@ -14,29 +14,42 @@ this module never loads ``src.api_server``
 Tests that need to stub a collaborator patch it where this module binds it —
 ``src.config_api.routes.<name>``.
 
-``config`` carries eight checked-in exceptions to the ratchet, all in the
-manifest with reasons: six ``declared_errors`` (this domain is read-heavy —
-six routes are parameterless reads of local state with no failure path) and
-two ``no_200_on_failure`` (the probe endpoints' declared verdict contract,
-#1887).
+The domain's behaviour lives in ``src/config_api/service.py``, created when
+``config_api`` opted into ``tests/test_layering_ratchet.py``: the first-run
+determination, the board probe and the enablement exchange were 421 lines of
+router with no HTTP in them. They raise
+:class:`~src.config_api.service.BoardProbeError`; the handlers translate it and
+change nothing about the status or the detail.
+
+``config`` carries six checked-in ``declared_errors`` exceptions to the
+conventions ratchet — this domain is read-heavy, and six routes are
+parameterless reads of local state with no failure path.
+
+It carried two more, ``no_200_on_failure`` on the probe endpoints, until those
+bodies moved down. That rule walks the *handler's own AST*, so a handler that
+no longer builds the ``{"success": false, ...}`` verdict stops tripping it, and
+``validate_manifest`` fails the build on an exception whose rule already
+passes. Nothing about the contract changed — ``tests/test_config_contract.py``
+and ``tests/test_status_code_correctness.py`` pin every status/verdict pair by
+value, which is stronger than the AST proxy was — and the deleted reasons are
+preserved on the service functions.
 """
 
 from __future__ import annotations
 
-import asyncio
 import logging
 
-import requests
 from fastapi import APIRouter, HTTPException, Response
 
 from src.api_errors import errors
-from src.board_guards import primary_board_entry, validate_board_host, validate_board_host_is_local_network
+from src.board_guards import primary_board_entry
 from src.config import Config
 from src.config_manager import get_config_manager
 from src.display_runtime import get_service, reinitialize_board_clients
 from src.settings.service import get_settings_service
 from src.time_service import reset_time_service
 
+from . import service
 from .models import (
     BoardConfigResetResponse,
     BoardConfigResponse,
@@ -59,6 +72,15 @@ from .models import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["config"])
+
+
+def _as_http(exc: service.BoardProbeError) -> HTTPException:
+    """The domain's refusal, in the transport's vocabulary.
+
+    Status and detail pass through untouched — ``tests/test_config_contract.py``
+    pins every pair by value.
+    """
+    return HTTPException(status_code=exc.status_code, detail=exc.detail)
 
 
 @router.get("/config", response_model=ConfigSummaryResponse)
@@ -261,76 +283,7 @@ async def validate_config():
     ensures users who set up a board through Settings (rather than the
     wizard) are not treated as first-run.
     """
-    config_manager = get_config_manager()
-    is_valid, validation_errors = config_manager.validate()
-
-    # Get board config to check first-run state
-    board_config = config_manager.get_board()
-    api_mode = board_config.get("api_mode", "local")
-
-    # Detect first-run: no API key configured for the selected mode
-    is_first_run = False
-    missing_fields = []
-
-    if api_mode == "cloud":
-        if not board_config.get("cloud_key"):
-            is_first_run = True
-            missing_fields.append("board.cloud_key")
-    else:  # local mode
-        if not board_config.get("local_api_key"):
-            is_first_run = True
-            missing_fields.append("board.local_api_key")
-        if not board_config.get("host"):
-            is_first_run = True
-            missing_fields.append("board.host")
-
-    # Also consider boards configured via the multi-board settings service.
-    # If any configured board instance has connection credentials, the user
-    # has completed setup (e.g. via Settings) and should not be treated as
-    # first-run. Board-related validation errors/missing_fields from the
-    # legacy config are dropped in that case.
-    has_configured_board_instance = False
-    has_connection_attempt = False
-    try:
-        from src.devices import BoardInstance
-
-        board_settings = get_settings_service().get_board_settings()
-        for b in board_settings.boards or []:
-            try:
-                instance = BoardInstance.from_dict(b)
-            except Exception:  # pragma: no cover - defensive
-                continue
-            if instance.has_connection_attempt:
-                has_connection_attempt = True
-            if instance.is_connection_configured:
-                has_configured_board_instance = True
-                break
-    except Exception:  # pragma: no cover - defensive
-        logger.exception("Failed to inspect multi-board settings during validate_config")
-
-    # A board with SOME connection detail but not a working set is
-    # *misconfigured*, not first-run: it must surface as a per-board error
-    # (#1813), never bounce an existing install back into the setup wizard.
-    # Before #1760 the legacy config.json copy masked this case; with
-    # settings as the single credential source the distinction is load-
-    # bearing (a token-less note array replacing the only board used to
-    # keep the wizard away purely via the stale legacy copy).
-    if has_connection_attempt and not has_configured_board_instance:
-        is_first_run = False
-
-    if has_configured_board_instance:
-        is_first_run = False
-        missing_fields = [f for f in missing_fields if not f.startswith("board.")]
-        board_error_prefixes = ("Board cloud_key", "Board local_api_key", "Board host")
-        validation_errors = [e for e in validation_errors if not e.startswith(board_error_prefixes)]
-        is_valid = len(validation_errors) == 0
-
-    return ConfigValidationResponse(
-        valid=is_valid,
-        is_first_run=is_first_run,
-        errors=validation_errors,
-        missing_fields=missing_fields,
-    )
+    return service.determine_config_validity()
 
 
 @router.post(
@@ -369,189 +322,10 @@ async def test_board_connection(request: BoardTestRequest):
              the host is not one this server will connect to
         500: an unanticipated server-side error
     """
-    from src.board_client import BoardClient, is_successful_board_read_response
-
-    api_mode = request.api_mode.lower()
-
-    # Validate required fields based on mode
-    if api_mode == "cloud":
-        if not request.cloud_key:
-            raise HTTPException(status_code=400, detail="Cloud API key is required")
-        api_key = request.cloud_key
-        use_cloud = True
-        host = None
-    else:  # local mode
-        if not request.local_api_key:
-            raise HTTPException(status_code=400, detail="Local API key is required")
-        if not request.host:
-            raise HTTPException(status_code=400, detail="Board host/IP is required for Local API")
-        api_key = request.local_api_key
-        use_cloud = False
-        host = request.host
-        # The host guard is the reason this endpoint cannot be pointed at an
-        # arbitrary URL. Its 400 propagates unchanged: swallowing it into a
-        # 200 body made a refused request look like a failed probe (#1887).
-        validate_board_host(host)
-
     try:
-        # Create temporary client with provided credentials
-        client = BoardClient(api_key=api_key, host=host, use_cloud=use_cloud, skip_unchanged=False, port=request.port)
-
-        # Test the connection directly so we can inspect HTTP status codes
-        # (read_current_message() swallows errors and returns None, losing details)
-        response = await asyncio.to_thread(requests.get, client.base_url, headers=client.headers, timeout=10)
-
-        if response.status_code == 200:
-            # Parse the response to verify it's valid board data
-            try:
-                data = response.json()
-                if is_successful_board_read_response(data):
-                    logger.info(f"Board connection test successful ({api_mode} mode)")
-                    return {
-                        "success": True,
-                        "message": "Successfully connected to your board!",
-                        "api_mode": api_mode,
-                    }
-                detail = (
-                    f"JSON keys: {', '.join(sorted(data))}"
-                    if isinstance(data, dict)
-                    else f"body type: {type(data).__name__}"
-                )
-                logger.warning(f"Board connection test: HTTP 200 but unrecognized response ({api_mode} mode): {detail}")
-                return {
-                    "success": False,
-                    "message": "Connected to Vestaboard but the response shape was not recognized.",
-                    "error": f"Unrecognized read response ({detail}).",
-                    "troubleshooting": [
-                        "Update FiestaBoard to the latest version.",
-                        "If this persists, file an issue with the response keys shown above (no API keys).",
-                    ],
-                }
-            except ValueError:
-                logger.warning(f"Board connection test: HTTP 200 but invalid JSON ({api_mode} mode)")
-                return {
-                    "success": False,
-                    "message": "Connected to the board but the response could not be read. The board may be starting up.",
-                    "error": "Invalid JSON response",
-                    "troubleshooting": [
-                        "Wait 30 seconds and try again — the board may still be starting up.",
-                        "Try unplugging the board for 10 seconds and plugging it back in.",
-                    ],
-                }
-
-        elif response.status_code == 401 or response.status_code == 403:
-            logger.warning(f"Board connection test: auth rejected HTTP {response.status_code} ({api_mode} mode)")
-            if use_cloud:
-                return {
-                    "success": False,
-                    "message": f"Your API key was rejected by the Vestaboard cloud service (HTTP {response.status_code}).",
-                    "error": f"HTTP {response.status_code}",
-                    "troubleshooting": [
-                        "Go to https://web.vestaboard.com and sign in to your account.",
-                        "Make sure you are copying the Read/Write API key (not the subscription key or installable key).",
-                        "Paste the key into the Cloud API Key field and try again.",
-                    ],
-                }
-            else:
-                return {
-                    "success": False,
-                    "message": f"Your API key was rejected by the board (HTTP {response.status_code}).",
-                    "error": f"HTTP {response.status_code}",
-                    "troubleshooting": [
-                        "Verify your Local API key is correct — it was provided when you enabled the Local API with your enablement token.",
-                        "If you need a new key, request an enablement token at https://www.vestaboard.com/local-api",
-                        "Paste the correct key into the Local API Key field and try again.",
-                        "If the key was recently regenerated, the old key will no longer work.",
-                    ],
-                }
-
-        elif response.status_code >= 500:
-            logger.warning(f"Board connection test: server error HTTP {response.status_code} ({api_mode} mode)")
-            return {
-                "success": False,
-                "message": f"The board returned an error (HTTP {response.status_code}). It may be temporarily unavailable.",
-                "error": f"HTTP {response.status_code}",
-                "troubleshooting": [
-                    "Try unplugging the Vestaboard for 10 seconds and plugging it back in.",
-                    "Wait about a minute for the board to restart, then try again.",
-                    "If the problem continues, check for firmware updates in the Vestaboard app.",
-                ],
-            }
-
-        else:
-            logger.warning(f"Board connection test: unexpected HTTP {response.status_code} ({api_mode} mode)")
-            return {
-                "success": False,
-                "message": f"Received an unexpected response from the board (HTTP {response.status_code}).",
-                "error": f"HTTP {response.status_code}",
-                "troubleshooting": [
-                    "Try unplugging the Vestaboard for 10 seconds and plugging it back in.",
-                    "Check for firmware updates in the Vestaboard app.",
-                    "If the problem continues, try using the other connection mode (Local or Cloud).",
-                ],
-            }
-
-    except ValueError as e:
-        # BoardClient rejected the credentials/host combination outright, so
-        # no probe happened: a precondition failure, not a board verdict.
-        logger.warning("Board connection test failed - invalid config", exc_info=True)
-        raise HTTPException(status_code=400, detail="Board connection configuration is invalid.") from e
-    except requests.exceptions.ConnectionError as e:
-        logger.error(f"Board connection test error: {e}")
-        if use_cloud:
-            return {
-                "success": False,
-                "message": "Could not connect to the Vestaboard cloud service.",
-                "error": "Connection error",
-                "troubleshooting": [
-                    "Make sure the device running FiestaBoard has a working internet connection.",
-                    "Try opening https://rw.vestaboard.com in a browser to verify the service is reachable.",
-                    "If you use a VPN or corporate network, make sure it allows connections to rw.vestaboard.com.",
-                ],
-            }
-        else:
-            return {
-                "success": False,
-                "message": "Could not connect to the board. The board may be off or not on the same network.",
-                "error": "Connection error",
-                "troubleshooting": [
-                    "Make sure the Vestaboard is powered on (check for the LED on the back).",
-                    "Make sure both FiestaBoard and the Vestaboard are on the same Wi-Fi network.",
-                    "Double-check the board's IP address — you can find it on your router's admin page or use FiestaBoard's network scan.",
-                    "Make sure the Local API is enabled on your board (see https://docs.vestaboard.com/docs/local-api/authentication).",
-                ],
-            }
-    except requests.exceptions.Timeout as e:
-        logger.error(f"Board connection test timeout: {e}")
-        if use_cloud:
-            return {
-                "success": False,
-                "message": "Connection to the Vestaboard cloud service timed out.",
-                "error": "Timeout",
-                "troubleshooting": [
-                    "Check that the device running FiestaBoard has a stable internet connection.",
-                    "The Vestaboard cloud service may be experiencing issues — try again in a few minutes.",
-                ],
-            }
-        else:
-            return {
-                "success": False,
-                "message": "Connection to the board timed out. The board may be off or the IP address may be wrong.",
-                "error": "Timeout",
-                "troubleshooting": [
-                    "Make sure the Vestaboard is powered on.",
-                    "Double-check the IP address in the Vestaboard app under Settings.",
-                    "Make sure both devices are on the same network.",
-                    "Try using the board's IP address instead of a hostname.",
-                ],
-            }
-    except HTTPException:
-        raise
-    except Exception as e:
-        # Not a board verdict — the probe itself broke. Detail stays generic;
-        # the exception is in the log, not in the response (#1887).
-        logger.error(f"Board connection test error: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Board connection test failed unexpectedly.") from e
+        return await service.probe_board_connection(request)
+    except service.BoardProbeError as exc:
+        raise _as_http(exc) from exc
 
 
 @router.post(
@@ -584,106 +358,10 @@ async def enable_local_api(request: EnablementTokenRequest):
              host is not one this server will contact
         500: an unanticipated server-side error
     """
-    import requests as http_requests
-
-    if not request.host:
-        raise HTTPException(status_code=400, detail="Board IP address is required")
-
-    if not request.enablement_token:
-        raise HTTPException(status_code=400, detail="Enablement token is required")
-
-    # Validate the host before composing the URL so an attacker can't
-    # redirect this request away from the local board (SSRF). These 400s
-    # propagate unchanged — downgrading them to a 200 body meant a blocked
-    # SSRF attempt and a board that rejected the token were the same
-    # response to every client (#1887).
-    validate_board_host(request.host)
-    validate_board_host_is_local_network(request.host)
-
-    # Resolve the host to a concrete IPv4 address and ensure it is a private/
-    # loopback/link-local address.  Using the ``ipaddress`` module's
-    # ``is_private``/``is_loopback``/``is_link_local`` checks is the
-    # CodeQL-recognised sanitiser for ``py/full-ssrf``: downstream sinks see
-    # a value derived from an ``IPv4Address`` object, not from raw user input.
-    import ipaddress as _ipaddress_mod
-    import socket as _socket_mod
-
     try:
-        _ip_obj = _ipaddress_mod.IPv4Address(request.host)
-    except ValueError:
-        try:
-            _addrinfo = _socket_mod.getaddrinfo(
-                request.host, None, family=_socket_mod.AF_INET, type=_socket_mod.SOCK_STREAM
-            )
-        except _socket_mod.gaierror as exc:
-            raise HTTPException(status_code=400, detail="host could not be resolved") from exc
-        _resolved = [info[4][0] for info in _addrinfo if info and len(info) >= 5 and info[4]]
-        if not _resolved:
-            raise HTTPException(status_code=400, detail="host did not resolve to an IPv4 address") from None
-        _ip_obj = _ipaddress_mod.IPv4Address(_resolved[0])
-
-    if not (_ip_obj.is_private or _ip_obj.is_loopback or _ip_obj.is_link_local):
-        raise HTTPException(status_code=400, detail="host must be on a private network")
-    _safe_host = _ip_obj.compressed
-    url = f"http://{_safe_host}:7000/local-api/enablement"
-    headers = {"X-Vestaboard-Local-Api-Enablement-Token": request.enablement_token}
-
-    try:
-        logger.info(f"Attempting to enable local API on {request.host}")
-        response = http_requests.post(url, headers=headers, timeout=10)
-
-        if response.status_code == 200:
-            data = response.json()
-            api_key = data.get("apiKey")
-
-            if api_key:
-                logger.info(f"Successfully enabled local API on {request.host}")
-                return {
-                    "success": True,
-                    "api_key": api_key,
-                    "message": "Local API enabled successfully! Your API key has been retrieved.",
-                }
-            else:
-                logger.warning(f"Local API enablement response missing apiKey: {data}")
-                return {
-                    "success": False,
-                    "message": "Received response but no API key was provided",
-                    "error": "Board response did not include an apiKey",
-                }
-        elif response.status_code == 401 or response.status_code == 403:
-            logger.warning("Local API enablement failed - invalid token")
-            return {
-                "success": False,
-                "message": "Invalid enablement token. Please check the token and try again.",
-                "error": f"HTTP {response.status_code}: Unauthorized",
-            }
-        else:
-            logger.warning(f"Local API enablement failed - HTTP {response.status_code}")
-            return {
-                "success": False,
-                "message": f"Board returned an error (HTTP {response.status_code})",
-                "error": f"HTTP {response.status_code}",
-            }
-
-    except http_requests.exceptions.ConnectionError as e:
-        logger.error(f"Local API enablement connection error: {e}")
-        return {
-            "success": False,
-            "message": "Could not connect to board. Please check the IP address and ensure the board is on the same network.",
-            "error": "Connection error",
-        }
-    except http_requests.exceptions.Timeout as e:
-        logger.error(f"Local API enablement timeout: {e}")
-        return {
-            "success": False,
-            "message": "Connection timed out. Please check the IP address and try again.",
-            "error": "Timeout",
-        }
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Local API enablement error: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to enable local API.") from e
+        return await service.exchange_enablement_token(request)
+    except service.BoardProbeError as exc:
+        raise _as_http(exc) from exc
 
 
 @router.post("/config/board/scan", response_model=BoardScanResponse, responses=errors(422))

--- a/src/config_api/service.py
+++ b/src/config_api/service.py
@@ -1,0 +1,516 @@
+"""Domain behaviour behind the ``/config`` endpoints.
+
+``src/config_api/`` was the one converted domain with no service module at
+all: 421 lines of first-run determination, board probing and Local API
+enablement lived in the router, which is what
+``tests/test_layering_ratchet.py``'s ``router_no_domain_logic`` rule flagged on
+all three of its handlers.
+
+Nothing here imports ``fastapi``. Refusals are raised as
+:class:`BoardProbeError`, carrying the status and detail the router hands
+straight to ``HTTPException`` — ``tests/test_config_contract.py`` pins every
+one of those pairs by value. Two exceptions travel *through* this module
+rather than from it: ``src.board_guards.validate_board_host`` and
+``validate_board_host_is_local_network`` still raise ``HTTPException`` for the
+whole app, so their 400s pass through untouched.
+
+**The SSRF sanitiser in :func:`exchange_enablement_token` is deliberately
+contiguous with the request it guards.** CodeQL's ``py/full-ssrf`` recognises
+the shape — an ``ipaddress.IPv4Address`` derivation plus the
+``is_private``/``is_loopback``/``is_link_local`` gate, with the sink in the
+same function — and the two historical ``py/full-ssrf`` alerts on this code
+were closed by exactly that sequence. It moved whole: the guard, the address
+it derives, the URL built from that address and the ``requests.post`` that
+uses it are still one unbroken block, in one function. Only the exception
+class raised on rejection changed, because a domain module may not import
+``fastapi``. Do not split it, reorder it, or "tidy" it.
+
+Collaborators resolve from their canonical homes at **module import time**, so
+this module never loads ``src.api_server``. Tests that need to stub one patch
+it where this module binds it — ``src.config_api.service.<name>``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import requests
+
+from src.board_guards import validate_board_host, validate_board_host_is_local_network
+from src.config_manager import get_config_manager
+from src.settings.service import get_settings_service
+
+from .models import BoardTestRequest, ConfigValidationResponse, EnablementTokenRequest
+
+logger = logging.getLogger(__name__)
+
+
+class BoardProbeError(Exception):
+    """A ``/config`` operation refused, or failed, with the answer to give.
+
+    ``status_code`` and ``detail`` are handed to ``HTTPException`` verbatim by
+    the router. They are part of this domain's recorded contract
+    (``tests/test_config_contract.py``), not a transport detail.
+    """
+
+    def __init__(self, status_code: int, detail: str):
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+# ---------------------------------------------------------------------------
+# GET /config/validate — the first-run determination
+# ---------------------------------------------------------------------------
+
+
+def _multi_board_connection_state() -> tuple[bool, bool]:
+    """``(has_configured_board_instance, has_connection_attempt)``.
+
+    Reads the multi-board settings store, which is the credential source of
+    truth since #1760. Defensive throughout: a store this cannot parse must
+    not decide the wizard question on its own.
+    """
+    has_configured_board_instance = False
+    has_connection_attempt = False
+    try:
+        from src.devices import BoardInstance
+
+        board_settings = get_settings_service().get_board_settings()
+        for b in board_settings.boards or []:
+            try:
+                instance = BoardInstance.from_dict(b)
+            except Exception:  # pragma: no cover - defensive
+                continue
+            if instance.has_connection_attempt:
+                has_connection_attempt = True
+            if instance.is_connection_configured:
+                has_configured_board_instance = True
+                break
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("Failed to inspect multi-board settings during validate_config")
+    return has_configured_board_instance, has_connection_attempt
+
+
+def determine_config_validity() -> ConfigValidationResponse:
+    """Validate the configuration and decide whether this is a first run.
+
+    A board is considered configured when either the legacy single-board
+    config has the required credentials, or any board instance configured via
+    the multi-board settings service has connection credentials. That keeps
+    users who set a board up through Settings (rather than the wizard) out of
+    onboarding.
+    """
+    config_manager = get_config_manager()
+    is_valid, validation_errors = config_manager.validate()
+
+    # Get board config to check first-run state
+    board_config = config_manager.get_board()
+    api_mode = board_config.get("api_mode", "local")
+
+    # Detect first-run: no API key configured for the selected mode
+    is_first_run = False
+    missing_fields = []
+
+    if api_mode == "cloud":
+        if not board_config.get("cloud_key"):
+            is_first_run = True
+            missing_fields.append("board.cloud_key")
+    else:  # local mode
+        if not board_config.get("local_api_key"):
+            is_first_run = True
+            missing_fields.append("board.local_api_key")
+        if not board_config.get("host"):
+            is_first_run = True
+            missing_fields.append("board.host")
+
+    # Also consider boards configured via the multi-board settings service.
+    # If any configured board instance has connection credentials, the user
+    # has completed setup (e.g. via Settings) and should not be treated as
+    # first-run. Board-related validation errors/missing_fields from the
+    # legacy config are dropped in that case.
+    has_configured_board_instance, has_connection_attempt = _multi_board_connection_state()
+
+    # A board with SOME connection detail but not a working set is
+    # *misconfigured*, not first-run: it must surface as a per-board error
+    # (#1813), never bounce an existing install back into the setup wizard.
+    # Before #1760 the legacy config.json copy masked this case; with
+    # settings as the single credential source the distinction is load-
+    # bearing (a token-less note array replacing the only board used to
+    # keep the wizard away purely via the stale legacy copy).
+    if has_connection_attempt and not has_configured_board_instance:
+        is_first_run = False
+
+    if has_configured_board_instance:
+        is_first_run = False
+        missing_fields = [f for f in missing_fields if not f.startswith("board.")]
+        board_error_prefixes = ("Board cloud_key", "Board local_api_key", "Board host")
+        validation_errors = [e for e in validation_errors if not e.startswith(board_error_prefixes)]
+        is_valid = len(validation_errors) == 0
+
+    return ConfigValidationResponse(
+        valid=is_valid,
+        is_first_run=is_first_run,
+        errors=validation_errors,
+        missing_fields=missing_fields,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /config/board/test — the connection probe
+# ---------------------------------------------------------------------------
+
+
+def _probe_credentials(request: BoardTestRequest) -> tuple[str, str, bool, str | None]:
+    """``(api_mode, api_key, use_cloud, host)`` for a probe that can be run.
+
+    The order of these refusals is recorded: a local-mode body missing both
+    its key and its host is told about the key first, and the host guard runs
+    only once a host is present.
+    """
+    api_mode = request.api_mode.lower()
+    if api_mode == "cloud":
+        if not request.cloud_key:
+            raise BoardProbeError(400, "Cloud API key is required")
+        return api_mode, request.cloud_key, True, None
+    if not request.local_api_key:
+        raise BoardProbeError(400, "Local API key is required")
+    if not request.host:
+        raise BoardProbeError(400, "Board host/IP is required for Local API")
+    # The host guard is the reason this endpoint cannot be pointed at an
+    # arbitrary URL. Its 400 propagates unchanged: swallowing it into a
+    # 200 body made a refused request look like a failed probe (#1887).
+    validate_board_host(request.host)
+    return api_mode, request.local_api_key, False, request.host
+
+
+def _verdict_for_ok_response(response, api_mode: str) -> dict:
+    """The verdict for an HTTP 200 from the board: is this board data?"""
+    from src.board_client import is_successful_board_read_response
+
+    # The whole read stays inside one ``except ValueError`` on purpose: the
+    # shape inspection is part of "could this body be read at all", and
+    # splitting it would send a ValueError raised past ``json()`` to the
+    # caller's own ``except ValueError`` — a different answer entirely.
+    try:
+        data = response.json()
+        if is_successful_board_read_response(data):
+            logger.info(f"Board connection test successful ({api_mode} mode)")
+            return {
+                "success": True,
+                "message": "Successfully connected to your board!",
+                "api_mode": api_mode,
+            }
+        detail = (
+            f"JSON keys: {', '.join(sorted(data))}" if isinstance(data, dict) else f"body type: {type(data).__name__}"
+        )
+        logger.warning(f"Board connection test: HTTP 200 but unrecognized response ({api_mode} mode): {detail}")
+        return {
+            "success": False,
+            "message": "Connected to Vestaboard but the response shape was not recognized.",
+            "error": f"Unrecognized read response ({detail}).",
+            "troubleshooting": [
+                "Update FiestaBoard to the latest version.",
+                "If this persists, file an issue with the response keys shown above (no API keys).",
+            ],
+        }
+    except ValueError:
+        logger.warning(f"Board connection test: HTTP 200 but invalid JSON ({api_mode} mode)")
+        return {
+            "success": False,
+            "message": "Connected to the board but the response could not be read. The board may be starting up.",
+            "error": "Invalid JSON response",
+            "troubleshooting": [
+                "Wait 30 seconds and try again — the board may still be starting up.",
+                "Try unplugging the board for 10 seconds and plugging it back in.",
+            ],
+        }
+
+
+def _verdict_for_rejected_auth(status_code: int, use_cloud: bool) -> dict:
+    """The verdict for a 401/403 — a key the far end would not accept."""
+    if use_cloud:
+        return {
+            "success": False,
+            "message": f"Your API key was rejected by the Vestaboard cloud service (HTTP {status_code}).",
+            "error": f"HTTP {status_code}",
+            "troubleshooting": [
+                "Go to https://web.vestaboard.com and sign in to your account.",
+                "Make sure you are copying the Read/Write API key (not the subscription key or installable key).",
+                "Paste the key into the Cloud API Key field and try again.",
+            ],
+        }
+    return {
+        "success": False,
+        "message": f"Your API key was rejected by the board (HTTP {status_code}).",
+        "error": f"HTTP {status_code}",
+        "troubleshooting": [
+            "Verify your Local API key is correct — it was provided when you enabled the Local API with your enablement token.",
+            "If you need a new key, request an enablement token at https://www.vestaboard.com/local-api",
+            "Paste the correct key into the Local API Key field and try again.",
+            "If the key was recently regenerated, the old key will no longer work.",
+        ],
+    }
+
+
+def _verdict_for_unexpected_status(status_code: int, api_mode: str) -> dict:
+    """The verdict for a 5xx, or for anything else the board answered."""
+    if status_code >= 500:
+        logger.warning(f"Board connection test: server error HTTP {status_code} ({api_mode} mode)")
+        return {
+            "success": False,
+            "message": f"The board returned an error (HTTP {status_code}). It may be temporarily unavailable.",
+            "error": f"HTTP {status_code}",
+            "troubleshooting": [
+                "Try unplugging the Vestaboard for 10 seconds and plugging it back in.",
+                "Wait about a minute for the board to restart, then try again.",
+                "If the problem continues, check for firmware updates in the Vestaboard app.",
+            ],
+        }
+    logger.warning(f"Board connection test: unexpected HTTP {status_code} ({api_mode} mode)")
+    return {
+        "success": False,
+        "message": f"Received an unexpected response from the board (HTTP {status_code}).",
+        "error": f"HTTP {status_code}",
+        "troubleshooting": [
+            "Try unplugging the Vestaboard for 10 seconds and plugging it back in.",
+            "Check for firmware updates in the Vestaboard app.",
+            "If the problem continues, try using the other connection mode (Local or Cloud).",
+        ],
+    }
+
+
+def _verdict_for_connection_error(use_cloud: bool) -> dict:
+    """The verdict when no socket could be opened at all."""
+    if use_cloud:
+        return {
+            "success": False,
+            "message": "Could not connect to the Vestaboard cloud service.",
+            "error": "Connection error",
+            "troubleshooting": [
+                "Make sure the device running FiestaBoard has a working internet connection.",
+                "Try opening https://rw.vestaboard.com in a browser to verify the service is reachable.",
+                "If you use a VPN or corporate network, make sure it allows connections to rw.vestaboard.com.",
+            ],
+        }
+    return {
+        "success": False,
+        "message": "Could not connect to the board. The board may be off or not on the same network.",
+        "error": "Connection error",
+        "troubleshooting": [
+            "Make sure the Vestaboard is powered on (check for the LED on the back).",
+            "Make sure both FiestaBoard and the Vestaboard are on the same Wi-Fi network.",
+            "Double-check the board's IP address — you can find it on your router's admin page or use FiestaBoard's network scan.",
+            "Make sure the Local API is enabled on your board (see https://docs.vestaboard.com/docs/local-api/authentication).",
+        ],
+    }
+
+
+def _verdict_for_timeout(use_cloud: bool) -> dict:
+    """The verdict when the far end accepted the socket but never answered."""
+    if use_cloud:
+        return {
+            "success": False,
+            "message": "Connection to the Vestaboard cloud service timed out.",
+            "error": "Timeout",
+            "troubleshooting": [
+                "Check that the device running FiestaBoard has a stable internet connection.",
+                "The Vestaboard cloud service may be experiencing issues — try again in a few minutes.",
+            ],
+        }
+    return {
+        "success": False,
+        "message": "Connection to the board timed out. The board may be off or the IP address may be wrong.",
+        "error": "Timeout",
+        "troubleshooting": [
+            "Make sure the Vestaboard is powered on.",
+            "Double-check the IP address in the Vestaboard app under Settings.",
+            "Make sure both devices are on the same network.",
+            "Try using the board's IP address instead of a hostname.",
+        ],
+    }
+
+
+async def probe_board_connection(request: BoardTestRequest) -> dict:
+    """Test a board connection with the supplied credentials, saving nothing.
+
+    A *probe*: the endpoint's job is to report what the board said, so "your
+    key was rejected" is the requested answer at 200 through
+    ``BoardTestResponse``, not a transport failure. Preconditions the server
+    rejects before probing (missing credential, unsafe host) really are 400,
+    and unanticipated errors really are 500 (#1887, Task 10a). Making the
+    upstream verdicts 4xx would tell the wizard the request was malformed when
+    it was not.
+
+    That contract used to be recorded as a ``no_200_on_failure`` exception in
+    ``tests/conventions_manifest.json``; the rule reads the *handler's* AST, so
+    the exception went dead the moment this body moved down here.
+    ``tests/test_config_contract.py`` and
+    ``tests/test_status_code_correctness.py`` pin it by value instead.
+    """
+    from src.board_client import BoardClient
+
+    api_mode, api_key, use_cloud, host = _probe_credentials(request)
+
+    try:
+        # Create temporary client with provided credentials
+        client = BoardClient(api_key=api_key, host=host, use_cloud=use_cloud, skip_unchanged=False, port=request.port)
+
+        # Test the connection directly so we can inspect HTTP status codes
+        # (read_current_message() swallows errors and returns None, losing details)
+        response = await asyncio.to_thread(requests.get, client.base_url, headers=client.headers, timeout=10)
+
+        if response.status_code == 200:
+            return _verdict_for_ok_response(response, api_mode)
+        if response.status_code in (401, 403):
+            logger.warning(f"Board connection test: auth rejected HTTP {response.status_code} ({api_mode} mode)")
+            return _verdict_for_rejected_auth(response.status_code, use_cloud)
+        return _verdict_for_unexpected_status(response.status_code, api_mode)
+    except ValueError as e:
+        # BoardClient rejected the credentials/host combination outright, so
+        # no probe happened: a precondition failure, not a board verdict.
+        logger.warning("Board connection test failed - invalid config", exc_info=True)
+        raise BoardProbeError(400, "Board connection configuration is invalid.") from e
+    except requests.exceptions.ConnectionError as e:
+        logger.error(f"Board connection test error: {e}")
+        return _verdict_for_connection_error(use_cloud)
+    except requests.exceptions.Timeout as e:
+        logger.error(f"Board connection test timeout: {e}")
+        return _verdict_for_timeout(use_cloud)
+    except BoardProbeError:
+        # The twin of the router's `except HTTPException: raise`: without it
+        # the broad arm below would swallow this function's own refusal and
+        # re-raise it as a 500 (the stuttering "500: ..." bug, fixed once).
+        raise
+    except Exception as e:
+        # Not a board verdict — the probe itself broke. Detail stays generic;
+        # the exception is in the log, not in the response (#1887).
+        logger.error(f"Board connection test error: {e}", exc_info=True)
+        raise BoardProbeError(500, "Board connection test failed unexpectedly.") from e
+
+
+# ---------------------------------------------------------------------------
+# POST /config/board/enable-local-api — the enablement-token exchange
+# ---------------------------------------------------------------------------
+
+
+def _verdict_for_enablement_response(response, host: str) -> dict:
+    """Interpret the board's answer to an enablement-token exchange."""
+    if response.status_code == 200:
+        data = response.json()
+        api_key = data.get("apiKey")
+        if api_key:
+            logger.info(f"Successfully enabled local API on {host}")
+            return {
+                "success": True,
+                "api_key": api_key,
+                "message": "Local API enabled successfully! Your API key has been retrieved.",
+            }
+        logger.warning(f"Local API enablement response missing apiKey: {data}")
+        return {
+            "success": False,
+            "message": "Received response but no API key was provided",
+            "error": "Board response did not include an apiKey",
+        }
+    if response.status_code in (401, 403):
+        logger.warning("Local API enablement failed - invalid token")
+        return {
+            "success": False,
+            "message": "Invalid enablement token. Please check the token and try again.",
+            "error": f"HTTP {response.status_code}: Unauthorized",
+        }
+    logger.warning(f"Local API enablement failed - HTTP {response.status_code}")
+    return {
+        "success": False,
+        "message": f"Board returned an error (HTTP {response.status_code})",
+        "error": f"HTTP {response.status_code}",
+    }
+
+
+async def exchange_enablement_token(request: EnablementTokenRequest) -> dict:
+    """Exchange a Local API Enablement Token for a Local API Key.
+
+    The board issues the key; this only carries the token to it. Same declared
+    verdict contract as :func:`probe_board_connection` (#1887): "that
+    enablement token is not valid" is the board's answer at 200 through
+    ``EnableLocalApiResponse``, while the SSRF and host-validation rejections
+    are 400 and an unanticipated failure is 500. Pinned by value in
+    ``tests/test_config_contract.py``.
+
+    **The SSRF sequence below is CodeQL-recognised (``py/full-ssrf``) and is
+    reproduced verbatim from the router it moved out of.** The address
+    derivation, the private-network gate, the URL built from the derived
+    address and the request that uses it are one contiguous block on purpose.
+    See this module's docstring.
+    """
+    import requests as http_requests
+
+    if not request.host:
+        raise BoardProbeError(400, "Board IP address is required")
+
+    if not request.enablement_token:
+        raise BoardProbeError(400, "Enablement token is required")
+
+    # Validate the host before composing the URL so an attacker can't
+    # redirect this request away from the local board (SSRF). These 400s
+    # propagate unchanged — downgrading them to a 200 body meant a blocked
+    # SSRF attempt and a board that rejected the token were the same
+    # response to every client (#1887).
+    validate_board_host(request.host)
+    validate_board_host_is_local_network(request.host)
+
+    # Resolve the host to a concrete IPv4 address and ensure it is a private/
+    # loopback/link-local address.  Using the ``ipaddress`` module's
+    # ``is_private``/``is_loopback``/``is_link_local`` checks is the
+    # CodeQL-recognised sanitiser for ``py/full-ssrf``: downstream sinks see
+    # a value derived from an ``IPv4Address`` object, not from raw user input.
+    import ipaddress as _ipaddress_mod
+    import socket as _socket_mod
+
+    try:
+        _ip_obj = _ipaddress_mod.IPv4Address(request.host)
+    except ValueError:
+        try:
+            _addrinfo = _socket_mod.getaddrinfo(
+                request.host, None, family=_socket_mod.AF_INET, type=_socket_mod.SOCK_STREAM
+            )
+        except _socket_mod.gaierror as exc:
+            raise BoardProbeError(400, "host could not be resolved") from exc
+        _resolved = [info[4][0] for info in _addrinfo if info and len(info) >= 5 and info[4]]
+        if not _resolved:
+            raise BoardProbeError(400, "host did not resolve to an IPv4 address") from None
+        _ip_obj = _ipaddress_mod.IPv4Address(_resolved[0])
+
+    if not (_ip_obj.is_private or _ip_obj.is_loopback or _ip_obj.is_link_local):
+        raise BoardProbeError(400, "host must be on a private network")
+    _safe_host = _ip_obj.compressed
+    url = f"http://{_safe_host}:7000/local-api/enablement"
+    headers = {"X-Vestaboard-Local-Api-Enablement-Token": request.enablement_token}
+
+    try:
+        logger.info(f"Attempting to enable local API on {request.host}")
+        response = http_requests.post(url, headers=headers, timeout=10)
+        return _verdict_for_enablement_response(response, request.host)
+    except http_requests.exceptions.ConnectionError as e:
+        logger.error(f"Local API enablement connection error: {e}")
+        return {
+            "success": False,
+            "message": "Could not connect to board. Please check the IP address and ensure the board is on the same network.",
+            "error": "Connection error",
+        }
+    except http_requests.exceptions.Timeout as e:
+        logger.error(f"Local API enablement timeout: {e}")
+        return {
+            "success": False,
+            "message": "Connection timed out. Please check the IP address and try again.",
+            "error": "Timeout",
+        }
+    except BoardProbeError:
+        # The twin of the router's `except HTTPException: raise` — see
+        # ``probe_board_connection`` for why this arm has to precede the
+        # broad one below.
+        raise
+    except Exception as e:
+        logger.error(f"Local API enablement error: {e}", exc_info=True)
+        raise BoardProbeError(500, "Failed to enable local API.") from e

--- a/src/system/routes.py
+++ b/src/system/routes.py
@@ -18,6 +18,12 @@ patch the service module: ``patch("src.system.update_service.<name>")``.
 
 The module object is imported rather than its members so that a patch applied
 to ``src.system.update_service`` after import time still steers these handlers.
+
+Two multi-step workflows — the update apply and the rollback — moved down into
+that service when ``system`` opted into ``tests/test_layering_ratchet.py``.
+They raise :class:`~src.system.update_service.SidecarError`, which carries the
+status code and detail these endpoints have always answered; the handlers
+translate it into ``HTTPException`` and change nothing about it.
 """
 
 from __future__ import annotations
@@ -25,10 +31,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from datetime import UTC, datetime
-from typing import Any
 
-import requests
 from fastapi import APIRouter, HTTPException
 
 from src import __version__
@@ -50,6 +53,16 @@ from .models import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["system"])
+
+
+def _as_http(exc: update_service.SidecarError) -> HTTPException:
+    """The domain's refusal, in the transport's vocabulary.
+
+    Status and detail pass through untouched — ``tests/test_system_contract.py``
+    pins every pair by value.
+    """
+    return HTTPException(status_code=exc.status_code, detail=exc.detail)
+
 
 #: Declared error responses, reused across the sidecar-backed routes. Every
 #: code here is one these handlers actually raise.
@@ -154,75 +167,10 @@ async def system_update_apply():
         500 when the sidecar rejects our shared token.
         502 for any other sidecar failure.
     """
-    if not update_service._updater_token():
-        raise HTTPException(
-            status_code=503,
-            detail=(
-                "FIESTAUPDATER_TOKEN is not set. Add COMPOSE_PROFILES=fiestaupdater to your .env "
-                "and run 'docker compose up -d' to enable in-app updates."
-            ),
-        )
-
-    # Snapshot the current settings *before* we trigger the update so the
-    # user can later choose to roll configuration back to this exact
-    # moment via /system/update/rollback.  We tag the snapshot with the
-    # currently-running image's digest + reference (looked up via the
-    # sidecar's /version endpoint) so rollback knows which image to pair
-    # with the restored settings.  A snapshot failure is non-fatal: the
-    # user can still manually roll the image back via the sidecar.
-    version = await asyncio.to_thread(update_service._updater_version)
-    snapshot = await asyncio.to_thread(
-        update_service._take_settings_snapshot,
-        version.get("digest"),
-        version.get("image"),
-    )
-
-    url = f"{update_service._updater_url()}/update"
-    headers = {"Authorization": f"Bearer {update_service._updater_token()}"}
-
-    def _post():
-        return requests.post(url, headers=headers, timeout=(5, 30))
-
     try:
-        resp = await asyncio.to_thread(_post)
-    except requests.exceptions.ConnectionError:
-        raise HTTPException(
-            status_code=503,
-            detail=(
-                "Could not reach the fiestaupdater sidecar. Run 'docker compose pull && docker compose up -d' "
-                "from your install directory to update manually."
-            ),
-        ) from None
-    except Exception as e:
-        logger.warning(f"fiestaupdater update call failed: {e}")
-        raise HTTPException(status_code=502, detail=f"fiestaupdater update call failed: {e}") from e
-
-    if resp.status_code == 401:
-        raise HTTPException(
-            status_code=500,
-            detail="fiestaupdater rejected our token; check FIESTAUPDATER_TOKEN matches in both services",
-        )
-    if resp.status_code >= 400:
-        raise HTTPException(
-            status_code=502,
-            detail=f"fiestaupdater returned {resp.status_code}: {resp.text[:200]}",
-        )
-
-    # Record bookkeeping so the UI can show "last update".
-    body = {}
-    try:
-        body = resp.json()
-    except ValueError as e:
-        # fiestaupdater may return a non-JSON body (e.g. plain-text on error); fall back to empty dict.
-        logger.debug("fiestaupdater response is not JSON, using empty body (non-fatal): %s", e)
-    update_service._system_update_state_update(last_update=datetime.now(UTC).isoformat())
-
-    return UpdateApplyResponse(
-        status="queued",
-        mode="sidecar",
-        previous_digest=body.get("previous_digest"),
-        settings_snapshot=snapshot,
-    )
+        return await update_service.apply_update()
+    except update_service.SidecarError as exc:
+        raise _as_http(exc) from exc
 
 
 @router.post(
@@ -233,19 +181,12 @@ async def system_update_apply():
 async def system_update_rollback(req: RollbackRequest):
     """Roll the running instance back to a previous version.
 
-    The user selects a snapshot — the most recent by default — and we:
-
-    1. Look up the snapshot's recorded ``previous_digest`` /
-       ``previous_image`` (captured the moment the snapshot was taken).
-    2. (When ``restore_settings=True``, the default) restore configuration
-       from the snapshot via :class:`~src.backup.service.BackupService`.
-    3. (When ``restore_image=True``, the default) ask the sidecar's
-       ``POST /rollback`` to retag that digest back onto the original
-       image reference and force-recreate the container.
-
-    Settings are restored *before* the image flip so that when the
-    container comes back up on the previous image, it reads the matching
-    configuration.
+    The user selects a snapshot — the most recent by default — and we restore
+    configuration from it (when ``restore_settings``) and ask the sidecar to
+    retag the recorded digest back onto the original image reference (when
+    ``restore_image``). Settings are restored *before* the image flip so that
+    when the container comes back up on the previous image, it reads the
+    matching configuration.
 
     Raises:
         404 when no matching snapshot exists.
@@ -260,115 +201,10 @@ async def system_update_rollback(req: RollbackRequest):
     is *partial success*, not a failure: the settings were restored, so the
     response is a 200 whose ``warnings`` name what was skipped.
     """
-    if not req.restore_settings and not req.restore_image:
-        raise HTTPException(
-            status_code=400,
-            detail="At least one of restore_settings, restore_image must be true.",
-        )
-
-    path = await asyncio.to_thread(update_service._resolve_snapshot_name, req.snapshot)
-    if path is None:
-        raise HTTPException(status_code=404, detail="No matching settings snapshot was found.")
-
-    snapshot_meta = await asyncio.to_thread(update_service._read_snapshot_metadata, path)
-
-    warnings: list[str] = []
-    settings_result: dict[str, Any] | None = None
-    image_result: dict[str, Any] | None = None
-
-    # ── Settings rollback ───────────────────────────────────────────────
-    if req.restore_settings:
-        try:
-            raw = await asyncio.to_thread(path.read_text, "utf-8")
-        except OSError as e:
-            logger.warning("Could not read snapshot %s: %s", path, e)
-            raise HTTPException(status_code=400, detail=f"Could not read snapshot: {e}") from e
-        try:
-            from src.backup.service import BackupError, BackupRestoreAborted, get_backup_service
-        except Exception as e:  # pragma: no cover - import error is exceptional
-            logger.exception("BackupService unavailable")
-            raise HTTPException(status_code=500, detail=f"Backup service unavailable: {e}") from e
-
-        service = get_backup_service()
-        try:
-            # Don't reinstall plugins from a settings-only snapshot: the user is
-            # rolling back configuration, not reshaping their plugin set.
-            result = await asyncio.to_thread(service.import_from_json, raw, reinstall_plugins=False)
-        except BackupRestoreAborted as e:
-            # Environment failure (unwritable data dir, full disk), not a bad
-            # snapshot — see Phase 2 Task 10d.
-            logger.error("Settings rollback aborted: %s", e)
-            raise HTTPException(status_code=500, detail=str(e)) from e
-        except BackupError as e:
-            raise HTTPException(status_code=400, detail=str(e)) from e
-        settings_result = {
-            "restored_from": path.name,
-            "restored_files": result.get("restored_files", []),
-            "skipped_files": result.get("skipped_files", []),
-            "pre_restore_backup_suffix": result.get("pre_restore_backup_suffix", ""),
-            "reload_errors": result.get("reload_errors", []),
-        }
-
-    # ── Image rollback ──────────────────────────────────────────────────
-    if req.restore_image:
-        digest = snapshot_meta.get("previous_digest")
-        image_ref = snapshot_meta.get("previous_image")
-        if not digest or not image_ref:
-            # Old snapshot taken before we started annotating.  We can't
-            # safely guess the digest, so report partial success rather
-            # than guessing.
-            warnings.append("Snapshot does not record a previous image digest; image was not rolled back.")
-        elif not update_service._DIGEST_RE.fullmatch(digest) or not update_service._IMAGE_REF_RE.fullmatch(image_ref):
-            warnings.append("Snapshot's recorded image identity is malformed; image was not rolled back.")
-        elif not update_service._updater_token():
-            warnings.append(
-                "FIESTAUPDATER_TOKEN is not set; image rollback is unavailable. "
-                "Settings have been restored but the image is unchanged."
-            )
-        else:
-            url = f"{update_service._updater_url()}/rollback"
-            headers = {
-                "Authorization": f"Bearer {update_service._updater_token()}",
-                "Content-Type": "application/json",
-            }
-            payload = {"digest": digest, "image": image_ref}
-
-            def _post():
-                return requests.post(url, headers=headers, json=payload, timeout=(5, 30))
-
-            try:
-                resp = await asyncio.to_thread(_post)
-            except requests.exceptions.ConnectionError:
-                raise HTTPException(
-                    status_code=503,
-                    detail="Could not reach the fiestaupdater sidecar; image rollback unavailable.",
-                ) from None
-            except Exception as e:
-                logger.warning("fiestaupdater rollback call failed: %s", e)
-                raise HTTPException(status_code=502, detail=f"fiestaupdater rollback call failed: {e}") from e
-
-            if resp.status_code == 401:
-                raise HTTPException(status_code=500, detail="fiestaupdater rejected our token")
-            if resp.status_code >= 400:
-                raise HTTPException(
-                    status_code=502,
-                    detail=f"fiestaupdater returned {resp.status_code}: {resp.text[:200]}",
-                )
-
-            image_result = {
-                "target_digest": digest,
-                "target_image": image_ref,
-                "queued": True,
-            }
-
-    overall = "success" if not warnings else "partial"
-    return RollbackResponse(
-        status=overall,
-        snapshot=path.name,
-        image_rollback=image_result,
-        settings_rollback=settings_result,
-        warnings=warnings,
-    )
+    try:
+        return await update_service.rollback(req)
+    except update_service.SidecarError as exc:
+        raise _as_http(exc) from exc
 
 
 @router.post(
@@ -428,15 +264,10 @@ async def system_restart():
     The connection will drop while the container restarts (~5 s).
     Clients should poll /health until it comes back.
     """
-    update_service._require_updater_token()
     try:
-        resp = await asyncio.to_thread(update_service._updater_post, "/restart")
-    except requests.exceptions.ConnectionError:
-        raise HTTPException(status_code=503, detail="Could not reach the fiestaupdater sidecar.") from None
-    except Exception as e:
-        logger.warning("fiestaupdater restart call failed: %s", e)
-        raise HTTPException(status_code=502, detail=f"fiestaupdater restart call failed: {e}") from e
-    return update_service._handle_updater_response(resp, "restart")
+        return await update_service.perform_sidecar_action("restart")
+    except update_service.SidecarError as exc:
+        raise _as_http(exc) from exc
 
 
 @router.post("/system/shutdown", response_model=SystemActionResponse, responses=_SIDECAR_ERRORS)
@@ -447,12 +278,7 @@ async def system_shutdown():
     Requires the fiestaupdater container to have the SYS_BOOT capability
     (cap_add: [SYS_BOOT] in docker-compose.yml).
     """
-    update_service._require_updater_token()
     try:
-        resp = await asyncio.to_thread(update_service._updater_post, "/shutdown")
-    except requests.exceptions.ConnectionError:
-        raise HTTPException(status_code=503, detail="Could not reach the fiestaupdater sidecar.") from None
-    except Exception as e:
-        logger.warning("fiestaupdater shutdown call failed: %s", e)
-        raise HTTPException(status_code=502, detail=f"fiestaupdater shutdown call failed: {e}") from e
-    return update_service._handle_updater_response(resp, "shutdown")
+        return await update_service.perform_sidecar_action("shutdown")
+    except update_service.SidecarError as exc:
+        raise _as_http(exc) from exc

--- a/src/system/update_service.py
+++ b/src/system/update_service.py
@@ -12,6 +12,15 @@ and the post-upgrade regression hint, both of which used to live on
 ``api_server``. Nothing here imports ``src.api_server``, at module level or at
 call time (Phase 2 slice: system). Tests patch the name where it lives:
 ``patch("src.system.update_service.<name>")``.
+
+Nor does it import a web framework. It used to, for two ``HTTPException``
+raises, which is what ``tests/test_layering_ratchet.py``'s
+``service_no_fastapi`` rule flags: a domain module has to stay callable from
+MQTT, MCP, the display loop and a test without dragging a framework's error
+model along. Refusals are raised as :class:`SidecarError` instead, and
+``src/system/routes.py`` translates it back into the exact status/detail pairs
+the endpoints have always answered (``tests/test_system_contract.py`` pins all
+of them by value).
 """
 
 from __future__ import annotations
@@ -27,16 +36,36 @@ from pathlib import Path
 from typing import Any
 
 import requests
-from fastapi import HTTPException
 
 from src import __version__
 from src.atomic_io import write_json_atomic, write_text_atomic
 from src.config_manager import get_config_manager
 from src.paths import get_data_dir
 
-from .models import SystemActionResponse, UpdateCheckResponse
+from .models import (
+    RollbackRequest,
+    RollbackResponse,
+    SystemActionResponse,
+    UpdateApplyResponse,
+    UpdateCheckResponse,
+)
 
 logger = logging.getLogger(__name__)
+
+
+class SidecarError(Exception):
+    """A system-update operation refused, or failed, with the answer to give.
+
+    ``status_code`` and ``detail`` are handed to ``HTTPException`` verbatim by
+    the router. They are this domain's recorded contract
+    (``tests/test_system_contract.py``), not a transport detail — which is why
+    they live on the exception rather than being re-derived upstairs.
+    """
+
+    def __init__(self, status_code: int, detail: str):
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
 
 
 def _detect_hardware_model() -> str | None:
@@ -459,9 +488,9 @@ def _updater_post(path: str) -> requests.Response:
 def _require_updater_token():
     """Raise 503 if FIESTAUPDATER_TOKEN is not configured."""
     if not _updater_token():
-        raise HTTPException(
-            status_code=503,
-            detail=(
+        raise SidecarError(
+            503,
+            (
                 "FIESTAUPDATER_TOKEN is not set. Add COMPOSE_PROFILES=fiestaupdater to your .env "
                 "and run 'docker compose up -d' to enable sidecar features."
             ),
@@ -471,16 +500,30 @@ def _require_updater_token():
 def _handle_updater_response(resp: requests.Response, action: str) -> SystemActionResponse:
     """Translate a sidecar HTTP response into a SystemActionResponse or raise."""
     if resp.status_code == 401:
-        raise HTTPException(
-            status_code=500,
-            detail="fiestaupdater rejected our token; check FIESTAUPDATER_TOKEN matches in both services",
+        raise SidecarError(
+            500,
+            "fiestaupdater rejected our token; check FIESTAUPDATER_TOKEN matches in both services",
         )
     if resp.status_code >= 400:
-        raise HTTPException(
-            status_code=502,
-            detail=f"fiestaupdater returned {resp.status_code}: {resp.text[:200]}",
-        )
+        raise SidecarError(502, f"fiestaupdater returned {resp.status_code}: {resp.text[:200]}")
     return SystemActionResponse(status="queued", action=action)
+
+
+async def perform_sidecar_action(action: str) -> SystemActionResponse:
+    """Ask the sidecar to *action* (``restart`` / ``shutdown``) and report.
+
+    The connection drops while the sidecar acts on us, so this only reports
+    that the request was accepted; clients poll ``/health`` for the rest.
+    """
+    _require_updater_token()
+    try:
+        resp = await asyncio.to_thread(_updater_post, f"/{action}")
+    except requests.exceptions.ConnectionError:
+        raise SidecarError(503, "Could not reach the fiestaupdater sidecar.") from None
+    except Exception as e:
+        logger.warning("fiestaupdater %s call failed: %s", action, e)
+        raise SidecarError(502, f"fiestaupdater {action} call failed: {e}") from e
+    return _handle_updater_response(resp, action)
 
 
 # ── Settings snapshots (used by the rollback flow) ──────────────────────────
@@ -804,3 +847,217 @@ async def run_system_update_check_if_due() -> None:
             interval_name,
         )
         await _perform_update_check()
+
+
+# ── The two multi-step update workflows ─────────────────────────────────────
+#
+# Both were handler bodies in ``src/system/routes.py`` until the layering
+# ratchet (#1933) flagged them: 23 and 51 statements of sidecar bookkeeping
+# with nothing HTTP about them beyond the status codes, which now travel on
+# :class:`SidecarError`. ``apply_update`` in particular open-coded the
+# ``requests.post`` its siblings do through :func:`_updater_post`; it uses the
+# shared helper now, so there is one place a sidecar call is made.
+
+
+async def apply_update() -> UpdateApplyResponse:
+    """Trigger an in-place update via the fiestaupdater sidecar.
+
+    The sidecar answers 202 almost immediately; the container recreation that
+    kills this process happens shortly after, so the caller should expect its
+    connection to drop and poll ``/health`` for the new version.
+
+    A settings snapshot is taken *before* the sidecar is asked to do anything,
+    tagged with the currently-running image's digest and reference so
+    :func:`rollback` knows which image to pair with the restored settings. A
+    snapshot failure is non-fatal — the user can still roll the image back by
+    hand.
+    """
+    if not _updater_token():
+        raise SidecarError(
+            503,
+            (
+                "FIESTAUPDATER_TOKEN is not set. Add COMPOSE_PROFILES=fiestaupdater to your .env "
+                "and run 'docker compose up -d' to enable in-app updates."
+            ),
+        )
+
+    version = await asyncio.to_thread(_updater_version)
+    snapshot = await asyncio.to_thread(_take_settings_snapshot, version.get("digest"), version.get("image"))
+
+    try:
+        resp = await asyncio.to_thread(_updater_post, "/update")
+    except requests.exceptions.ConnectionError:
+        raise SidecarError(
+            503,
+            (
+                "Could not reach the fiestaupdater sidecar. Run 'docker compose pull && docker compose up -d' "
+                "from your install directory to update manually."
+            ),
+        ) from None
+    except Exception as e:
+        logger.warning(f"fiestaupdater update call failed: {e}")
+        raise SidecarError(502, f"fiestaupdater update call failed: {e}") from e
+
+    if resp.status_code == 401:
+        raise SidecarError(
+            500,
+            "fiestaupdater rejected our token; check FIESTAUPDATER_TOKEN matches in both services",
+        )
+    if resp.status_code >= 400:
+        raise SidecarError(502, f"fiestaupdater returned {resp.status_code}: {resp.text[:200]}")
+
+    # Record bookkeeping so the UI can show "last update".
+    body = {}
+    try:
+        body = resp.json()
+    except ValueError as e:
+        # fiestaupdater may return a non-JSON body (e.g. plain-text on error); fall back to empty dict.
+        logger.debug("fiestaupdater response is not JSON, using empty body (non-fatal): %s", e)
+    _system_update_state_update(last_update=datetime.now(UTC).isoformat())
+
+    return UpdateApplyResponse(
+        status="queued",
+        mode="sidecar",
+        previous_digest=body.get("previous_digest"),
+        settings_snapshot=snapshot,
+    )
+
+
+async def _restore_settings_from_snapshot(path: Path) -> dict[str, Any]:
+    """Restore configuration from the snapshot at *path*.
+
+    Returns the summary the rollback response carries. Raises
+    :class:`SidecarError` with 400 for a snapshot this cannot use and 500 when
+    the environment (unwritable data dir, full disk) aborted the restore —
+    the distinction Phase 2 Task 10d drew.
+    """
+    try:
+        raw = await asyncio.to_thread(path.read_text, "utf-8")
+    except OSError as e:
+        logger.warning("Could not read snapshot %s: %s", path, e)
+        raise SidecarError(400, f"Could not read snapshot: {e}") from e
+    try:
+        from src.backup.service import BackupError, BackupRestoreAborted, get_backup_service
+    except Exception as e:  # pragma: no cover - import error is exceptional
+        logger.exception("BackupService unavailable")
+        raise SidecarError(500, f"Backup service unavailable: {e}") from e
+
+    service = get_backup_service()
+    try:
+        # Don't reinstall plugins from a settings-only snapshot: the user is
+        # rolling back configuration, not reshaping their plugin set.
+        result = await asyncio.to_thread(service.import_from_json, raw, reinstall_plugins=False)
+    except BackupRestoreAborted as e:
+        # Environment failure (unwritable data dir, full disk), not a bad
+        # snapshot — see Phase 2 Task 10d.
+        logger.error("Settings rollback aborted: %s", e)
+        raise SidecarError(500, str(e)) from e
+    except BackupError as e:
+        raise SidecarError(400, str(e)) from e
+    return {
+        "restored_from": path.name,
+        "restored_files": result.get("restored_files", []),
+        "skipped_files": result.get("skipped_files", []),
+        "pre_restore_backup_suffix": result.get("pre_restore_backup_suffix", ""),
+        "reload_errors": result.get("reload_errors", []),
+    }
+
+
+async def _roll_image_back(snapshot_meta: dict[str, str | None], warnings: list[str]) -> dict[str, Any] | None:
+    """Ask the sidecar to retag the snapshot's recorded digest and recreate.
+
+    Returns the image-rollback summary, or *None* after appending a warning:
+    a snapshot with no usable image identity, or a missing sidecar token, is
+    *partial success* — the settings were already restored — not a failure.
+    """
+    digest = snapshot_meta.get("previous_digest")
+    image_ref = snapshot_meta.get("previous_image")
+    if not digest or not image_ref:
+        # Old snapshot taken before we started annotating.  We can't
+        # safely guess the digest, so report partial success rather
+        # than guessing.
+        warnings.append("Snapshot does not record a previous image digest; image was not rolled back.")
+        return None
+    if not _DIGEST_RE.fullmatch(digest) or not _IMAGE_REF_RE.fullmatch(image_ref):
+        warnings.append("Snapshot's recorded image identity is malformed; image was not rolled back.")
+        return None
+    if not _updater_token():
+        warnings.append(
+            "FIESTAUPDATER_TOKEN is not set; image rollback is unavailable. "
+            "Settings have been restored but the image is unchanged."
+        )
+        return None
+
+    url = f"{_updater_url()}/rollback"
+    headers = {
+        "Authorization": f"Bearer {_updater_token()}",
+        "Content-Type": "application/json",
+    }
+    payload = {"digest": digest, "image": image_ref}
+
+    def _post():
+        return requests.post(url, headers=headers, json=payload, timeout=(5, 30))
+
+    try:
+        resp = await asyncio.to_thread(_post)
+    except requests.exceptions.ConnectionError:
+        raise SidecarError(503, "Could not reach the fiestaupdater sidecar; image rollback unavailable.") from None
+    except Exception as e:
+        logger.warning("fiestaupdater rollback call failed: %s", e)
+        raise SidecarError(502, f"fiestaupdater rollback call failed: {e}") from e
+
+    if resp.status_code == 401:
+        raise SidecarError(500, "fiestaupdater rejected our token")
+    if resp.status_code >= 400:
+        raise SidecarError(502, f"fiestaupdater returned {resp.status_code}: {resp.text[:200]}")
+
+    return {
+        "target_digest": digest,
+        "target_image": image_ref,
+        "queued": True,
+    }
+
+
+async def rollback(req: RollbackRequest) -> RollbackResponse:
+    """Roll the running instance back to a previous version.
+
+    The user selects a snapshot — the most recent by default — and this:
+
+    1. Looks up the snapshot's recorded ``previous_digest`` /
+       ``previous_image`` (captured the moment the snapshot was taken).
+    2. (When ``restore_settings=True``, the default) restores configuration
+       from the snapshot via :class:`~src.backup.service.BackupService`.
+    3. (When ``restore_image=True``, the default) asks the sidecar's
+       ``POST /rollback`` to retag that digest back onto the original image
+       reference and force-recreate the container.
+
+    Settings are restored *before* the image flip so that when the container
+    comes back up on the previous image, it reads the matching configuration.
+    """
+    if not req.restore_settings and not req.restore_image:
+        raise SidecarError(400, "At least one of restore_settings, restore_image must be true.")
+
+    path = await asyncio.to_thread(_resolve_snapshot_name, req.snapshot)
+    if path is None:
+        raise SidecarError(404, "No matching settings snapshot was found.")
+
+    snapshot_meta = await asyncio.to_thread(_read_snapshot_metadata, path)
+
+    warnings: list[str] = []
+    settings_result: dict[str, Any] | None = None
+    image_result: dict[str, Any] | None = None
+
+    if req.restore_settings:
+        settings_result = await _restore_settings_from_snapshot(path)
+
+    if req.restore_image:
+        image_result = await _roll_image_back(snapshot_meta, warnings)
+
+    overall = "success" if not warnings else "partial"
+    return RollbackResponse(
+        status=overall,
+        snapshot=path.name,
+        image_rollback=image_result,
+        settings_rollback=settings_result,
+        warnings=warnings,
+    )

--- a/src/transitions/routes.py
+++ b/src/transitions/routes.py
@@ -2,43 +2,41 @@
 
 Handlers were moved here from ``src/api_server.py`` (Phase 2 slice 8, Task 8)
 into the existing ``src/transitions`` package — it already owns the runner —
-and the conventions pass was applied in the same commit.
+and the conventions pass was applied in the same commit. The 250 lines of
+frame-cap loops, grid sizing and board routing that came with them moved down
+again into ``src/transitions/service.py`` when this domain opted into
+``tests/test_layering_ratchet.py``; what is left here is HTTP.
 
 Every route is gated behind ``beta.transition_plugins_enabled`` and answers
 404 while it is off: the SDK is experimental and the feature is meant to be
-invisible until the operator opts in.
+invisible until the operator opts in. That gate stays in the router — a 404
+for "this endpoint does not exist yet" is a transport verdict, not a domain
+one.
+
+The service raises :class:`~src.transitions.service.TransitionError`, which
+carries the status code and detail these endpoints have always answered; the
+handlers translate it into ``HTTPException`` and change nothing about it.
 
 Collaborators resolve from their canonical homes at **module import time**, so
 this module never loads ``src.api_server``
 (``tests/test_small_domains_decoupled.py`` asserts that in a fresh
-interpreter). Tests that need to stub a collaborator — or the module-level
-``LIVE_TEST_FROM_HOLD_SECONDS`` seam — patch it where this module binds it:
-``src.transitions.routes.<name>``.
+interpreter). Tests that need to stub a collaborator — or the
+``LIVE_TEST_FROM_HOLD_SECONDS`` seam, which now lives beside the code that
+sleeps on it — patch it where the *service* binds it:
+``src.transitions.service.<name>``.
 """
 
 from __future__ import annotations
 
-import asyncio
 import logging
-import time
-from typing import Any
 
 from fastapi import APIRouter, HTTPException
 
 from src.api_errors import errors
-from src.board_guards import _board_dims, _board_is_paused, _require_board, _silence_active
-from src.board_send_executor import run_board_send
-from src.collections.models import is_collection_id
-from src.collections.service import get_collection_service
-from src.devices import resolve_dimensions
-from src.display_runtime import get_service
-from src.pages.service import get_page_service
-from src.plugins.registry import get_plugin_registry
 from src.settings.service import get_settings_service
-from src.text_to_board import text_to_board_array
 
+from . import service
 from .models import (
-    TransitionFrame,
     TransitionLiveTestRequest,
     TransitionLiveTestResponse,
     TransitionPluginEntry,
@@ -74,6 +72,15 @@ def _ensure_transition_plugins_beta() -> None:
         )
 
 
+def _as_http(exc: service.TransitionError) -> HTTPException:
+    """The domain's refusal, in the transport's vocabulary.
+
+    Status and detail pass through untouched — ``tests/test_transitions_contract.py``
+    pins every pair by value.
+    """
+    return HTTPException(status_code=exc.status_code, detail=exc.detail)
+
+
 @router.get("/transitions/plugins", response_model=TransitionPluginsResponse, responses=errors(404))
 async def list_transition_plugins():
     """List installed transition plugins available for selection.
@@ -88,35 +95,8 @@ async def list_transition_plugins():
     Gated behind ``beta.transition_plugins_enabled``.
     """
     _ensure_transition_plugins_beta()
-
-    from src.plugins.base import TransitionPluginBase
-
-    registry = get_plugin_registry()
-    out = []
-    # registry.plugins copies under the registry lock, so a concurrent
-    # install/uninstall can't mutate the dict mid-iteration (#1828).
-    for plugin_id, plugin in registry.plugins.items():
-        if not isinstance(plugin, TransitionPluginBase):
-            continue
-        manifest = registry.get_manifest(plugin_id)
-        if manifest is None:
-            continue
-        out.append(
-            {
-                "id": plugin_id,
-                "name": manifest.name,
-                "description": manifest.description,
-                "icon": manifest.icon,
-                "version": manifest.version,
-                "author": manifest.author,
-                "settings_schema": manifest.settings_schema,
-                "transition_settings": plugin.transition_settings,
-                "config": dict(plugin.config or {}),
-                "strategy": f"plugin:{plugin_id}",
-            }
-        )
-    out.sort(key=lambda e: e["name"].lower())
-    return TransitionPluginsResponse(plugins=[TransitionPluginEntry.model_validate(entry) for entry in out])
+    entries = service.list_installed_transition_plugins()
+    return TransitionPluginsResponse(plugins=[TransitionPluginEntry.model_validate(entry) for entry in entries])
 
 
 @router.post(
@@ -127,193 +107,20 @@ async def list_transition_plugins():
 async def preview_transition(request: TransitionPreviewRequest):
     """Drive a transition plugin once and return its frame sequence.
 
+    Designed for the standalone /transitions test harness in the web UI.
+    Frames are generated in-process and returned as JSON; nothing is sent
+    to a real board.  The runner's caps (max_frames, max_runtime_seconds,
+    min_interval_ms) are honored; exceeding one truncates the response and
+    sets ``capped`` so the UI can display a hint.
+
     Gated behind ``beta.transition_plugins_enabled`` -- see
     ``_ensure_transition_plugins_beta``.
     """
     _ensure_transition_plugins_beta()
-    return await _preview_transition_impl(request)
-
-
-async def _preview_transition_impl(request: TransitionPreviewRequest) -> TransitionPreviewResponse:
-    """Run a transition plugin once and return the resulting frame sequence.
-
-    Designed for the standalone /transitions test harness in the web UI.
-    Frames are generated in-process and returned as JSON; nothing is sent
-    to a real board.
-
-    Request body:
-      - plugin_id (str, required): the transition plugin to drive
-      - from_text (str, optional): text to render into the from-grid
-        (uses text_to_board_array).  Defaults to a blank grid.
-      - to_text (str, required): text to render into the to-grid
-      - config (dict, optional): per-run overrides for the plugin's
-        settings_schema fields.  Merged on top of the plugin's
-        currently-bound config.
-      - device_type (str, optional): "flagship" (default), "note", or
-        "note_array" (sized by notes_wide/notes_tall)
-      - notes_wide, notes_tall (int, optional): note-array geometry
-        (1-8 each; only used when device_type is "note_array")
-
-    Response:
-      ``{"frames": [{"grid": [[..]], "delay_ms": int}, ...],
-         "total_delay_ms": int, "capped": bool, "plugin_id": str}``
-
-    The runner's caps (max_frames, max_runtime_seconds, min_interval_ms)
-    are honored.  If the plugin exceeds either max_frames or
-    max_runtime_seconds the response is truncated and ``capped`` is set
-    to true so the UI can display a hint.
-
-    Iteration happens on a worker thread (``asyncio.to_thread``) so a
-    slow / runaway plugin generator cannot block FastAPI's event loop.
-    """
-    from src.devices import MAX_NOTES_PER_AXIS, board_context_for
-
-    plugin_id = request.plugin_id
-    if not plugin_id or not isinstance(plugin_id, str):
-        raise HTTPException(status_code=400, detail="plugin_id is required")
-
-    registry = get_plugin_registry()
-    plugin = registry.get_transition_plugin(plugin_id)
-    if plugin is None:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Transition plugin {plugin_id!r} not loaded or not enabled",
-        )
-
-    device_type = request.device_type
-    if device_type not in ("flagship", "note", "note_array"):
-        raise HTTPException(status_code=400, detail=f"Unknown device_type: {device_type}")
     try:
-        notes_wide = int(request.notes_wide)
-        notes_tall = int(request.notes_tall)
-    except (TypeError, ValueError) as exc:
-        raise HTTPException(status_code=400, detail="notes_wide/notes_tall must be integers") from exc
-    if not (1 <= notes_wide <= MAX_NOTES_PER_AXIS and 1 <= notes_tall <= MAX_NOTES_PER_AXIS):
-        raise HTTPException(
-            status_code=400,
-            detail=f"notes_wide/notes_tall must be between 1 and {MAX_NOTES_PER_AXIS}",
-        )
-    device = board_context_for(device_type, notes_wide=notes_wide, notes_tall=notes_tall)
-
-    from_text = request.from_text
-    to_text = request.to_text
-    from_grid = text_to_board_array(from_text, rows=device.rows, cols=device.cols)
-    to_grid = text_to_board_array(to_text, rows=device.rows, cols=device.cols)
-
-    # Merge override config on top of the plugin's currently-bound config.
-    config = dict(plugin.config or {})
-    config.update(request.config or {})
-
-    caps = plugin.transition_settings
-    max_frames = int(caps["max_frames"])
-    min_interval_ms = int(caps["min_interval_ms"])
-    max_runtime_s = int(caps["max_runtime_seconds"])
-
-    def _collect_frames() -> tuple[list, int, bool, str | None]:
-        """Run on a worker thread; returns (frames, total_delay, capped, error)."""
-        import time
-
-        frames: list = []
-        total_delay = 0
-        capped_flag = False
-        started = time.monotonic()
-        try:
-            for raw_frame in plugin.generate_frames(from_grid, to_grid, device, config):
-                if len(frames) >= max_frames:
-                    capped_flag = True
-                    break
-                if (time.monotonic() - started) >= max_runtime_s:
-                    capped_flag = True
-                    break
-                if isinstance(raw_frame, tuple) and len(raw_frame) == 2:
-                    grid, delay = raw_frame
-                else:
-                    grid, delay = raw_frame, 0
-                try:
-                    delay = int(delay or 0)
-                except (TypeError, ValueError):
-                    delay = 0
-                delay = max(delay, min_interval_ms)
-                if not isinstance(grid, list) or not grid or not isinstance(grid[0], list):
-                    continue
-                frames.append({"grid": grid, "delay_ms": delay})
-                total_delay += delay
-        except Exception as exc:
-            return frames, total_delay, capped_flag, str(exc)
-        return frames, total_delay, capped_flag, None
-
-    try:
-        # Bound the thread itself: if iteration takes longer than the cap +
-        # a small grace period, give up rather than letting a runaway
-        # plugin tie up a worker thread indefinitely.
-        frames, total_delay, capped, error = await asyncio.wait_for(
-            asyncio.to_thread(_collect_frames),
-            timeout=max_runtime_s + 5,
-        )
-    except TimeoutError as exc:
-        logger.warning(
-            "Transition preview for %s exceeded %ds; aborting",
-            plugin_id,
-            max_runtime_s,
-        )
-        raise HTTPException(
-            status_code=504,
-            detail=(f"Plugin {plugin_id!r} exceeded the {max_runtime_s}s runtime cap and was aborted."),
-        ) from exc
-
-    if error is not None:
-        logger.warning("Transition preview failed for %s: %s", plugin_id, error)
-        raise HTTPException(status_code=500, detail=f"Plugin error: {error}")
-
-    return TransitionPreviewResponse(
-        plugin_id=plugin_id,
-        device_type=device_type,
-        frames=[TransitionFrame(**frame) for frame in frames],
-        frame_count=len(frames),
-        total_delay_ms=total_delay,
-        capped=capped,
-        from_grid=from_grid,
-        to_grid=to_grid,
-    )
-
-
-# Hold the from-page on the board briefly before starting a live-test
-# transition so the starting state is actually visible (physical tile
-# flips take a moment to settle).
-LIVE_TEST_FROM_HOLD_SECONDS = 1.5
-
-
-def _resolve_live_board_client(board_id: str | None) -> tuple[dict | None, Any]:
-    """Resolve ``(board_entry, client)`` for a Transition Lab live send.
-
-    Mirrors the routing used by ``/pages/{id}/send``: an explicit
-    *board_id* targets that board's client; omitted keeps the legacy
-    primary-client path.  Raises :class:`HTTPException` when the service
-    or client isn't available.
-    """
-    service = get_service()
-    if board_id is not None:
-        if not service:
-            raise HTTPException(status_code=503, detail="Service not initialized")
-        board = _require_board(board_id)
-        client = service.get_board_client(board_id)
-        if client is None:
-            raise HTTPException(status_code=503, detail=f"Board client not initialized: {board_id}")
-        return board, client
-    if not service or not service.vb_client:
-        raise HTTPException(status_code=503, detail="Service not initialized")
-    return None, service.vb_client
-
-
-def _render_live_page_grid(page_id: str, rows: int, cols: int) -> list[list[int]]:
-    """Render *page_id* fresh and convert it to a rows×cols grid."""
-    page_service = get_page_service()
-    result = page_service.preview_page(page_id, force_refresh=True)
-    if result is None:
-        raise HTTPException(status_code=404, detail=f"Page not found: {page_id}")
-    if not result.available:
-        raise HTTPException(status_code=503, detail=result.error or f"Page rendering failed: {page_id}")
-    return text_to_board_array(result.formatted, rows=rows, cols=cols)
+        return await service.preview_transition(request)
+    except service.TransitionError as exc:
+        raise _as_http(exc) from exc
 
 
 @router.post(
@@ -342,94 +149,10 @@ async def run_live_transition_test(request: TransitionLiveTestRequest):
     Gated behind ``beta.transition_plugins_enabled``.
     """
     _ensure_transition_plugins_beta()
-
-    plugin_id = request.plugin_id
-    if not plugin_id or not isinstance(plugin_id, str):
-        raise HTTPException(status_code=400, detail="plugin_id is required")
-    to_page_id = request.to_page_id
-    if not to_page_id or not isinstance(to_page_id, str):
-        raise HTTPException(status_code=400, detail="to_page_id is required")
-    from_page_id = request.from_page_id
-    board_id = request.board_id
-
-    registry = get_plugin_registry()
-    plugin = registry.get_transition_plugin(plugin_id)
-    if plugin is None:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Transition plugin {plugin_id!r} not loaded or not enabled",
-        )
-
-    board, board_client = _resolve_live_board_client(board_id)
-
-    if _silence_active(board_id):
-        raise HTTPException(status_code=409, detail="Silence mode is active - live test blocked")
-    if _board_is_paused(board_id):
-        raise HTTPException(status_code=409, detail="Board is paused - live test blocked")
-
-    page_service = get_page_service()
-    to_page = page_service.get_page(to_page_id)
-    if not to_page:
-        raise HTTPException(status_code=404, detail=f"Page not found: {to_page_id}")
-    if from_page_id and not page_service.get_page(from_page_id):
-        raise HTTPException(status_code=404, detail=f"Page not found: {from_page_id}")
-
-    # Size grids to the explicit target board when given (issue #1244);
-    # otherwise keep the to-page's own device type, matching /pages/{id}/send.
-    if board is not None:
-        dims = _board_dims(board)
-        device_hint = board.get("device_type") or to_page.device_type
-    else:
-        dims = resolve_dimensions(to_page.device_type, to_page.notes_wide, to_page.notes_tall)
-        device_hint = to_page.device_type
-
-    to_grid = _render_live_page_grid(to_page_id, dims.rows, dims.cols)
-    from_grid = _render_live_page_grid(from_page_id, dims.rows, dims.cols) if from_page_id else None
-
-    # Merge override config on top of the plugin's currently-bound config,
-    # mirroring /transitions/preview so live behavior matches the preview.
-    config = dict(plugin.config or {})
-    config.update(request.config or {})
-
-    max_runtime_s = int(plugin.transition_settings["max_runtime_seconds"])
-
-    def _run_live() -> tuple[bool, bool]:
-        if from_grid is not None:
-            board_client.send_characters(from_grid, strategy=None, force=True)
-            time.sleep(LIVE_TEST_FROM_HOLD_SECONDS)
-        return board_client.render(
-            to_grid,
-            strategy=f"plugin:{plugin_id}",
-            force=True,
-            device_type=device_hint,
-            transition_config=config,
-        )
-
     try:
-        # The runner enforces the plugin's runtime cap itself; the outer
-        # timeout only guards against a generator that blocks inside next()
-        # (the abandoned thread still snaps the board to the target).
-        success, was_sent = await asyncio.wait_for(
-            asyncio.to_thread(_run_live),
-            timeout=max_runtime_s + LIVE_TEST_FROM_HOLD_SECONDS + 15,
-        )
-    except TimeoutError as exc:
-        logger.warning("Live transition test for %s exceeded %ds; abandoning", plugin_id, max_runtime_s)
-        raise HTTPException(
-            status_code=504,
-            detail=f"Plugin {plugin_id!r} exceeded the {max_runtime_s}s runtime cap.",
-        ) from exc
-
-    if not success:
-        raise HTTPException(status_code=502, detail="Board unreachable - live test failed")
-
-    return TransitionLiveTestResponse(
-        sent=was_sent,
-        plugin_id=plugin_id,
-        from_page_id=from_page_id,
-        to_page_id=to_page_id,
-        board_id=board_id,
-    )
+        return await service.run_live_transition_test(request)
+    except service.TransitionError as exc:
+        raise _as_http(exc) from exc
 
 
 @router.post(
@@ -451,43 +174,7 @@ async def restore_after_transition_test(request: TransitionRestoreRequest | None
     Gated behind ``beta.transition_plugins_enabled``.
     """
     _ensure_transition_plugins_beta()
-
-    board_id = (request or TransitionRestoreRequest()).board_id
-
-    board, board_client = _resolve_live_board_client(board_id)
-
-    if _silence_active(board_id):
-        raise HTTPException(status_code=409, detail="Silence mode is active - restore blocked")
-    if _board_is_paused(board_id):
-        raise HTTPException(status_code=409, detail="Board is paused - restore blocked")
-
-    settings_service = get_settings_service()
-    if board_id is not None:
-        active_page_id = settings_service.get_active_page_id(board_id=board_id)
-    else:
-        active_page_id = settings_service.get_active_page_id()
-    if not active_page_id:
-        raise HTTPException(status_code=404, detail="No active page set")
-
-    if is_collection_id(active_page_id):
-        resolved = get_collection_service().resolve_page_id(active_page_id)
-        if not resolved:
-            raise HTTPException(status_code=404, detail="Collection could not be resolved")
-        active_page_id = resolved
-
-    page_service = get_page_service()
-    page = page_service.get_page(active_page_id)
-    if not page:
-        raise HTTPException(status_code=404, detail="Active page not found")
-
-    if board is not None:
-        dims = _board_dims(board)
-    else:
-        dims = resolve_dimensions(page.device_type, page.notes_wide, page.notes_tall)
-    grid = _render_live_page_grid(active_page_id, dims.rows, dims.cols)
-
-    success, was_sent = await run_board_send(board_client.render, grid, strategy=None, force=True)
-    if not success:
-        raise HTTPException(status_code=502, detail="Board unreachable - restore failed")
-
-    return TransitionRestoreResponse(page_id=active_page_id, sent=was_sent, board_id=board_id)
+    try:
+        return await service.restore_after_transition_test(request)
+    except service.TransitionError as exc:
+        raise _as_http(exc) from exc

--- a/src/transitions/runner.py
+++ b/src/transitions/runner.py
@@ -43,6 +43,33 @@ logger = logging.getLogger(__name__)
 TransitionResolver = Callable[[str], TransitionPluginBase | None]
 
 
+def unpack_frame(frame: Any) -> tuple[list[list[int]] | None, int]:
+    """Coerce a plugin's yielded value into ``(grid, delay_ms)``.
+
+    Accepts ``(grid, delay)`` tuples and bare grids (treated as zero delay).
+    Returns ``(None, 0)`` on shapes we can't make sense of, leaving the caller
+    to decide what that means — :meth:`TransitionRunner._drive_generator`
+    aborts the run, while ``/transitions/preview`` skips the frame.
+
+    Module level, not a method, because both callers are outside this class:
+    ``src/transitions/service.py`` open-coded a byte-for-byte copy of this
+    coercion until the router→service move gave the two loops one definition
+    of what a frame is.
+    """
+    if isinstance(frame, tuple) and len(frame) == 2:
+        grid, delay = frame
+        try:
+            delay_int = int(delay)
+        except (TypeError, ValueError):
+            delay_int = 0
+        if isinstance(grid, list) and grid and isinstance(grid[0], list):
+            return grid, delay_int
+        return None, 0
+    if isinstance(frame, list) and frame and isinstance(frame[0], list):
+        return frame, 0
+    return None, 0
+
+
 @dataclass
 class TransitionRunResult:
     """Outcome of a single :meth:`TransitionRunner.run` invocation.
@@ -334,7 +361,7 @@ class TransitionRunner:
                 reason = "cancelled by concurrent send"
                 break
 
-            grid, delay_ms = self._unpack_frame(frame)
+            grid, delay_ms = unpack_frame(frame)
             if grid is None:
                 reason = "plugin yielded malformed frame"
                 break
@@ -371,26 +398,3 @@ class TransitionRunner:
             reason=reason,
             last_send_monotonic=last_send,
         )
-
-    @staticmethod
-    def _unpack_frame(
-        frame: Any,
-    ) -> tuple[list[list[int]] | None, int]:
-        """Coerce a plugin's yielded value into ``(grid, delay_ms)``.
-
-        Accepts ``(grid, delay)`` tuples and bare grids (treated as zero
-        delay).  Returns ``(None, 0)`` on shapes we can't make sense of so
-        the caller aborts the run with a logged reason.
-        """
-        if isinstance(frame, tuple) and len(frame) == 2:
-            grid, delay = frame
-            try:
-                delay_int = int(delay)
-            except (TypeError, ValueError):
-                delay_int = 0
-            if isinstance(grid, list) and grid and isinstance(grid[0], list):
-                return grid, delay_int
-            return None, 0
-        if isinstance(frame, list) and frame and isinstance(frame[0], list):
-            return frame, 0
-        return None, 0

--- a/src/transitions/service.py
+++ b/src/transitions/service.py
@@ -1,0 +1,409 @@
+"""Domain behaviour behind the ``/transitions`` endpoints.
+
+The three Transition Lab operations — preview a plugin in-process, drive it
+once on a real board, and snap the board back afterwards — used to live in
+``src/transitions/routes.py``, where they were 250 lines of frame-cap loops,
+grid sizing and board routing that had nothing to do with HTTP, and where
+``tests/test_layering_ratchet.py``'s ``router_no_domain_logic`` rule flagged
+all three.
+
+The functions here raise :class:`TransitionError` rather than
+``fastapi.HTTPException``: a domain module has to stay callable from MQTT,
+MCP, the display loop and a test without a web framework's error model
+(ARCHITECTURE.md, "The shape of a request"). The router translates it back
+into the exact status/detail pairs the endpoints have always answered, pinned
+by value in ``tests/test_transitions_contract.py``. The one exception is
+``src.board_guards._require_board``, which still raises ``HTTPException`` for
+the whole app; its 404 travels through untouched.
+
+Collaborators resolve from their canonical homes at **module import time**, so
+this module never loads ``src.api_server``. Tests that need to stub one patch
+it where this module binds it — ``src.transitions.service.<name>``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+from src.board_guards import _board_dims, _board_is_paused, _require_board, _silence_active
+from src.board_send_executor import run_board_send
+from src.collections.models import is_collection_id
+from src.collections.service import get_collection_service
+from src.devices import resolve_dimensions
+from src.display_runtime import get_service
+from src.pages.service import get_page_service
+from src.plugins.registry import get_plugin_registry
+from src.settings.service import get_settings_service
+from src.text_to_board import text_to_board_array
+
+from .models import (
+    TransitionFrame,
+    TransitionLiveTestRequest,
+    TransitionLiveTestResponse,
+    TransitionPreviewRequest,
+    TransitionPreviewResponse,
+    TransitionRestoreRequest,
+    TransitionRestoreResponse,
+)
+from .runner import unpack_frame
+
+logger = logging.getLogger(__name__)
+
+
+class TransitionError(Exception):
+    """A transition operation refused, or failed, with the answer to give.
+
+    ``status_code`` and ``detail`` are the values the router hands to
+    ``HTTPException`` verbatim. They are part of this domain's recorded
+    contract (``tests/test_transitions_contract.py``), not an implementation
+    detail of the transport.
+    """
+
+    def __init__(self, status_code: int, detail: str):
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+# Hold the from-page on the board briefly before starting a live-test
+# transition so the starting state is actually visible (physical tile
+# flips take a moment to settle).
+LIVE_TEST_FROM_HOLD_SECONDS = 1.5
+
+
+def list_installed_transition_plugins() -> list[dict[str, Any]]:
+    """Every installed transition plugin, as the listing endpoint reports it.
+
+    Installed, not enabled: unlike data plugins, transitions don't need to be
+    enabled in the Marketplace to be selectable — installing one is opting in.
+    Sorted by display name so the picker's order is stable.
+    """
+    from src.plugins.base import TransitionPluginBase
+
+    registry = get_plugin_registry()
+    out: list[dict[str, Any]] = []
+    # registry.plugins copies under the registry lock, so a concurrent
+    # install/uninstall can't mutate the dict mid-iteration (#1828).
+    for plugin_id, plugin in registry.plugins.items():
+        if not isinstance(plugin, TransitionPluginBase):
+            continue
+        manifest = registry.get_manifest(plugin_id)
+        if manifest is None:
+            continue
+        out.append(
+            {
+                "id": plugin_id,
+                "name": manifest.name,
+                "description": manifest.description,
+                "icon": manifest.icon,
+                "version": manifest.version,
+                "author": manifest.author,
+                "settings_schema": manifest.settings_schema,
+                "transition_settings": plugin.transition_settings,
+                "config": dict(plugin.config or {}),
+                "strategy": f"plugin:{plugin_id}",
+            }
+        )
+    out.sort(key=lambda e: e["name"].lower())
+    return out
+
+
+def _resolve_preview_device(request: TransitionPreviewRequest):
+    """Validate the requested geometry and build its :class:`BoardContext`."""
+    from src.devices import MAX_NOTES_PER_AXIS, board_context_for
+
+    device_type = request.device_type
+    if device_type not in ("flagship", "note", "note_array"):
+        raise TransitionError(400, f"Unknown device_type: {device_type}")
+    try:
+        notes_wide = int(request.notes_wide)
+        notes_tall = int(request.notes_tall)
+    except (TypeError, ValueError) as exc:
+        raise TransitionError(400, "notes_wide/notes_tall must be integers") from exc
+    if not (1 <= notes_wide <= MAX_NOTES_PER_AXIS and 1 <= notes_tall <= MAX_NOTES_PER_AXIS):
+        raise TransitionError(400, f"notes_wide/notes_tall must be between 1 and {MAX_NOTES_PER_AXIS}")
+    return board_context_for(device_type, notes_wide=notes_wide, notes_tall=notes_tall)
+
+
+def _require_plugin_id(plugin_id: Any) -> None:
+    """400 when the body named no plugin. Kept separate from the registry
+    lookup because the live-test endpoint validates *both* ids before it
+    looks anything up, and the order of those two 400s is recorded."""
+    if not plugin_id or not isinstance(plugin_id, str):
+        raise TransitionError(400, "plugin_id is required")
+
+
+def _load_transition_plugin(plugin_id: str):
+    """The loaded transition plugin for *plugin_id*, or a 404 naming it."""
+    plugin = get_plugin_registry().get_transition_plugin(plugin_id)
+    if plugin is None:
+        raise TransitionError(404, f"Transition plugin {plugin_id!r} not loaded or not enabled")
+    return plugin
+
+
+def _collect_preview_frames(
+    plugin,
+    from_grid: list[list[int]],
+    to_grid: list[list[int]],
+    device,
+    config: dict,
+    caps: dict,
+) -> tuple[list[dict[str, Any]], int, bool, str | None]:
+    """Iterate the plugin's generator on a worker thread, collecting frames.
+
+    Returns ``(frames, total_delay, capped, error)``.
+
+    This is the preview twin of :meth:`TransitionRunner._drive_generator`, and
+    deliberately **not** the same loop: the runner sends each frame to a board
+    and aborts the run on a malformed one, while a preview collects frames
+    into JSON and skips a malformed frame so the harness still shows the rest.
+    What the two genuinely shared — coercing a yielded value into
+    ``(grid, delay_ms)`` — is now :func:`src.transitions.runner.unpack_frame`,
+    called by both.
+    """
+    max_frames = int(caps["max_frames"])
+    min_interval_ms = int(caps["min_interval_ms"])
+    max_runtime_s = int(caps["max_runtime_seconds"])
+
+    frames: list[dict[str, Any]] = []
+    total_delay = 0
+    capped_flag = False
+    started = time.monotonic()
+    try:
+        for raw_frame in plugin.generate_frames(from_grid, to_grid, device, config):
+            if len(frames) >= max_frames:
+                capped_flag = True
+                break
+            if (time.monotonic() - started) >= max_runtime_s:
+                capped_flag = True
+                break
+            grid, delay = unpack_frame(raw_frame)
+            if grid is None:
+                continue
+            delay = max(delay, min_interval_ms)
+            frames.append({"grid": grid, "delay_ms": delay})
+            total_delay += delay
+    except Exception as exc:
+        return frames, total_delay, capped_flag, str(exc)
+    return frames, total_delay, capped_flag, None
+
+
+async def preview_transition(request: TransitionPreviewRequest) -> TransitionPreviewResponse:
+    """Run a transition plugin once and return the resulting frame sequence.
+
+    Frames are generated in-process and returned as JSON; nothing is sent to a
+    real board. The runner's caps (``max_frames``, ``max_runtime_seconds``,
+    ``min_interval_ms``) are honored; exceeding either bound truncates the
+    response and sets ``capped`` so the UI can show a hint.
+
+    Iteration happens on a worker thread (``asyncio.to_thread``) so a slow or
+    runaway plugin generator cannot block FastAPI's event loop, and the thread
+    itself is bounded: past the runtime cap plus a small grace period the run
+    is abandoned rather than tying up a worker indefinitely.
+    """
+    _require_plugin_id(request.plugin_id)
+    plugin = _load_transition_plugin(request.plugin_id)
+    device = _resolve_preview_device(request)
+
+    from_grid = text_to_board_array(request.from_text, rows=device.rows, cols=device.cols)
+    to_grid = text_to_board_array(request.to_text, rows=device.rows, cols=device.cols)
+
+    # Merge override config on top of the plugin's currently-bound config.
+    config = dict(plugin.config or {})
+    config.update(request.config or {})
+
+    caps = plugin.transition_settings
+    max_runtime_s = int(caps["max_runtime_seconds"])
+
+    try:
+        frames, total_delay, capped, error = await asyncio.wait_for(
+            asyncio.to_thread(_collect_preview_frames, plugin, from_grid, to_grid, device, config, caps),
+            timeout=max_runtime_s + 5,
+        )
+    except TimeoutError as exc:
+        logger.warning("Transition preview for %s exceeded %ds; aborting", request.plugin_id, max_runtime_s)
+        raise TransitionError(
+            504,
+            f"Plugin {request.plugin_id!r} exceeded the {max_runtime_s}s runtime cap and was aborted.",
+        ) from exc
+
+    if error is not None:
+        logger.warning("Transition preview failed for %s: %s", request.plugin_id, error)
+        raise TransitionError(500, f"Plugin error: {error}")
+
+    return TransitionPreviewResponse(
+        plugin_id=request.plugin_id,
+        device_type=request.device_type,
+        frames=[TransitionFrame(**frame) for frame in frames],
+        frame_count=len(frames),
+        total_delay_ms=total_delay,
+        capped=capped,
+        from_grid=from_grid,
+        to_grid=to_grid,
+    )
+
+
+def _resolve_live_board_client(board_id: str | None) -> tuple[dict | None, Any]:
+    """Resolve ``(board_entry, client)`` for a Transition Lab live send.
+
+    Mirrors the routing used by ``/pages/{id}/send``: an explicit *board_id*
+    targets that board's client; omitted keeps the legacy primary-client path.
+    """
+    service = get_service()
+    if board_id is not None:
+        if not service:
+            raise TransitionError(503, "Service not initialized")
+        board = _require_board(board_id)
+        client = service.get_board_client(board_id)
+        if client is None:
+            raise TransitionError(503, f"Board client not initialized: {board_id}")
+        return board, client
+    if not service or not service.vb_client:
+        raise TransitionError(503, "Service not initialized")
+    return None, service.vb_client
+
+
+def _render_live_page_grid(page_id: str, rows: int, cols: int) -> list[list[int]]:
+    """Render *page_id* fresh and convert it to a rows×cols grid."""
+    page_service = get_page_service()
+    result = page_service.preview_page(page_id, force_refresh=True)
+    if result is None:
+        raise TransitionError(404, f"Page not found: {page_id}")
+    if not result.available:
+        raise TransitionError(503, result.error or f"Page rendering failed: {page_id}")
+    return text_to_board_array(result.formatted, rows=rows, cols=cols)
+
+
+def _require_board_is_writable(board_id: str | None, what: str) -> None:
+    """409 while the target board is silenced or paused."""
+    if _silence_active(board_id):
+        raise TransitionError(409, f"Silence mode is active - {what} blocked")
+    if _board_is_paused(board_id):
+        raise TransitionError(409, f"Board is paused - {what} blocked")
+
+
+async def run_live_transition_test(request: TransitionLiveTestRequest) -> TransitionLiveTestResponse:
+    """Run a transition plugin once on the real board (Transition Lab).
+
+    Respects silence mode and board pause (409 so the UI can explain why
+    nothing happened). The board is left showing the to-page; ``restore`` — or
+    the normal display loop — returns it to its active page.
+    """
+    plugin_id = request.plugin_id
+    _require_plugin_id(plugin_id)
+    to_page_id = request.to_page_id
+    if not to_page_id or not isinstance(to_page_id, str):
+        raise TransitionError(400, "to_page_id is required")
+    from_page_id = request.from_page_id
+    board_id = request.board_id
+
+    plugin = _load_transition_plugin(plugin_id)
+    board, board_client = _resolve_live_board_client(board_id)
+    _require_board_is_writable(board_id, "live test")
+
+    page_service = get_page_service()
+    to_page = page_service.get_page(to_page_id)
+    if not to_page:
+        raise TransitionError(404, f"Page not found: {to_page_id}")
+    if from_page_id and not page_service.get_page(from_page_id):
+        raise TransitionError(404, f"Page not found: {from_page_id}")
+
+    # Size grids to the explicit target board when given (issue #1244);
+    # otherwise keep the to-page's own device type, matching /pages/{id}/send.
+    if board is not None:
+        dims = _board_dims(board)
+        device_hint = board.get("device_type") or to_page.device_type
+    else:
+        dims = resolve_dimensions(to_page.device_type, to_page.notes_wide, to_page.notes_tall)
+        device_hint = to_page.device_type
+
+    to_grid = _render_live_page_grid(to_page_id, dims.rows, dims.cols)
+    from_grid = _render_live_page_grid(from_page_id, dims.rows, dims.cols) if from_page_id else None
+
+    # Merge override config on top of the plugin's currently-bound config,
+    # mirroring the preview so live behavior matches what the UI showed.
+    config = dict(plugin.config or {})
+    config.update(request.config or {})
+
+    max_runtime_s = int(plugin.transition_settings["max_runtime_seconds"])
+
+    def _run_live() -> tuple[bool, bool]:
+        if from_grid is not None:
+            board_client.send_characters(from_grid, strategy=None, force=True)
+            time.sleep(LIVE_TEST_FROM_HOLD_SECONDS)
+        return board_client.render(
+            to_grid,
+            strategy=f"plugin:{plugin_id}",
+            force=True,
+            device_type=device_hint,
+            transition_config=config,
+        )
+
+    try:
+        # The runner enforces the plugin's runtime cap itself; the outer
+        # timeout only guards against a generator that blocks inside next()
+        # (the abandoned thread still snaps the board to the target).
+        success, was_sent = await asyncio.wait_for(
+            asyncio.to_thread(_run_live),
+            timeout=max_runtime_s + LIVE_TEST_FROM_HOLD_SECONDS + 15,
+        )
+    except TimeoutError as exc:
+        logger.warning("Live transition test for %s exceeded %ds; abandoning", plugin_id, max_runtime_s)
+        raise TransitionError(504, f"Plugin {plugin_id!r} exceeded the {max_runtime_s}s runtime cap.") from exc
+
+    if not success:
+        raise TransitionError(502, "Board unreachable - live test failed")
+
+    return TransitionLiveTestResponse(
+        sent=was_sent,
+        plugin_id=plugin_id,
+        from_page_id=from_page_id,
+        to_page_id=to_page_id,
+        board_id=board_id,
+    )
+
+
+async def restore_after_transition_test(request: TransitionRestoreRequest | None = None) -> TransitionRestoreResponse:
+    """Snap the board back to its active page after a live transition test.
+
+    Re-renders the board's active page and sends it plainly (no transition),
+    cancelling any still-running plugin transition. The normal display loop
+    would eventually do the same; this just lets the Lab do it on demand.
+    """
+    board_id = (request or TransitionRestoreRequest()).board_id
+
+    board, board_client = _resolve_live_board_client(board_id)
+    _require_board_is_writable(board_id, "restore")
+
+    settings_service = get_settings_service()
+    if board_id is not None:
+        active_page_id = settings_service.get_active_page_id(board_id=board_id)
+    else:
+        active_page_id = settings_service.get_active_page_id()
+    if not active_page_id:
+        raise TransitionError(404, "No active page set")
+
+    if is_collection_id(active_page_id):
+        resolved = get_collection_service().resolve_page_id(active_page_id)
+        if not resolved:
+            raise TransitionError(404, "Collection could not be resolved")
+        active_page_id = resolved
+
+    page = get_page_service().get_page(active_page_id)
+    if not page:
+        raise TransitionError(404, "Active page not found")
+
+    if board is not None:
+        dims = _board_dims(board)
+    else:
+        dims = resolve_dimensions(page.device_type, page.notes_wide, page.notes_tall)
+    grid = _render_live_page_grid(active_page_id, dims.rows, dims.cols)
+
+    success, was_sent = await run_board_send(board_client.render, grid, strategy=None, force=True)
+    if not success:
+        raise TransitionError(502, "Board unreachable - restore failed")
+
+    return TransitionRestoreResponse(page_id=active_page_id, sent=was_sent, board_id=board_id)

--- a/tests/conventions_manifest.json
+++ b/tests/conventions_manifest.json
@@ -271,16 +271,6 @@
       "reason": "The same handler as GET /health, split into its own operation only so FastAPI emits a distinct operationId (#1572). It cannot fail differently from the route it delegates to."
     },
     {
-      "route": "POST /config/board/enable-local-api",
-      "rule": "no_200_on_failure",
-      "reason": "Same declared verdict contract as POST /config/board/test (#1887): 'that enablement token is not valid' is the board's answer at 200 through EnableLocalApiResponse. The SSRF and host-validation rejections stayed 400 and the unexpected-exception path stayed 500 when Task 10a fixed this handler."
-    },
-    {
-      "route": "POST /config/board/test",
-      "rule": "no_200_on_failure",
-      "reason": "Declared probe contract (#1887, Task 10a): the endpoint's job is to report what the board said, so 'your key was rejected' is the requested answer at 200 through BoardTestResponse, not a transport failure. Preconditions the server rejects before probing (missing credential, unsafe host) really are 400, and unanticipated errors really are 500 — tests/test_status_code_correctness.py pins both. Making the upstream verdicts 4xx would tell the wizard the request was malformed when it was not."
-    },
-    {
       "route": "POST /pages/ai/chat",
       "rule": "response_model",
       "reason": "Serves a Server-Sent Events stream, not a JSON document: the body is a sequence of `event:`/`data:` frames written over an open connection, and any response_model would either be a lie about what the client receives or would make FastAPI buffer and re-serialize the stream, which is the one thing an SSE endpoint must not do. The schema is published instead as the 200's text/event-stream content type plus CHAT_STREAM_EVENTS in src/ai/page_routes.py, which names each of the five event types and the model describing its payload; tests/test_ai_pages_contract.py validates real frames against that registry and cross-checks it against the literal event dicts in src/ai/chat.py, so it cannot drift the way an undocumented stream would."

--- a/tests/layering_manifest.json
+++ b/tests/layering_manifest.json
@@ -1,11 +1,14 @@
 {
-  "_comment": "Layering ratchet. Enforced by tests/test_layering_ratchet.py; the layering it defends is drawn in docs/internal/reference/ARCHITECTURE.md. Three rules: a domain module may not import fastapi (service_no_fastapi), a transport module may not touch the filesystem (router_no_file_io), and a router function may not exceed the size proxy for domain logic (router_no_domain_logic). Append a domain to enforced_domains in the PR that makes it comply — never before, and never by loosening a rule until it passes. Every exception needs a target that exists in the tree, a known rule id, and a reason a reviewer can argue with; an exception whose rule already passes is a build failure.",
+  "_comment": "Layering ratchet. Enforced by tests/test_layering_ratchet.py; the layering it defends is drawn in docs/internal/reference/ARCHITECTURE.md. Three rules: a domain module may not import fastapi (service_no_fastapi), a transport module may not touch the filesystem (router_no_file_io), and a router function may not exceed the size proxy for domain logic (router_no_domain_logic). Append a domain to enforced_domains in the PR that makes it comply \u2014 never before, and never by loosening a rule until it passes. Every exception needs a target that exists in the tree, a known rule id, and a reason a reviewer can argue with; an exception whose rule already passes is a build failure.",
   "enforced_domains": [
     "auth",
     "backup",
+    "config_api",
     "mqtt",
     "network",
     "schedules",
+    "system",
+    "transitions",
     "triggers"
   ],
   "exceptions": []

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -68,6 +68,7 @@ def mock_config_manager():
     with (
         patch("src.api_server.get_config_manager") as mock_get,
         patch("src.config_api.routes.get_config_manager", new=mock_get),
+        patch("src.config_api.service.get_config_manager", new=mock_get),
         patch("src.service_api.routes.get_config_manager", new=mock_get),
         patch("src.board_api.routes.get_config_manager", new=mock_get),
     ):
@@ -104,6 +105,7 @@ def mock_settings_service():
         patch("src.api_server.get_settings_service") as mock_get,
         patch("src.pages.routes.get_settings_service") as routes_get,
         patch("src.config_api.routes.get_settings_service") as config_get,
+        patch("src.config_api.service.get_settings_service", new=config_get),
         patch("src.board_guards.get_settings_service") as guards_get,
         patch("src.displays.routes.get_settings_service") as displays_get,
     ):

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -29,6 +29,7 @@ def mock_config_manager():
     with (
         patch("src.api_server.get_config_manager") as mock_get,
         patch("src.config_api.routes.get_config_manager", new=mock_get),
+        patch("src.config_api.service.get_config_manager", new=mock_get),
     ):
         cm = Mock()
         cm.get_all_masked.return_value = {"board": {}, "general": {}}
@@ -68,6 +69,7 @@ def mock_settings_service():
         patch("src.pages.routes.get_settings_service") as pages_get,
         patch("src.schedules.routes.get_settings_service") as routes_get,
         patch("src.config_api.routes.get_settings_service") as config_get,
+        patch("src.config_api.service.get_settings_service", new=config_get),
         patch("src.board_guards.get_settings_service") as guards_get,
         patch("src.displays.routes.get_settings_service") as displays_get,
     ):
@@ -1965,7 +1967,7 @@ class TestEnableLocalAPI:
         mock_resp = Mock()
         mock_resp.status_code = 200
         mock_resp.json.return_value = {"apiKey": "generated_api_key_abc"}
-        with patch("src.config_api.routes.requests.post", return_value=mock_resp):
+        with patch("src.config_api.service.requests.post", return_value=mock_resp):
             response = client.post(
                 "/config/board/enable-local-api",
                 json={
@@ -1982,7 +1984,7 @@ class TestEnableLocalAPI:
         mock_resp = Mock()
         mock_resp.status_code = 200
         mock_resp.json.return_value = {}
-        with patch("src.config_api.routes.requests.post", return_value=mock_resp):
+        with patch("src.config_api.service.requests.post", return_value=mock_resp):
             response = client.post(
                 "/config/board/enable-local-api",
                 json={
@@ -1997,7 +1999,7 @@ class TestEnableLocalAPI:
         mock_resp = Mock()
         mock_resp.status_code = 401
         mock_resp.text = "Unauthorized"
-        with patch("src.config_api.routes.requests.post", return_value=mock_resp):
+        with patch("src.config_api.service.requests.post", return_value=mock_resp):
             response = client.post(
                 "/config/board/enable-local-api",
                 json={
@@ -2012,7 +2014,7 @@ class TestEnableLocalAPI:
         mock_resp = Mock()
         mock_resp.status_code = 500
         mock_resp.text = "Internal Server Error"
-        with patch("src.config_api.routes.requests.post", return_value=mock_resp):
+        with patch("src.config_api.service.requests.post", return_value=mock_resp):
             response = client.post(
                 "/config/board/enable-local-api",
                 json={
@@ -2027,7 +2029,7 @@ class TestEnableLocalAPI:
         import requests as http_requests
 
         with patch(
-            "src.config_api.routes.requests.post", side_effect=http_requests.exceptions.ConnectionError("refused")
+            "src.config_api.service.requests.post", side_effect=http_requests.exceptions.ConnectionError("refused")
         ):
             response = client.post(
                 "/config/board/enable-local-api",
@@ -2042,7 +2044,7 @@ class TestEnableLocalAPI:
     def test_timeout_error(self, client):
         import requests as http_requests
 
-        with patch("src.config_api.routes.requests.post", side_effect=http_requests.exceptions.Timeout("timed out")):
+        with patch("src.config_api.service.requests.post", side_effect=http_requests.exceptions.Timeout("timed out")):
             response = client.post(
                 "/config/board/enable-local-api",
                 json={
@@ -2054,7 +2056,7 @@ class TestEnableLocalAPI:
         assert response.json()["success"] is False
 
     def test_generic_error(self, client):
-        with patch("src.config_api.routes.requests.post", side_effect=RuntimeError("unexpected")):
+        with patch("src.config_api.service.requests.post", side_effect=RuntimeError("unexpected")):
             response = client.post(
                 "/config/board/enable-local-api",
                 json={
@@ -2066,7 +2068,7 @@ class TestEnableLocalAPI:
 
     def test_rejects_public_ip(self, client):
         """SSRF guard: a public IP must be rejected before any HTTP request."""
-        with patch("src.config_api.routes.requests.post") as mock_post:
+        with patch("src.config_api.service.requests.post") as mock_post:
             response = client.post(
                 "/config/board/enable-local-api",
                 json={
@@ -2083,7 +2085,7 @@ class TestEnableLocalAPI:
 
     def test_rejects_aws_metadata_address(self, client):
         """SSRF guard: the AWS instance-metadata IP must be rejected."""
-        with patch("src.config_api.routes.requests.post") as mock_post:
+        with patch("src.config_api.service.requests.post") as mock_post:
             response = client.post(
                 "/config/board/enable-local-api",
                 json={
@@ -2120,7 +2122,7 @@ class TestTrafficGeocode:
         mock_resp.status_code = 200
         mock_resp.json.return_value = [{"lat": "40.7128", "lon": "-74.0060", "display_name": "NYC"}]
         mock_resp.raise_for_status = Mock()
-        with patch("src.config_api.routes.requests.get", return_value=mock_resp):
+        with patch("src.config_api.service.requests.get", return_value=mock_resp):
             response = client.post("/traffic/routes/geocode", json={"address": "NYC"})
         assert response.status_code == 200
         data = response.json()
@@ -2135,7 +2137,7 @@ class TestTrafficGeocode:
         mock_resp.status_code = 200
         mock_resp.json.return_value = []
         mock_resp.raise_for_status = Mock()
-        with patch("src.config_api.routes.requests.get", return_value=mock_resp):
+        with patch("src.config_api.service.requests.get", return_value=mock_resp):
             response = client.post("/traffic/routes/geocode", json={"address": "xyznonexistent"})
         assert response.status_code == 404
 

--- a/tests/test_board_connection_test.py
+++ b/tests/test_board_connection_test.py
@@ -48,7 +48,7 @@ def client():
 class TestBoardTestSuccess:
     """Test successful board connection responses."""
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_local_success_with_message_dict(self, mock_client_cls, mock_get, client):
         """Local API returns 200 with {message: [[...]]}."""
@@ -76,7 +76,7 @@ class TestBoardTestSuccess:
         assert data["success"] is True
         assert "successfully" in data["message"].lower()
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_local_success_with_list_response(self, mock_client_cls, mock_get, client):
         """Local API returns 200 with a list (older firmware format)."""
@@ -102,7 +102,7 @@ class TestBoardTestSuccess:
         data = response.json()
         assert data["success"] is True
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_cloud_success(self, mock_client_cls, mock_get, client):
         """Cloud API returns 200 with valid data."""
@@ -136,7 +136,7 @@ class TestBoardTestSuccess:
 class TestBoardTestAuthFailure:
     """Test auth rejection error messages with troubleshooting steps."""
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_local_401_returns_troubleshooting(self, mock_client_cls, mock_get, client):
         mock_client = Mock()
@@ -163,7 +163,7 @@ class TestBoardTestAuthFailure:
         assert "troubleshooting" in data
         assert any("Local API" in s for s in data["troubleshooting"])
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_local_403_returns_troubleshooting(self, mock_client_cls, mock_get, client):
         mock_client = Mock()
@@ -188,7 +188,7 @@ class TestBoardTestAuthFailure:
         assert data["success"] is False
         assert "rejected" in data["message"].lower()
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_cloud_401_returns_cloud_troubleshooting(self, mock_client_cls, mock_get, client):
         mock_client = Mock()
@@ -222,7 +222,7 @@ class TestBoardTestAuthFailure:
 class TestBoardTestServerError:
     """Test server error messages with troubleshooting steps."""
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_500_returns_troubleshooting(self, mock_client_cls, mock_get, client):
         mock_client = Mock()
@@ -249,7 +249,7 @@ class TestBoardTestServerError:
         assert "troubleshooting" in data
         assert any("unplug" in s.lower() for s in data["troubleshooting"])
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_502_returns_troubleshooting(self, mock_client_cls, mock_get, client):
         mock_client = Mock()
@@ -283,7 +283,7 @@ class TestBoardTestServerError:
 class TestBoardTestConnectionError:
     """Test connection error messages with troubleshooting steps."""
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_local_connection_refused(self, mock_client_cls, mock_get, client):
         mock_client = Mock()
@@ -308,7 +308,7 @@ class TestBoardTestConnectionError:
         assert "troubleshooting" in data
         assert any("same wi-fi" in s.lower() for s in data["troubleshooting"])
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_cloud_connection_error(self, mock_client_cls, mock_get, client):
         mock_client = Mock()
@@ -340,7 +340,7 @@ class TestBoardTestConnectionError:
 class TestBoardTestTimeout:
     """Test timeout error messages with troubleshooting steps."""
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_local_timeout(self, mock_client_cls, mock_get, client):
         mock_client = Mock()
@@ -365,7 +365,7 @@ class TestBoardTestTimeout:
         assert "troubleshooting" in data
         assert any("ip" in s.lower() or "address" in s.lower() for s in data["troubleshooting"])
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_cloud_timeout(self, mock_client_cls, mock_get, client):
         mock_client = Mock()
@@ -397,7 +397,7 @@ class TestBoardTestTimeout:
 class TestBoardTestUnexpectedResponse:
     """Test unexpected response format messages."""
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_200_unexpected_json_format(self, mock_client_cls, mock_get, client):
         """200 but no 'message' key and not a list → unexpected format."""
@@ -426,7 +426,7 @@ class TestBoardTestUnexpectedResponse:
         assert "status" in data.get("error", "").lower() or "keys" in data.get("error", "").lower()
         assert "troubleshooting" in data
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_cloud_200_current_message_note_layout(self, mock_client_cls, mock_get, client):
         """Cloud GET returns Vestaboard currentMessage.layout string (Note 3x15)."""
@@ -455,7 +455,7 @@ class TestBoardTestUnexpectedResponse:
         assert data["success"] is True
         assert data["api_mode"] == "cloud"
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_cloud_200_current_message_null(self, mock_client_cls, mock_get, client):
         """Cloud GET with empty board (currentMessage null) still counts as connected."""
@@ -475,7 +475,7 @@ class TestBoardTestUnexpectedResponse:
         )
         assert response.json()["success"] is True
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_200_invalid_json(self, mock_client_cls, mock_get, client):
         """200 but body is not valid JSON."""
@@ -502,7 +502,7 @@ class TestBoardTestUnexpectedResponse:
         assert data["success"] is False
         assert "troubleshooting" in data
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_unexpected_http_status(self, mock_client_cls, mock_get, client):
         """Non-200, non-401/403, non-500+ status code."""
@@ -528,7 +528,7 @@ class TestBoardTestUnexpectedResponse:
         assert data["success"] is False
         assert "troubleshooting" in data
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_200_empty_list(self, mock_client_cls, mock_get, client):
         """200 with empty list — no message data."""
@@ -564,7 +564,7 @@ class TestBoardTestUnexpectedResponse:
 class TestBoardTestGeneralError:
     """Test the catch-all exception handler."""
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_unexpected_exception(self, mock_client_cls, mock_get, client):
         mock_client = Mock()
@@ -596,7 +596,7 @@ class TestBoardTestGeneralError:
 class TestBoardTestTroubleshootingStructure:
     """Verify troubleshooting field is always a list of strings."""
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_troubleshooting_is_list_of_strings(self, mock_client_cls, mock_get, client):
         """Every error response should have troubleshooting as a list of strings."""
@@ -630,7 +630,7 @@ class TestBoardTestTroubleshootingStructure:
 class TestBoardTestPort:
     """The test endpoint honors a custom Local API port (local-array tiles)."""
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_custom_port_forwarded_to_client(self, mock_client_cls, mock_get, client):
         mock_client = Mock()
@@ -652,7 +652,7 @@ class TestBoardTestPort:
         assert response.json()["success"] is True
         assert mock_client_cls.call_args.kwargs["port"] == 7001
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_port_omitted_defaults_to_none(self, mock_client_cls, mock_get, client):
         """No port in the request → BoardClient gets None and applies its 7000 default."""

--- a/tests/test_config_contract.py
+++ b/tests/test_config_contract.py
@@ -524,3 +524,132 @@ def test_enable_local_api_returns_the_key_the_board_issued(client):
     body = response.json()
     assert body["success"] is True
     assert body["api_key"] == "issued-key-123"
+
+
+# ---------------------------------------------------------------------------
+# The verdict branches the two probes answer at 200, and the preconditions
+# they answer at 4xx.
+#
+# Pinned by value ahead of the router→service move (#1934) so that "the same
+# tests still pass" is evidence the move changed nothing. Every message below
+# was recorded from the unmodified tree; none of these branches had a value
+# pin before.
+# ---------------------------------------------------------------------------
+
+
+def test_enable_local_api_rejects_an_empty_host_before_contacting_anything(client):
+    response = client.post("/config/board/enable-local-api", json={"host": "", "enablement_token": "t"})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Board IP address is required"
+
+
+def test_enable_local_api_rejects_an_empty_token_before_contacting_anything(client):
+    response = client.post("/config/board/enable-local-api", json={"host": "192.168.1.10", "enablement_token": ""})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Enablement token is required"
+
+
+def test_enable_local_api_reports_an_unreachable_board_as_a_verdict_at_200(client):
+    import requests
+
+    with patch.object(requests, "post", side_effect=requests.exceptions.ConnectionError("refused")):
+        response = client.post(
+            "/config/board/enable-local-api",
+            json={"host": "192.168.1.10", "enablement_token": "t"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is False
+    assert body["error"] == "Connection error"
+    assert body["message"] == (
+        "Could not connect to board. Please check the IP address and ensure the board is on the same network."
+    )
+
+
+def test_enable_local_api_reports_a_timeout_as_a_verdict_at_200(client):
+    import requests
+
+    with patch.object(requests, "post", side_effect=requests.exceptions.Timeout("slow")):
+        response = client.post(
+            "/config/board/enable-local-api",
+            json={"host": "192.168.1.10", "enablement_token": "t"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is False
+    assert body["error"] == "Timeout"
+    assert body["message"] == "Connection timed out. Please check the IP address and try again."
+
+
+def test_enable_local_api_reports_a_200_without_an_api_key_as_a_failed_exchange(client):
+    import requests
+
+    with patch.object(requests, "post") as mock_post:
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {"ok": True}
+        response = client.post(
+            "/config/board/enable-local-api",
+            json={"host": "192.168.1.10", "enablement_token": "t"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is False
+    assert body["message"] == "Received response but no API key was provided"
+    assert body["error"] == "Board response did not include an apiKey"
+
+
+def test_enable_local_api_quotes_an_unexpected_board_status_in_its_verdict(client):
+    import requests
+
+    with patch.object(requests, "post") as mock_post:
+        mock_post.return_value.status_code = 500
+        response = client.post(
+            "/config/board/enable-local-api",
+            json={"host": "192.168.1.10", "enablement_token": "t"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is False
+    assert body["message"] == "Board returned an error (HTTP 500)"
+    assert body["error"] == "HTTP 500"
+
+
+def test_enable_local_api_reports_an_unanticipated_failure_as_a_generic_500(client):
+    """The detail stays generic — the exception belongs in the log (#1887)."""
+    import requests
+
+    with patch.object(requests, "post", side_effect=RuntimeError("secret internal detail")):
+        response = client.post(
+            "/config/board/enable-local-api",
+            json={"host": "192.168.1.10", "enablement_token": "t"},
+        )
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to enable local API."
+
+
+def test_validate_drops_the_legacy_board_errors_once_a_board_instance_is_configured(client):
+    """The multi-board override clears *board* errors only.
+
+    A non-board validation error must survive, and ``valid`` is recomputed
+    from what is left — the branch at the end of the first-run determination.
+    """
+    from src.config_manager import get_config_manager
+
+    _configure_board(client)
+    with patch.object(
+        get_config_manager(),
+        "validate",
+        return_value=(False, ["Board host is not set", "Timezone is not a known IANA name"]),
+    ):
+        body = client.get("/config/validate").json()
+
+    assert body["is_first_run"] is False
+    assert body["errors"] == ["Timezone is not a known IANA name"]
+    assert body["valid"] is False

--- a/tests/test_config_decoupled.py
+++ b/tests/test_config_decoupled.py
@@ -37,6 +37,7 @@ import src.config_api.routes as routes
 from src.config_api.models import BoardConfigUpdate, BoardScanRequest, GeneralConfigUpdate
 
 assert "src.api_server" not in sys.modules, "importing the config router must not import api_server"
+assert "src.config_api.service" in sys.modules, "the router must resolve its service at import time"
 
 
 def call(coro):
@@ -71,6 +72,8 @@ service = MagicMock()
 with (
     patch("src.config_api.routes.get_config_manager", return_value=config_manager),
     patch("src.config_api.routes.get_settings_service", return_value=settings_service),
+    patch("src.config_api.service.get_config_manager", return_value=config_manager),
+    patch("src.config_api.service.get_settings_service", return_value=settings_service),
     patch("src.config_api.routes.primary_board_entry", return_value={"host": "192.0.2.4", "local_api_key": "stored"}),
     patch("src.config_api.routes.reinitialize_board_clients") as reinit,
     patch("src.config_api.routes.get_service", return_value=service),
@@ -140,7 +143,7 @@ def test_config_router_source_declares_no_api_server_import():
     rarely-taken ``except`` branch fails the build too.
     """
     offenders: list[str] = []
-    for name in ("routes.py", "models.py", "__init__.py"):
+    for name in ("routes.py", "service.py", "models.py", "__init__.py"):
         tree = ast.parse((REPO_ROOT / "src" / "config_api" / name).read_text())
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):

--- a/tests/test_silence_per_board_call_sites.py
+++ b/tests/test_silence_per_board_call_sites.py
@@ -141,9 +141,9 @@ class TestApiSendGuards:
         with (
             _board_aware_silence(),
             patch("src.transitions.routes._ensure_transition_plugins_beta"),
-            patch("src.transitions.routes.get_plugin_registry", return_value=registry),
-            patch("src.transitions.routes._resolve_live_board_client", return_value=(BOARDS[0], MagicMock())),
-            patch("src.transitions.routes.get_settings_service", return_value=_settings(primary=LOUD_BOARD)),
+            patch("src.transitions.service.get_plugin_registry", return_value=registry),
+            patch("src.transitions.service._resolve_live_board_client", return_value=(BOARDS[0], MagicMock())),
+            patch("src.transitions.service.get_settings_service", return_value=_settings(primary=LOUD_BOARD)),
         ):
             response = client.post(
                 "/transitions/test-live",
@@ -159,8 +159,8 @@ class TestApiSendGuards:
         with (
             _board_aware_silence(),
             patch("src.transitions.routes._ensure_transition_plugins_beta"),
-            patch("src.transitions.routes._resolve_live_board_client", return_value=(BOARDS[0], MagicMock())),
-            patch("src.transitions.routes.get_settings_service", return_value=_settings(primary=LOUD_BOARD)),
+            patch("src.transitions.service._resolve_live_board_client", return_value=(BOARDS[0], MagicMock())),
+            patch("src.transitions.service.get_settings_service", return_value=_settings(primary=LOUD_BOARD)),
         ):
             response = client.post("/transitions/restore", json={"board_id": SILENCED_BOARD})
 

--- a/tests/test_small_domains_decoupled.py
+++ b/tests/test_small_domains_decoupled.py
@@ -292,13 +292,14 @@ settings_service.get_beta_settings.return_value = SimpleNamespace(transition_plu
 settings_service.get_active_page_id.return_value = "p1"
 
 with (
-    patch("src.transitions.routes.get_plugin_registry", return_value=registry),
     patch("src.transitions.routes.get_settings_service", return_value=settings_service),
-    patch("src.transitions.routes.get_service", return_value=service),
-    patch("src.transitions.routes.get_page_service", return_value=page_service),
-    patch("src.transitions.routes._silence_active", return_value=False),
-    patch("src.transitions.routes._board_is_paused", return_value=False),
-    patch("src.transitions.routes.LIVE_TEST_FROM_HOLD_SECONDS", 0),
+    patch("src.transitions.service.get_plugin_registry", return_value=registry),
+    patch("src.transitions.service.get_settings_service", return_value=settings_service),
+    patch("src.transitions.service.get_service", return_value=service),
+    patch("src.transitions.service.get_page_service", return_value=page_service),
+    patch("src.transitions.service._silence_active", return_value=False),
+    patch("src.transitions.service._board_is_paused", return_value=False),
+    patch("src.transitions.service.LIVE_TEST_FROM_HOLD_SECONDS", 0),
 ):
     listed = asyncio.run(routes.list_transition_plugins())
     assert listed.plugins == [], listed

--- a/tests/test_status_code_correctness.py
+++ b/tests/test_status_code_correctness.py
@@ -74,7 +74,7 @@ class TestBoardTestPreconditions:
         answering 200 made a rejected request indistinguishable from a
         board that merely refused the key.
         """
-        with patch("src.config_api.routes.requests.get") as mock_get:
+        with patch("src.config_api.service.requests.get") as mock_get:
             response = client.post(
                 "/config/board/test",
                 json={"api_mode": "local", "local_api_key": "key", "host": "evil.example.com/@10.0.0.1"},
@@ -86,7 +86,7 @@ class TestBoardTestPreconditions:
 class TestBoardTestUpstreamVerdictsStay200:
     """The declared contract: an upstream board result is data, not an error."""
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_board_rejects_key_stays_200_with_typed_body(self, mock_client_cls, mock_get, client):
         mock_client_cls.return_value = _local_client_mock()
@@ -101,7 +101,7 @@ class TestBoardTestUpstreamVerdictsStay200:
         assert body["success"] is False
         assert isinstance(body["troubleshooting"], list)
 
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_board_unreachable_stays_200(self, mock_client_cls, mock_get, client):
         mock_client_cls.return_value = _local_client_mock()
@@ -119,7 +119,7 @@ class TestBoardTestUpstreamVerdictsStay200:
 
 
 class TestBoardTestUnexpectedErrors:
-    @patch("src.config_api.routes.requests.get")
+    @patch("src.config_api.service.requests.get")
     @patch("src.board_client.BoardClient")
     def test_unexpected_exception_is_500(self, mock_client_cls, mock_get, client):
         mock_client_cls.return_value = _local_client_mock()
@@ -149,7 +149,7 @@ class TestEnableLocalApiPreconditions:
 
     def test_public_ip_is_400_and_issues_no_request(self, client):
         """SSRF guard (#1887): the 400 must reach the client as a 400."""
-        with patch("src.config_api.routes.requests.post") as mock_post:
+        with patch("src.config_api.service.requests.post") as mock_post:
             response = client.post(
                 "/config/board/enable-local-api",
                 json={"host": "8.8.8.8", "enablement_token": "test_token"},
@@ -161,9 +161,9 @@ class TestEnableLocalApiPreconditions:
         import socket as socket_mod
 
         with (
-            patch("src.config_api.routes.validate_board_host_is_local_network"),
+            patch("src.config_api.service.validate_board_host_is_local_network"),
             patch("socket.getaddrinfo", side_effect=socket_mod.gaierror("no such host")),
-            patch("src.config_api.routes.requests.post") as mock_post,
+            patch("src.config_api.service.requests.post") as mock_post,
         ):
             response = client.post(
                 "/config/board/enable-local-api",
@@ -175,7 +175,7 @@ class TestEnableLocalApiPreconditions:
 
 class TestEnableLocalApiUpstreamVerdictsStay200:
     def test_invalid_enablement_token_stays_200(self, client):
-        with patch("src.config_api.routes.requests.post", return_value=Mock(status_code=401)):
+        with patch("src.config_api.service.requests.post", return_value=Mock(status_code=401)):
             response = client.post(
                 "/config/board/enable-local-api",
                 json={"host": "192.168.1.100", "enablement_token": "bad"},
@@ -189,7 +189,7 @@ class TestEnableLocalApiUpstreamVerdictsStay200:
 
 class TestEnableLocalApiUnexpectedErrors:
     def test_unexpected_exception_is_500(self, client):
-        with patch("src.config_api.routes.requests.post", side_effect=RuntimeError("unexpected")):
+        with patch("src.config_api.service.requests.post", side_effect=RuntimeError("unexpected")):
             response = client.post(
                 "/config/board/enable-local-api",
                 json={"host": "192.168.1.100", "enablement_token": "test_token"},

--- a/tests/test_transitions_api.py
+++ b/tests/test_transitions_api.py
@@ -21,7 +21,7 @@ from types import SimpleNamespace
 import pytest
 from fastapi import HTTPException
 
-import src.transitions.routes as transitions_routes
+import src.transitions.service as transitions_service
 from src.config import Config
 from src.plugins.base import TransitionPluginBase
 from src.plugins.manifest import PluginManifest
@@ -366,12 +366,12 @@ def live_env(monkeypatch, patched_registry):
     no silence, no pause, zero from-page hold."""
     board_client = _FakeBoardClient()
     fake_service = SimpleNamespace(vb_client=board_client, get_board_client=lambda board_id: board_client)
-    monkeypatch.setattr(transitions_routes, "get_service", lambda: fake_service)
-    monkeypatch.setattr(transitions_routes, "get_page_service", _FakePageService)
+    monkeypatch.setattr(transitions_service, "get_service", lambda: fake_service)
+    monkeypatch.setattr(transitions_service, "get_page_service", _FakePageService)
     # Since issue #1788 the guard resolves the target board, so the stub takes a board_id.
     monkeypatch.setattr(Config, "is_silence_mode_active", staticmethod(lambda board_id=None: False))
-    monkeypatch.setattr(transitions_routes, "_board_is_paused", lambda board_id=None: False)
-    monkeypatch.setattr(transitions_routes, "LIVE_TEST_FROM_HOLD_SECONDS", 0)
+    monkeypatch.setattr(transitions_service, "_board_is_paused", lambda board_id=None: False)
+    monkeypatch.setattr(transitions_service, "LIVE_TEST_FROM_HOLD_SECONDS", 0)
     return board_client
 
 
@@ -434,7 +434,7 @@ def test_live_blocked_by_silence_mode(live_env, monkeypatch):
 
 
 def test_live_blocked_when_board_paused(live_env, monkeypatch):
-    monkeypatch.setattr(transitions_routes, "_board_is_paused", lambda board_id=None: True)
+    monkeypatch.setattr(transitions_service, "_board_is_paused", lambda board_id=None: True)
     with pytest.raises(HTTPException) as exc:
         _run(_live({"plugin_id": "fake_typewriter", "to_page_id": "page-to"}))
     assert exc.value.status_code == 409
@@ -445,7 +445,7 @@ def test_restore_sends_active_page_plainly(live_env, monkeypatch):
         get_active_page_id=lambda board_id=None: "page-to",
         get_beta_settings=lambda: SimpleNamespace(transition_plugins_enabled=True),
     )
-    monkeypatch.setattr(transitions_routes, "get_settings_service", lambda: fake_settings)
+    monkeypatch.setattr(transitions_service, "get_settings_service", lambda: fake_settings)
     data = _run(_restore({}))
     assert data.status == "success"
     assert data.page_id == "page-to"
@@ -458,7 +458,7 @@ def test_restore_without_active_page_returns_404(live_env, monkeypatch):
         get_active_page_id=lambda board_id=None: None,
         get_beta_settings=lambda: SimpleNamespace(transition_plugins_enabled=True),
     )
-    monkeypatch.setattr(transitions_routes, "get_settings_service", lambda: fake_settings)
+    monkeypatch.setattr(transitions_service, "get_settings_service", lambda: fake_settings)
     with pytest.raises(HTTPException) as exc:
         _run(_restore({}))
     assert exc.value.status_code == 404
@@ -506,3 +506,33 @@ def test_page_create_persists_transition_fields(tmp_path):
     assert stored.transition_strategy == "plugin:fake_typewriter"
     assert stored.transition_interval_ms == 50
     assert stored.transition_step_size == 2
+
+
+# ---------------------------------------------------------------------------
+# The unreachable-board branch of both live endpoints.
+#
+# Pinned by value ahead of the router→service move (#1934): the 502 travelled
+# from the handler into ``src/transitions/service.py`` and back out through
+# the router's error translation, and nothing covered it before.
+# ---------------------------------------------------------------------------
+
+
+def test_live_reports_an_unreachable_board_as_502(live_env, monkeypatch):
+    monkeypatch.setattr(live_env, "render", lambda *a, **k: (False, False))
+    with pytest.raises(HTTPException) as exc:
+        _run(_live({"plugin_id": "fake_typewriter", "to_page_id": "page-to"}))
+    assert exc.value.status_code == 502
+    assert exc.value.detail == "Board unreachable - live test failed"
+
+
+def test_restore_reports_an_unreachable_board_as_502(live_env, monkeypatch):
+    fake_settings = SimpleNamespace(
+        get_active_page_id=lambda board_id=None: "page-to",
+        get_beta_settings=lambda: SimpleNamespace(transition_plugins_enabled=True),
+    )
+    monkeypatch.setattr(transitions_service, "get_settings_service", lambda: fake_settings)
+    monkeypatch.setattr(live_env, "render", lambda *a, **k: (False, False))
+    with pytest.raises(HTTPException) as exc:
+        _run(_restore({}))
+    assert exc.value.status_code == 502
+    assert exc.value.detail == "Board unreachable - restore failed"

--- a/tests/test_transitions_contract.py
+++ b/tests/test_transitions_contract.py
@@ -97,6 +97,53 @@ def registry(monkeypatch):
     return fresh
 
 
+class _CrashesMidRun(TransitionPluginBase):
+    """Yields one good frame, then raises — the plugin-error branch."""
+
+    @property
+    def plugin_id(self) -> str:
+        return "contract_crashes"
+
+    def generate_frames(self, from_grid, to_grid, device, config):
+        yield to_grid, 0
+        raise RuntimeError("boom")
+
+
+class _YieldsRubbish(TransitionPluginBase):
+    """Yields one unusable value between two good frames."""
+
+    @property
+    def plugin_id(self) -> str:
+        return "contract_rubbish"
+
+    def generate_frames(self, from_grid, to_grid, device, config):
+        yield to_grid, 0
+        yield "not a grid"
+        yield to_grid, 0
+
+
+def _install(registry_mod, fresh, plugin_cls, plugin_id):
+    """Add one hand-built transition plugin to *fresh* under *plugin_id*."""
+    manifest = dict(_TWO_FRAMES_MANIFEST, id=plugin_id, name=plugin_id)
+    plugin = plugin_cls(manifest)
+    plugin.config = {}
+    fresh._plugins[plugin_id] = plugin
+    fresh._manifests[plugin_id] = PluginManifest.from_dict(manifest)
+    fresh._enabled[plugin_id] = True
+
+
+@pytest.fixture
+def misbehaving_registry(monkeypatch):
+    """A registry holding the two plugins that misbehave on purpose."""
+    from src.plugins import registry as registry_mod
+
+    fresh = registry_mod.PluginRegistry()
+    _install(registry_mod, fresh, _CrashesMidRun, "contract_crashes")
+    _install(registry_mod, fresh, _YieldsRubbish, "contract_rubbish")
+    monkeypatch.setattr(registry_mod, "_registry", fresh)
+    return fresh
+
+
 # ---------------------------------------------------------------------------
 # The beta gate
 # ---------------------------------------------------------------------------
@@ -273,3 +320,30 @@ def test_restore_accepts_an_omitted_body(client, beta_on, registry):
     response = client.post("/transitions/restore")
     assert response.status_code == 503
     assert response.json()["detail"] == "Service not initialized"
+
+
+# ---------------------------------------------------------------------------
+# What the preview frame loop does with a plugin that misbehaves.
+#
+# Pinned by value ahead of the router→service move (#1934): the loop moved out
+# of the router into ``src/transitions/service.py`` and now shares its frame
+# coercion with the runner, so "the same tests still pass" has to cover the
+# branches where the two loops deliberately differ.
+# ---------------------------------------------------------------------------
+
+
+def test_preview_reports_a_crashing_plugin_as_a_500_quoting_the_error(client, beta_on, misbehaving_registry):
+    response = client.post("/transitions/preview", json={"plugin_id": "contract_crashes", "to_text": "HI"})
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Plugin error: boom"
+
+
+def test_preview_skips_a_malformed_frame_rather_than_failing_the_run(client, beta_on, misbehaving_registry):
+    """A preview shows the frames it could read; only the runner aborts."""
+    response = client.post("/transitions/preview", json={"plugin_id": "contract_rubbish", "to_text": "HI"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["frame_count"] == 2
+    assert body["capped"] is False


### PR DESCRIPTION
## What

`config_api`, `transitions` and `system` each failed `tests/test_layering_ratchet.py`'s `router_no_domain_logic` rule; `system` also failed `service_no_fastapi`. This moves the logic **down** into services and appends all three to `tests/layering_manifest.json`.

Measured before:

```
=== config_api ===
  routes.py::validate_config       40 statements, cc 16
  routes.py::test_board_connection 53 statements, cc 20
  routes.py::enable_local_api      46 statements, cc 20
=== transitions ===
  routes.py::_preview_transition_impl         63 statements, cc 24
  routes.py::run_live_transition_test         46 statements, cc 19
  routes.py::restore_after_transition_test    30 statements, cc 11
=== system ===
  update_service.py: imports fastapi
  routes.py::system_update_apply     23 statements
  routes.py::system_update_rollback  51 statements, cc 20
```

After: all three domains report nothing on all three rules, with **no exception recorded** and no rule loosened.

## Lines moved

| Domain | Router before → after | Service | Domain total |
|---|---|---|---|
| `config_api` | 759 → 441 | `service.py` **new**, 512 | +194 |
| `transitions` | 493 → 180 | `service.py` **new**, 405; `runner.py` 396 → 400 | +96 |
| `system` | 458 → 284 | `update_service.py` 806 → 1063 | +83 |

**~800 lines of handler body left the three routers.** `src/` goes 60,651 → 61,028 (**+377, +0.6%**) — not net-neutral, and worth saying why: the expansion is module docstrings on two new files, the two exception classes and their translation seams, and five named verdict helpers in `config_api/service.py` that exist because `probe_board_connection`'s decision tree had to come apart to fit under the size proxy. No behaviour was added.

## What did not move

- **No status code, response shape or error string.** Every refusal is raised as a domain error carrying the status and detail the router hands straight to `HTTPException`.
- **`tests/golden/api_routes.json` is byte-identical.** This moves code, not routes.
- **The `except HTTPException: raise` arms.** Each one moved with its code as `except <DomainError>: raise`, in the same position, still ahead of the broad `except Exception` that would otherwise swallow the function's own refusal and re-raise it as a 500.
- **`src/plugin_support/routes.py`** — untouched, as are `settings/routes.py`, `board_api/routes.py`, `templates/routes.py` and `displays/routes.py`.

## The CodeQL barriers — what I found

Both `config_api` probes were checked before anything moved.

- **`enable_local_api` has a real, shape-dependent barrier.** It carries the inline `ipaddress.IPv4Address` derivation + `is_private`/`is_loopback`/`is_link_local` gate, and GitHub code scanning shows two historical `py/full-ssrf` alerts on this repo (`src/api_server.py:3638`, `:8334`), both now `fixed` — closed by exactly this sequence. **The sequence moved whole**: the guard, the address it derives, the URL built from that address, and the `requests.post` that uses it are still one unbroken block inside one function. Only the exception class raised on rejection changed (`HTTPException` → `BoardProbeError`), because a domain module may not import `fastapi`; the class of a `raise` is not a CodeQL barrier or sanitiser. A comment in `src/config_api/service.py` says so, in terms, so nobody "tidies" it later.
- **`test_board_connection` has no inline sanitiser.** Its host handling is a call to `src.board_guards.validate_board_host`, which did not move and is shared by six routers. Nothing there was shape-sensitive.
- Open code-scanning alerts before this PR: **zero**. If any `py/full-ssrf` alert appears on this branch, that is the signal to revert the `enable_local_api` move specifically.

## Two `no_200_on_failure` exceptions are deleted — read this bit

`tests/conventions_manifest.json` excused `POST /config/board/test` and `POST /config/board/enable-local-api` from `no_200_on_failure`, because a probe reports its verdict at 200. Both entries went **dead** the moment the verdict bodies moved into the service: that rule walks the *handler's own* AST, and the handler no longer builds a `{"success": false, ...}` dict. `validate_manifest` fails the build on a dead exception, so both had to go.

Nothing about the contract changed, and nothing is left unguarded — the status/verdict pairs are pinned **by value** in `tests/test_config_contract.py` and `tests/test_status_code_correctness.py`, which is a stronger guarantee than the AST proxy was giving. The general lesson (moving logic *out* of a handler silently retires this ratchet's coverage of it, so the value pins have to exist first) is now written into `API_CONVENTIONS.md`.

## Zero-regression evidence

Twelve value pins were added for branches the moved code owned and that had no pin: the enablement-exchange verdicts (empty host, empty token, connection error, timeout, 200-without-apiKey, unexpected status, generic 500), the multi-board validation-error filtering, a transition plugin that crashes mid-run, a malformed frame, and both unreachable-board 502s.

**All twelve pass against unmodified `origin/next`** — staged onto a clean checkout of `497f825ae` with the two `transitions_api` pins repointed to the pre-move binding:

```
tests/test_config_contract.py ..........................................
tests/test_transitions_contract.py ....................
tests/test_transitions_api.py ..........................
============================= 90 passed in 28.11s ==============================
```

and they pass on this branch unchanged.

Full suite, `pytest tests/ -m "not integration" -n auto`, same container both sides:

| | passed | skipped | failed |
|---|---|---|---|
| `origin/next` | 6862 | 1 | 1 |
| this branch | 6874 | 1 | 1 |

Collected node ids are a **strict superset**: 6864 → 6876, zero removed, exactly the 12 added. The one failure is `test_check_image_formats.py::TestRepositoryIsClean`, which fails identically on `origin/next` in this container — it shells out to `git ls-files` and the worktree's `.git` file points outside the bind mount. Environmental; it passes in CI.

**Data-dir leak: 0** (checksummed before and after, no diff).

`ruff==0.16.5` `check` and `format --check` clean over `src/ plugins/ tests/ scripts/`.

## Each manifest entry is load-bearing

Reintroduced a chunk of the moved logic into each router and captured the ratchet's verbatim failure. All four reverted afterwards.

`config_api` — the first-run determination back inline:

```
E   src/config_api/routes.py::validate_config: line 277: 26 statements (max 15) and cyclomatic complexity 10 (max 8) — move the decision-making into the domain's service
```

`transitions` — the frame-cap loop back inline:

```
E   src/transitions/routes.py::preview_transition: line 107: 33 statements (max 15) — move the decision-making into the domain's service
```

`system` — the rollback workflow back inline, and `from fastapi import HTTPException` back on the service:

```
E   src/system/update_service.py: imports fastapi — a domain module must be callable from MQTT, MCP, the display loop and a test without a web framework
E   src/system/routes.py::system_update_rollback: line 181: 25 statements (max 15) and cyclomatic complexity 12 (max 8) — move the decision-making into the domain's service
```

## Not a redesign

Two places where the "obvious" collapse would have changed behaviour and was deliberately not taken:

- **The preview frame loop is not folded into `TransitionRunner._drive_generator`.** They differ on two axes that matter: the runner *sends* each frame and aborts the run on a malformed one; the preview *collects* frames into JSON and skips a malformed one so the harness still shows the rest. What the two genuinely shared — coercing a yielded value into `(grid, delay_ms)` — is now one function, `runner.unpack_frame`, called by both, and it is a faithful drop-in (verified case by case against the preview's open-coded copy). A `test_preview_skips_a_malformed_frame_rather_than_failing_the_run` pin records the difference.
- **`_verdict_for_ok_response` keeps the whole read inside one `except ValueError`.** Splitting the shape inspection out of that `try` would have sent a `ValueError` raised past `json()` to the caller's own `except ValueError` — a 400 instead of a 200 verdict.

## Open

- `src.board_guards.validate_board_host` / `validate_board_host_is_local_network` and `_require_board` still raise `fastapi.HTTPException` and are now called from inside two services. The ratchet checks *imports*, so this passes, and the behaviour is identical to before the move — but it is a real wart. Fixing it means giving those shared guards a non-HTTP error and translating in six routers, which is its own PR and touches files another agent is editing this wave.
- `tests/conftest.py::_drop_all_singletons` was left alone: both new modules are stateless (module-level functions, no singleton), so there is nothing to reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mYPdfxvAKCmztHasToHzH