### PR TITLE
perf(engine): close the measured Pi findings — fingerprint cost, fetch dispatch, timeout keying, loop blocking, no-op writes

### DIFF
--- a/docs/internal/reference/ARCHITECTURE.md
+++ b/docs/internal/reference/ARCHITECTURE.md
@@ -153,6 +153,13 @@ Names you will meet:
   unchanged tick skips the render entirely. It re-checks its own content
   against the live dedupe cache before it is trusted, which is why every
   existing cache-invalidation site invalidates the memo for free.
+  The fingerprint enters each plugin's payload as a hash computed once on the
+  `PluginResult` that `PluginBase` cached, not by re-encoding the
+  payload, and the fingerprint itself is memoised per board **size** inside
+  the per-tick context cache. Both matter: without them, deciding "nothing
+  changed" cost one full `json.dumps` of every referenced payload per board
+  per tick. The memo is per-size and never global, because board-aware plugins
+  legitimately return different data per geometry.
 - **Silence and pause** are per board, resolved through `src/board_guards.py`.
   Every send path asks; both guards degrade to "not blocked" and log rather
   than raising, because a guard that raises turns an unrelated failure into a
@@ -172,9 +179,20 @@ Two properties are load-bearing and easy to break:
   deadlock, and no other test would see it.
 - **A wedged plugin cannot starve the healthy ones.** Fetches run on one
   shared bounded pool, in-flight dedupe caps each plugin at one worker, and a
-  per-plugin circuit breaker takes a repeatedly-timing-out plugin out of
-  rotation. Without the breaker, eight distinct wedged plugins were enough to
-  block every plugin's data.
+  circuit breaker takes a repeatedly-timing-out plugin out of rotation.
+  Without the breaker, eight distinct wedged plugins were enough to block
+  every plugin's data. The breaker, the in-flight dedupe and the fetch itself
+  are all keyed by `(plugin_id, board_key)` — one plugin on one geometry —
+  and they must stay that way: keyed by `plugin_id` alone, two boards charged
+  two timeouts per tick and one healthy geometry cleared the streak a wedged
+  one was accumulating.
+- **`CONTEXT_BUILD_TIMEOUT_SECONDS` must stay below the poll interval.**
+  `build_template_context` blocks the service thread that also runs the 1 Hz
+  silence-boundary detector, so a budget equal to the tick period lets one
+  slow plugin consume a whole tick *and* delay silence entry by that long.
+- **An already-cached plugin is read on the calling thread**, not dispatched
+  to the pool. A fully cached tick therefore never enters `futures_wait` and
+  can never pay the fetch budget for a plugin it was not going to talk to.
 
 ## Operations: one grammar for chat and MCP
 

--- a/docs/internal/reference/PERSISTENCE.md
+++ b/docs/internal/reference/PERSISTENCE.md
@@ -16,6 +16,17 @@ because the third rule is deliberately *not* enforced at all.
 crash mid-write leaves the previous contents fully intact (#1304); the partial
 staging file is removed rather than leaked.
 
+`if_changed=True` reads the target first and skips the write when the bytes
+would be identical, returning whether it wrote. `ConfigManager` and
+`JsonStore` both use it, so a restart that merges in no new defaults, and a
+PUT that stores the value already stored, cost zero fsyncs instead of one
+each. It is opt-in because a caller that writes to signal liveness must keep
+writing. A read that fails for any reason answers "changed", so the failure
+mode is a needless write and never a skipped one.
+
+`config_generation` is deliberately NOT conditional on the write happening.
+It means "what this process reads has moved", not "the disk moved".
+
 Every store's default path resolves through `src.paths.get_data_dir()`, the one
 seam that honours `FIESTABOARD_DATA_DIR`. `tests/test_data_dir_isolation.py` is
 the guard: it constructs each store with defaults and asserts the resulting

--- a/src/atomic_io.py
+++ b/src/atomic_io.py
@@ -83,7 +83,8 @@ def write_json_atomic(
     *,
     indent: int | None = 2,
     private: bool = False,
-) -> None:
+    if_changed: bool = False,
+) -> bool:
     """Serialise *data* as JSON onto *target* without ever truncating it.
 
     Stages the JSON in the process-scoped sibling from :func:`staging_path`,
@@ -95,12 +96,29 @@ def write_json_atomic(
     Parent directories are created if missing. ``private=True`` creates the
     file owner-only (0600). Exceptions propagate — the caller decides whether
     a failed save is fatal.
+
+    ``if_changed=True`` reads the existing file first and does nothing when
+    the bytes would be identical. An SD card is not worn out by writes that
+    change something; it is worn out by writes, and a rewrite of identical
+    content is the one class of write with no upside at all. The cost of the
+    check is a read of a file we were about to rewrite anyway, against an
+    fsync we then skip entirely.
+
+    It is deliberately opt-in. A caller that writes to signal liveness (a
+    heartbeat, a mtime other code reads) must keep writing, and only the
+    caller knows that.
+
+    Returns True when the file was written, False when an ``if_changed`` write
+    was skipped as a no-op.
     """
     target.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(data, indent=indent)
+    if if_changed and _matches(target, payload):
+        return False
     tmp_path = staging_path(target)
     try:
         with _open_staging(tmp_path, private) as fh:
-            json.dump(data, fh, indent=indent)
+            fh.write(payload)
             fh.flush()
             os.fsync(fh.fileno())
         tmp_path.replace(target)
@@ -108,6 +126,21 @@ def write_json_atomic(
         with contextlib.suppress(OSError):
             tmp_path.unlink(missing_ok=True)
         raise
+    return True
+
+
+def _matches(target: Path, payload: str) -> bool:
+    """True when *target* already holds exactly *payload*.
+
+    Any problem reading it — missing, unreadable, wrong encoding — answers
+    False, so an ``if_changed`` write degrades to an ordinary write rather
+    than to a silent skip. The failure mode has to be "wrote when it did not
+    need to", never "did not write when it did".
+    """
+    try:
+        return target.read_text(encoding="utf-8") == payload
+    except (OSError, UnicodeDecodeError):
+        return False
 
 
 def write_text_atomic(target: Path, text: str, *, private: bool = False) -> None:

--- a/src/atomic_io.py
+++ b/src/atomic_io.py
@@ -101,8 +101,8 @@ def write_json_atomic(
     the bytes would be identical. An SD card is not worn out by writes that
     change something; it is worn out by writes, and a rewrite of identical
     content is the one class of write with no upside at all. The cost of the
-    check is a read of a file we were about to rewrite anyway, against an
-    fsync we then skip entirely.
+    check is a read of a file we were about to rewrite anyway plus one
+    in-memory serialisation, against an fsync we then skip entirely.
 
     It is deliberately opt-in. A caller that writes to signal liveness (a
     heartbeat, a mtime other code reads) must keep writing, and only the
@@ -112,13 +112,19 @@ def write_json_atomic(
     was skipped as a no-op.
     """
     target.parent.mkdir(parents=True, exist_ok=True)
-    payload = json.dumps(data, indent=indent)
-    if if_changed and _matches(target, payload):
+    if if_changed and _matches(target, json.dumps(data, indent=indent)):
         return False
     tmp_path = staging_path(target)
     try:
+        # ``json.dump`` streams into the staging file rather than building the
+        # whole document first. That is load-bearing, not incidental: a
+        # serialisation failure partway through must leave a partial STAGING
+        # file that gets unlinked below, never a partial target
+        # (tests/test_storage_kernel.py crashes json.dump to prove it). The
+        # ``if_changed`` comparison above therefore serialises separately
+        # instead of reusing this write's output.
         with _open_staging(tmp_path, private) as fh:
-            fh.write(payload)
+            json.dump(data, fh, indent=indent)
             fh.flush()
             os.fsync(fh.fileno())
         tmp_path.replace(target)

--- a/src/board_api/routes.py
+++ b/src/board_api/routes.py
@@ -69,6 +69,7 @@ from src.board_client import board_client_from_board_dict
 from src.board_guards import _board_dims, _require_board, _silence_active
 from src.board_guards import raise_if_paused as _raise_if_paused
 from src.board_guards import raise_if_throttled as _raise_if_throttled
+from src.board_send_executor import run_board_send
 from src.config_manager import get_config_manager
 from src.devices import resolve_dimensions
 from src.text_to_board import text_to_board_array
@@ -366,7 +367,10 @@ async def send_welcome_message():
     board_array = text_to_board_array("\n".join(welcome_template), rows=dims.rows, cols=dims.cols)
 
     try:
-        success, was_sent = board_client.render(
+        # Board network I/O goes on the dedicated bounded send pool, never
+        # inline on the event loop (#1878) — see src/board_send_executor.py.
+        success, was_sent = await run_board_send(
+            board_client.render,
             board_array,
             strategy=transition.strategy,
             step_interval_ms=transition.step_interval_ms,

--- a/src/config_api/service.py
+++ b/src/config_api/service.py
@@ -490,7 +490,12 @@ async def exchange_enablement_token(request: EnablementTokenRequest) -> dict:
 
     try:
         logger.info(f"Attempting to enable local API on {request.host}")
-        response = http_requests.post(url, headers=headers, timeout=10)
+        # Off the event loop (#1826 class): a board that accepts the connection
+        # and never answers holds the loop for the full 10s timeout otherwise.
+        # The sink's arguments are unchanged and it stays adjacent to the
+        # private-network gate above, so the SSRF barrier #1938 verified with
+        # CodeQL is not reshaped — only the thread it runs on changes.
+        response = await asyncio.to_thread(http_requests.post, url, headers=headers, timeout=10)
         return _verdict_for_enablement_response(response, request.host)
     except http_requests.exceptions.ConnectionError as e:
         logger.error(f"Local API enablement connection error: {e}")

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -737,11 +737,21 @@ class ConfigManager:
 
             write_json_atomic(target, doc)
 
+            # These accumulate one file per version change forever otherwise
+            # (58 files / 1.3 MB observed live). Same retention as the
+            # pre-update snapshots this shares a directory and a filename
+            # shape with; imported lazily because update_service pulls in the
+            # backup service, which reaches back into this module.
+            from src.system.update_service import prune_snapshot_dir
+
+            pruned = prune_snapshot_dir(snapshot_dir)
+
             logger.info(
-                "Version change detected (%s -> %s); pre-init snapshot written to %s",
+                "Version change detected (%s -> %s); pre-init snapshot written to %s%s",
                 seen or "<unknown>",
                 current_version,
                 target.name,
+                f" ({pruned} older snapshot(s) pruned)" if pruned else "",
             )
         except Exception:
             logger.warning(
@@ -882,15 +892,27 @@ class ConfigManager:
         scoped staging file + ``os.replace``) so a mid-write crash (OOM,
         SIGKILL, power loss) never leaves a truncated config file (see #1304)
         and concurrent processes never collide on a fixed staging name.
+
+        ``if_changed``: the boot path calls this unconditionally after the
+        defaults merge, and on a normal restart the merge changes nothing —
+        measured, config.json's md5 is identical before and after. That was one
+        fsync + rename per restart for no content change, and the same is true
+        of any PUT that stores the value already stored. Only the disk write is
+        conditional; the generation bump below is not.
         """
         # Bump BEFORE the write (and regardless of its outcome): the in-memory
         # config this process reads from has already changed by the time any
         # caller reaches a save, so generation-keyed caches must invalidate
-        # even when the disk write fails (issue #1752).
+        # even when the disk write fails (issue #1752). This must NOT become
+        # conditional on the write happening — a caller that mutated the config
+        # and then wrote identical bytes still changed what this process reads
+        # if the file on disk was ahead of it.
         self._config_generation = getattr(self, "_config_generation", 0) + 1
         try:
-            write_json_atomic(self._config_path, self._config)
-            logger.debug(f"Saved config to {self._config_path}")
+            if write_json_atomic(self._config_path, self._config, if_changed=True):
+                logger.debug(f"Saved config to {self._config_path}")
+            else:
+                logger.debug(f"Config unchanged on disk; skipped rewrite of {self._config_path}")
         except OSError as e:
             logger.error(f"Failed to save config: {e}")
             raise

--- a/src/displays/routes.py
+++ b/src/displays/routes.py
@@ -14,12 +14,14 @@ Tests that need to stub a collaborator patch it where this module binds it —
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from fastapi import APIRouter, HTTPException, Response
 
 from src.api_errors import errors
 from src.board_guards import _board_is_paused
+from src.board_send_executor import run_board_send
 from src.devices import resolve_dimensions
 from src.display_runtime import get_service
 from src.settings.service import VALID_OUTPUT_TARGETS, get_settings_service
@@ -75,7 +77,8 @@ async def get_display(display_type: str):
         Formatted message text ready for display on board.
     """
     display_service = get_display_service()
-    result = display_service.get_display(display_type)
+    # Plugin data fetch — never on the event loop.
+    result = await asyncio.to_thread(display_service.get_display, display_type)
 
     # Check for invalid display type (will have error message about valid types)
     if not result.available and result.error and "Unknown display type" in result.error:
@@ -125,7 +128,8 @@ async def get_display_raw(display_type: str, response: Response):
     response.headers["Link"] = f'</plugins/{display_type}/data>; rel="successor-version"'
 
     display_service = get_display_service()
-    result = display_service.get_display(display_type)
+    # Plugin data fetch — never on the event loop.
+    result = await asyncio.to_thread(display_service.get_display, display_type)
 
     if not result.available and result.error:
         raise HTTPException(status_code=503, detail=result.error)
@@ -177,7 +181,8 @@ async def get_displays_raw_batch(request: DisplayRawBatchRequest):
 
     for display_type in display_types:
         try:
-            result = display_service.get_display(display_type)
+            # Plugin data fetch — never on the event loop.
+            result = await asyncio.to_thread(display_service.get_display, display_type)
 
             if enabled_only and not result.available:
                 continue
@@ -222,8 +227,9 @@ async def send_display(display_type: str, target: str | None = None):
     if not service or not service.vb_client:
         raise HTTPException(status_code=503, detail="Service not initialized")
 
-    # Get the display content (validates display_type against plugin registry)
-    result = display_service.get_display(display_type)
+    # Get the display content (validates display_type against plugin registry).
+    # This fetches plugin data, so it cannot run on the event loop either.
+    result = await asyncio.to_thread(display_service.get_display, display_type)
 
     # Check for invalid display type
     if not result.available and result.error and "Unknown display type" in result.error:
@@ -260,7 +266,10 @@ async def send_display(display_type: str, target: str | None = None):
                 notes_tall = primary_board.get("notes_tall", 1)
             dims = resolve_dimensions(device_type, notes_wide, notes_tall)
             board_array = text_to_board_array(result.formatted, rows=dims.rows, cols=dims.cols)
-            success, was_sent = service.vb_client.render(
+            # Board network I/O goes on the dedicated bounded send pool, never
+            # inline on the event loop (#1878).
+            success, was_sent = await run_board_send(
+                service.vb_client.render,
                 board_array,
                 strategy=transition.strategy,
                 step_interval_ms=transition.step_interval_ms,

--- a/src/main.py
+++ b/src/main.py
@@ -24,7 +24,11 @@ from .devices import (
 )
 from .displays.send_worker import BoardSendWorker, SendJob
 from .pages.models import LineMetadata, Page
-from .pages.service import get_page_service
+from .pages.service import (
+    CONTEXT_FINGERPRINT_PREFIX,
+    CONTEXT_RENDER_MEMO_PREFIX,
+    get_page_service,
+)
 from .schedules.service import get_schedule_service
 from .settings.service import get_settings_service
 from .templates.engine import extract_template_plugin_ids
@@ -1275,7 +1279,34 @@ class DisplayService:
 
     # Bumped whenever the set of inputs the fingerprint covers changes, so a
     # memo recorded by an older build can never be mistaken for a match.
-    _RENDER_FINGERPRINT_VERSION = 1
+    # v2: plugin payloads enter the hash as their own precomputed hashes
+    # rather than as re-serialised payloads.
+    _RENDER_FINGERPRINT_VERSION = 2
+
+    # Stands in for a referenced plugin that contributed no data to the
+    # context. Never collides with a payload hash (which is hex).
+    _FINGERPRINT_ABSENT = "\x00absent"
+
+    @staticmethod
+    def _fingerprint_data_part(contexts, size, context, sorted_refs) -> dict:
+        """The per-plugin inputs the render fingerprint hashes.
+
+        Prefers the per-size payload-hash companion ``shared_context_for``
+        records: one 32-char digest per referenced plugin, computed ONCE on
+        the ``PluginResult`` object ``PluginBase`` caches, instead of a full
+        ``json.dumps`` of every referenced payload once per board per tick.
+
+        Falls back to the raw payloads whenever the companion does not
+        provably cover every referenced plugin the context actually holds
+        data for. That check is the load-bearing part: a missing digest would
+        otherwise read as "this plugin contributed nothing", which would hide
+        a real data change and strand the board on a stale frame.
+        """
+        data = context or {}
+        fingerprints = contexts.get(CONTEXT_FINGERPRINT_PREFIX + size)
+        if isinstance(fingerprints, dict) and all(ref in fingerprints for ref in sorted_refs if ref in data):
+            return {ref: fingerprints.get(ref, DisplayService._FINGERPRINT_ABSENT) for ref in sorted_refs}
+        return {ref: data.get(ref) for ref in sorted_refs}
 
     @staticmethod
     def _render_fingerprint(page, active_page_id, page_service, contexts, *, override_active: bool) -> str | None:
@@ -1306,6 +1337,17 @@ class DisplayService:
         owners are not statically knowable, a page object without a Pydantic
         dump, a config manager with no generation counter, or any exception at
         all. Every unknown fails toward rendering.
+
+        The result is memoised inside the per-pass ``contexts`` dict, keyed by
+        board SIZE and by every input above. Four same-size boards on the same
+        page used to serialise the identical ``(page, context)`` pair four
+        times per tick; now the second, third and fourth read the memo. The
+        memo is per-size and never global because board-aware plugins
+        legitimately return different data per geometry — collapsing sizes
+        would hand one board another board's fingerprint. It lives and dies
+        with the tick, so it cannot outlive the state it summarises; the
+        self-validating ``rt.last_render`` triple, which is re-checked against
+        the live dedupe cache at the call site, is unchanged.
         """
         if contexts is None:
             return None
@@ -1328,6 +1370,33 @@ class DisplayService:
             if generation is None:
                 return None  # cannot see config writes -> cannot skip a render
 
+            size = size_key(
+                getattr(page, "device_type", None) or DEFAULT_DEVICE_TYPE,
+                getattr(page, "notes_wide", 1) or 1,
+                getattr(page, "notes_tall", 1) or 1,
+            )
+            sorted_refs = tuple(sorted(refs))
+            # ``id(page)`` and ``updated_at`` together: every stored mutation
+            # bumps updated_at, and the identity check additionally catches a
+            # page object swapped out mid-pass. Both must match, so the memo
+            # can only ever be MORE conservative than recomputing.
+            memo_key = (
+                active_page_id,
+                id(page),
+                getattr(page, "updated_at", None),
+                bool(override_active),
+                generation,
+                sorted_refs,
+            )
+            memo = contexts.get(CONTEXT_RENDER_MEMO_PREFIX + size)
+            if isinstance(memo, dict):
+                memoised = memo.get(memo_key)
+                if memoised is not None:
+                    return memoised
+            else:
+                memo = {}
+                contexts[CONTEXT_RENDER_MEMO_PREFIX + size] = memo
+
             context = None
             if refs:
                 context = page_service.shared_context_for(
@@ -1346,16 +1415,18 @@ class DisplayService:
                     "page": dump(),
                     "override": bool(override_active),
                     "generation": generation,
-                    "data": {ref: (context or {}).get(ref) for ref in sorted(refs)},
+                    "data": DisplayService._fingerprint_data_part(contexts, size, context, sorted_refs),
                 },
                 sort_keys=True,
                 default=str,
                 separators=(",", ":"),
             )
+            fingerprint = hashlib.blake2b(payload.encode("utf-8", "replace"), digest_size=16).hexdigest()
+            memo[memo_key] = fingerprint
         except Exception as e:  # never let the optimization break a send
             logger.debug("Render fingerprint unavailable for %s: %s", active_page_id, e)
             return None
-        return hashlib.blake2b(payload.encode("utf-8", "replace"), digest_size=16).hexdigest()
+        return fingerprint
 
     # ------------------------------------------------------------------ #
     # Per-board display engine (single tick loop)

--- a/src/pages/service.py
+++ b/src/pages/service.py
@@ -39,6 +39,19 @@ PREVIEW_CACHE_TTL = 120
 # A size WITHOUT a coverage entry was built with fetch-all (full coverage).
 _CONTEXT_COVERAGE_PREFIX = "\x00fetched:"
 
+# Prefix for the per-size payload-hash companion entries `shared_context_for`
+# keeps beside each cached context (issue #1883 follow-up): ``fingerprint_key
+# -> {plugin_id: PluginResult.data_fingerprint()}``, covering EXACTLY the ids
+# in that size's context. The render short-circuit composes those hashes
+# instead of re-serialising every payload once per board per tick; a size
+# WITHOUT this entry makes it fall back to hashing the payloads itself.
+CONTEXT_FINGERPRINT_PREFIX = "\x00fingerprints:"
+
+# Prefix for the per-size render-fingerprint memo (issue #1883 follow-up).
+# Keyed by size so board-aware plugins, which legitimately return different
+# data per geometry, can never have their fingerprints collapsed together.
+CONTEXT_RENDER_MEMO_PREFIX = "\x00render-fp:"
+
 
 # Default welcome page templates per device type
 DEFAULT_PAGE_TEMPLATES = {
@@ -389,6 +402,7 @@ class PageService:
             return None
         key = size_key(device_type or DEFAULT_DEVICE_TYPE, notes_wide or 1, notes_tall or 1)
         coverage_key = _CONTEXT_COVERAGE_PREFIX + key
+        fingerprint_key = CONTEXT_FINGERPRINT_PREFIX + key
         try:
             from src.plugins.registry import get_plugin_registry
 
@@ -396,13 +410,15 @@ class PageService:
             context = contexts.get(key)
             if context is None:
                 board = board_context_for(device_type, notes_wide, notes_tall)
+                fingerprints: dict[str, str] = {}
                 if plugin_ids is None:
-                    context = registry.build_template_context(board)
+                    context = registry.build_template_context(board, fingerprints=fingerprints)
                     # No coverage entry: a fetch-all context covers everything.
                 else:
-                    context = registry.build_template_context(board, plugin_ids=plugin_ids)
+                    context = registry.build_template_context(board, plugin_ids=plugin_ids, fingerprints=fingerprints)
                     contexts[coverage_key] = set(plugin_ids) | set(getattr(registry, "trigger_plugins", {}) or {})
                 contexts[key] = context
+                contexts[fingerprint_key] = fingerprints
                 return context
 
             fetched = contexts.get(coverage_key)
@@ -422,7 +438,20 @@ class PageService:
             # this size already fetched the trigger plugins (they are in
             # ``fetched``), so re-unioning them here would fetch each trigger
             # plugin once per widening consumer (#1862 review).
-            context.update(registry.build_template_context(board, plugin_ids=missing, include_trigger_plugins=False))
+            widened: dict[str, str] = {}
+            context.update(
+                registry.build_template_context(
+                    board, plugin_ids=missing, include_trigger_plugins=False, fingerprints=widened
+                )
+            )
+            # Keep the hash companion covering exactly what the context holds:
+            # a widening that added payloads without adding their hashes would
+            # leave the render short-circuit hashing "absent" for live data.
+            existing = contexts.get(fingerprint_key)
+            if isinstance(existing, dict):
+                existing.update(widened)
+            else:
+                contexts[fingerprint_key] = widened
             if plugin_ids is None:
                 contexts.pop(coverage_key, None)  # widened to full coverage
             else:

--- a/src/panels/routes.py
+++ b/src/panels/routes.py
@@ -36,6 +36,7 @@ from fastapi import APIRouter, HTTPException
 from src.api_errors import errors
 from src.board_chars import characters_to_message
 from src.board_guards import _board_dims, _find_board
+from src.board_send_executor import run_board_send
 from src.devices import resolve_dimensions
 from src.display_runtime import get_service, reinitialize_board_clients
 from src.pages.service import find_incompatible_board_references
@@ -282,7 +283,9 @@ async def get_panel_frame(panel_id: str):
     updated_at = None
     if client is not None:
         if getattr(client, "is_virtual", False):
-            characters = client.read_current_message()
+            # A virtual board reads from memory, but the same call on a real
+            # client is network I/O; keep it off the loop either way (#1878).
+            characters = await run_board_send(client.read_current_message)
         else:
             characters = getattr(client, "_last_characters", None)
         ts = getattr(client, "_last_sent_at", None)

--- a/src/plugins/base.py
+++ b/src/plugins/base.py
@@ -48,10 +48,13 @@ class PluginResult:
     error: str | None = None
     formatted_lines: list[str] | None = None
 
-    #: Memo for :meth:`data_fingerprint`. Excluded from ``__init__``, ``repr``
-    #: and ``__eq__`` so two results with equal fields stay equal whether or
-    #: not either has been hashed yet.
-    _data_fingerprint: str | None = field(default=None, init=False, repr=False, compare=False)
+    #: Memo for :meth:`data_fingerprint`. Deliberately a plain class attribute
+    #: with NO annotation, so it is not a dataclass field: ``asdict`` (used by
+    #: ``src/ops/results.py::serialize``) walks fields and would otherwise leak
+    #: a ``_data_fingerprint`` key into API responses. Keeping it off the field
+    #: list also keeps ``__eq__`` and ``__repr__`` unchanged, so two results
+    #: with equal data stay equal whether or not either has been hashed.
+    _data_fingerprint = None
 
     def data_fingerprint(self) -> str:
         """Stable hash of :attr:`data`, serialised at most once per result.

--- a/src/plugins/base.py
+++ b/src/plugins/base.py
@@ -5,6 +5,8 @@ plugins (frame-by-frame board animations) inherit from
 :class:`TransitionPluginBase` instead.
 """
 
+import hashlib
+import json
 import logging
 import threading
 from abc import ABC, abstractmethod
@@ -45,6 +47,30 @@ class PluginResult:
     data: dict[str, Any] | None = None
     error: str | None = None
     formatted_lines: list[str] | None = None
+
+    #: Memo for :meth:`data_fingerprint`. Excluded from ``__init__``, ``repr``
+    #: and ``__eq__`` so two results with equal fields stay equal whether or
+    #: not either has been hashed yet.
+    _data_fingerprint: str | None = field(default=None, init=False, repr=False, compare=False)
+
+    def data_fingerprint(self) -> str:
+        """Stable hash of :attr:`data`, serialised at most once per result.
+
+        The render short-circuit (issue #1883) needs to know whether a
+        plugin's payload moved, not what it contains. Hashing here — once,
+        on the object ``PluginBase`` caches and hands back to every consumer
+        — means a cached plugin costs O(1) per board per tick instead of a
+        full ``json.dumps`` of its payload per board per tick.
+
+        Two threads racing to fill the memo both compute the same value, so
+        no lock is needed.
+        """
+        fingerprint = self._data_fingerprint
+        if fingerprint is None:
+            payload = json.dumps(self.data, sort_keys=True, default=str, separators=(",", ":"))
+            fingerprint = hashlib.blake2b(payload.encode("utf-8", "replace"), digest_size=16).hexdigest()
+            self._data_fingerprint = fingerprint
+        return fingerprint
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for API responses."""
@@ -465,6 +491,33 @@ class PluginBase(ABC):
                 self._last_fetch_times[key] = datetime.now()
 
         return result
+
+    def cached_result(self, board: BoardContext | None = None) -> PluginResult | None:
+        """Return this plugin's cached result for *board* if it is still fresh.
+
+        A pure dict lookup under ``_cache_lock``: it never calls
+        :meth:`fetch_data`, never touches the network, and never blocks on
+        plugin code, so a caller may use it on a latency-sensitive thread to
+        decide whether a fetch needs dispatching at all (issue #1751 follow-up).
+
+        Returns ``None`` for "you must fetch" — including for live-data
+        plugins and plugins with no refresh interval, which have no cache by
+        definition. It never means "this plugin has no data".
+        """
+        if self.live_data:
+            return None
+        interval = self.refresh_seconds
+        if interval is None:
+            return None
+        key = self._cache_key(board)
+        with self._cache_lock:
+            cached = self._cached_results.get(key)
+            last_fetch = self._last_fetch_times.get(key)
+        if cached is None or last_fetch is None:
+            return None
+        if (datetime.now() - last_fetch).total_seconds() >= interval:
+            return None
+        return cached
 
     @staticmethod
     def _cache_key(board: BoardContext | None) -> str:

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -1822,11 +1822,35 @@ class PluginRegistry:
 
         return _done
 
+    def get_cached_plugin_data(self, plugin_id: str, board: BoardContext | None = None) -> PluginResult | None:
+        """Return a plugin's already-cached result, or None if a fetch is needed.
+
+        The non-blocking half of :meth:`fetch_plugin_data`: registry lookups
+        under ``_lock``, then a dict read under the plugin's own cache lock.
+        No plugin code runs, so this is safe to call on the calling thread
+        even when that thread is the service thread.
+        """
+        with self._lock:
+            plugin = self._plugins.get(plugin_id)
+            enabled = self._enabled.get(plugin_id, False)
+        if plugin is None or not enabled or not isinstance(plugin, PluginBase):
+            return None
+        try:
+            result = plugin.cached_result(board)
+        except Exception:  # a broken property must never break a render
+            logger.debug("Cached-data probe failed for %s", plugin_id, exc_info=True)
+            return None
+        # Only a genuine PluginResult may short-circuit a fetch. A subclass
+        # (or a test double) that returns something else must fall through to
+        # the real fetch rather than have its stand-in land in the context.
+        return result if isinstance(result, PluginResult) else None
+
     def build_template_context(
         self,
         board: BoardContext | None = None,
         plugin_ids: Collection[str] | None = None,
         include_trigger_plugins: bool = True,
+        fingerprints: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         """Build context dictionary for template rendering.
 
@@ -1849,6 +1873,12 @@ class PluginRegistry:
                 build — otherwise every widening would re-fetch them, up to
                 N times per tick (#1862 review). Only meaningful when
                 ``plugin_ids`` is given.
+            fingerprints: Optional out-parameter. When given, it is filled
+                with ``plugin_id -> PluginResult.data_fingerprint()`` for
+                EXACTLY the ids this build puts into the returned context —
+                the invariant the render short-circuit relies on to know its
+                hash map covers every payload it is standing in for. Hashing
+                happens once per result object, not once per consumer.
 
         Returns:
             Dictionary mapping plugin_id to plugin data
@@ -1891,6 +1921,33 @@ class PluginRegistry:
                 len(quarantined),
                 quarantined,
             )
+        if not to_fetch:
+            return context
+
+        # Calling-thread fast path for already-cached plugins. Dispatching a
+        # fetch whose own cache is fresh costs a Future allocation, a queue
+        # put, a worker wakeup, a condvar wait, a done-callback and three lock
+        # round-trips — measured at 21x the cost of the in-memory dict read it
+        # is wrapping. Serving those inline also means a fully-cached tick
+        # never reaches ``futures_wait`` at all, so it can never pay
+        # CONTEXT_BUILD_TIMEOUT_SECONDS for a plugin it was not going to talk
+        # to. ``get_cached_plugin_data`` runs no plugin code and cannot block,
+        # which is what makes it safe on the single service thread.
+        #
+        # Deliberately AFTER the breaker gate: a quarantined plugin stays
+        # dropped from the build whether or not it has stale-but-fresh-enough
+        # data lying around.
+        still_to_fetch: list[str] = []
+        for plugin_id in to_fetch:
+            cached = self.get_cached_plugin_data(plugin_id, board)
+            if cached is None:
+                still_to_fetch.append(plugin_id)
+                continue
+            if cached.available and cached.data:
+                context[plugin_id] = cached.data
+                if fingerprints is not None:
+                    fingerprints[plugin_id] = cached.data_fingerprint()
+        to_fetch = still_to_fetch
         if not to_fetch:
             return context
 
@@ -1963,6 +2020,8 @@ class PluginRegistry:
                 result = future.result()
                 if result.available and result.data:
                     context[plugin_id] = result.data
+                    if fingerprints is not None:
+                        fingerprints[plugin_id] = result.data_fingerprint()
             except Exception:
                 logger.exception(f"Plugin {plugin_id} raised an error during context build")
 

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -52,7 +52,27 @@ _INSTANCE_LABEL_RE = re.compile(r"^[a-zA-Z0-9_-]{1,40}$")
 # How long build_template_context() waits for the slowest enabled plugin before
 # rendering without it. A board that is a little stale beats a board that never
 # updates because one data source is wedged.
-CONTEXT_BUILD_TIMEOUT_SECONDS = 15
+#
+# It MUST stay strictly below the smallest poll interval the settings service
+# will accept (``set_polling_interval`` floors at 10s, default 15s), and with
+# room to spare. ``build_template_context`` runs on the single service thread,
+# which also drives the 1 Hz silence-boundary detector and the
+# collection-cadence gate (src/main.py). At 15s this constant EQUALLED the
+# default interval, so one slow plugin consumed an entire tick period AND
+# delayed silence entry/exit by up to a full 15 seconds — the user-visible
+# half. At 5s the worst case is a fifth of that and the tick still finishes
+# inside its own period.
+#
+# A plugin slower than this budget is not lost: its fetch keeps running on its
+# pool worker, ``PluginBase`` caches the result when it lands, and the next
+# tick serves that cached result from the calling-thread fast path below
+# without dispatching anything. It arrives one tick late instead of holding
+# the service thread hostage. Serving it also CLEARS its timeout streak, so a
+# merely slow data source is never mistaken for a wedged one.
+#
+# tests/test_plugin_fetch_breaker.py ratchets the relationship so the two
+# constants cannot drift back into equality.
+CONTEXT_BUILD_TIMEOUT_SECONDS = 5
 
 # One persistent, bounded pool serves every plugin fetch (issue #1751). The
 # previous design built a fresh ThreadPoolExecutor per render and abandoned it
@@ -235,8 +255,19 @@ class PluginRegistry:
         # fetches that actually started; _fetch_breaker_until holds the
         # monotonic deadline until which a quarantined plugin is neither
         # submitted nor waited on.
-        self._fetch_timeouts: dict[str, int] = {}
-        self._fetch_breaker_until: dict[str, float] = {}
+        #
+        # Keyed by ``(plugin_id, board_key)`` — the SAME key the in-flight
+        # registry above uses, because that is the granularity of the work
+        # being measured: one fetch per plugin per board geometry. Keying
+        # these by plugin_id alone made the counters cross geometries in both
+        # directions. Two wedged geometries charged two timeouts per tick and
+        # tripped a threshold-3 breaker in two ticks; and one HEALTHY geometry
+        # cleared the streak the wedged one was accumulating, so a plugin
+        # wedged on Flagship but fine on Note was never quarantined and every
+        # Flagship render kept paying the full context-build timeout forever —
+        # exactly the stall the breaker exists to end.
+        self._fetch_timeouts: dict[tuple[str, tuple | None], int] = {}
+        self._fetch_breaker_until: dict[tuple[str, tuple | None], float] = {}
 
         # Set once initialize() has loaded the plugin set. Guards against a
         # repeat call rebuilding every live plugin (issue #1753).
@@ -1905,6 +1936,11 @@ class PluginRegistry:
         if not to_fetch:
             return context
 
+        # The identity of a fetch: one plugin ON one board geometry. The
+        # in-flight registry, the circuit breaker and the timeout streaks all
+        # key off it, so they agree on what "this fetch" means.
+        board_key = None if board is None else (board.device_type, board.rows, board.cols)
+
         # Circuit-breaker gate (issue #1884): a quarantined plugin is dropped
         # from this build entirely — not submitted, and crucially not WAITED
         # on. Skipping the wait is what removes the per-render
@@ -1912,9 +1948,9 @@ class PluginRegistry:
         # plugin used to impose on every tick.
         now = time.monotonic()
         with self._inflight_lock:
-            quarantined = [pid for pid in to_fetch if self._fetch_breaker_until.get(pid, 0.0) > now]
+            quarantined = [pid for pid in to_fetch if self._fetch_breaker_until.get((pid, board_key), 0.0) > now]
             if quarantined:
-                to_fetch = [pid for pid in to_fetch if self._fetch_breaker_until.get(pid, 0.0) <= now]
+                to_fetch = [pid for pid in to_fetch if self._fetch_breaker_until.get((pid, board_key), 0.0) <= now]
         if quarantined:
             logger.debug(
                 "Skipping %d quarantined plugin(s) this render (fetch circuit breaker open): %s",
@@ -1938,15 +1974,25 @@ class PluginRegistry:
         # dropped from the build whether or not it has stale-but-fresh-enough
         # data lying around.
         still_to_fetch: list[str] = []
+        answered: list[str] = []
         for plugin_id in to_fetch:
             cached = self.get_cached_plugin_data(plugin_id, board)
             if cached is None:
                 still_to_fetch.append(plugin_id)
                 continue
+            answered.append(plugin_id)
             if cached.available and cached.data:
                 context[plugin_id] = cached.data
                 if fingerprints is not None:
                     fingerprints[plugin_id] = cached.data_fingerprint()
+        if answered:
+            # Cached data is PROOF the plugin answered — a fetch this build
+            # abandoned at the timeout still landed and filled the cache. Ending
+            # its streak here is what keeps a merely slow data source out of the
+            # quarantine the breaker reserves for wedged ones.
+            with self._inflight_lock:
+                for plugin_id in answered:
+                    self._fetch_timeouts.pop((plugin_id, board_key), None)
         to_fetch = still_to_fetch
         if not to_fetch:
             return context
@@ -1968,7 +2014,6 @@ class PluginRegistry:
         # A done future means the previous fetch finished; submit a fresh
         # one (fetch_plugin_data's own caching decides how fresh the data
         # actually is, exactly as before).
-        board_key = None if board is None else (board.device_type, board.rows, board.cols)
         futures: dict[Any, str] = {}
         submitted: list[tuple[tuple, Any]] = []
         with self._inflight_lock:
@@ -2003,7 +2048,7 @@ class PluginRegistry:
             # CANCELLED, so what is left is the set that genuinely started and
             # is still running — the only set the breaker may hold against a
             # plugin (issue #1884).
-            self._record_fetch_timeouts([f for f in not_done if not f.cancelled()], futures)
+            self._record_fetch_timeouts([f for f in not_done if not f.cancelled()], futures, board_key)
 
         if done:
             # A fetch that completed — with data, without data, or with an
@@ -2011,8 +2056,8 @@ class PluginRegistry:
             # any quarantine is lifted.
             with self._inflight_lock:
                 for future in done:
-                    self._fetch_timeouts.pop(futures[future], None)
-                    self._fetch_breaker_until.pop(futures[future], None)
+                    self._fetch_timeouts.pop((futures[future], board_key), None)
+                    self._fetch_breaker_until.pop((futures[future], board_key), None)
 
         for future in done:
             plugin_id = futures[future]
@@ -2027,8 +2072,12 @@ class PluginRegistry:
 
         return context
 
-    def _record_fetch_timeouts(self, running: list, futures: dict) -> None:
+    def _record_fetch_timeouts(self, running: list, futures: dict, board_key: tuple | None = None) -> None:
         """Charge one consecutive timeout to each plugin in *running*.
+
+        Charged against ``(plugin_id, board_key)`` — the geometry whose fetch
+        actually failed to answer — so a plugin that is wedged on one board
+        size keeps serving every other size.
 
         Opens the circuit breaker for any plugin that reaches
         PLUGIN_FETCH_BREAKER_THRESHOLD, and writes off the pool worker its
@@ -2044,11 +2093,12 @@ class PluginRegistry:
         with self._inflight_lock:
             for future in running:
                 plugin_id = futures[future]
-                count = self._fetch_timeouts.get(plugin_id, 0) + 1
-                self._fetch_timeouts[plugin_id] = count
+                breaker_key = (plugin_id, board_key)
+                count = self._fetch_timeouts.get(breaker_key, 0) + 1
+                self._fetch_timeouts[breaker_key] = count
                 if count < PLUGIN_FETCH_BREAKER_THRESHOLD:
                     continue
-                self._fetch_breaker_until[plugin_id] = deadline
+                self._fetch_breaker_until[breaker_key] = deadline
                 opened.append(plugin_id)
                 if not getattr(future, "_fb_worker_written_off", False):
                     future._fb_worker_written_off = True
@@ -2069,19 +2119,31 @@ class PluginRegistry:
         Maps plugin_id -> ``{"consecutive_timeouts": int, "quarantined": bool,
         "cooldown_remaining_seconds": float}`` for every plugin with a live
         timeout streak. Empty when every data source is answering.
+
+        The breaker's own bookkeeping is per ``(plugin_id, board_key)``; this
+        report is per plugin because that is the unit a user recognises. A
+        plugin wedged on one board geometry and healthy on another is reported
+        by its WORST geometry — the deepest streak and the longest remaining
+        cooldown — so "this data source is in trouble" is never hidden by a
+        second board that happens to be fine.
         """
         now = time.monotonic()
         with self._inflight_lock:
             timeouts = dict(self._fetch_timeouts)
             until = dict(self._fetch_breaker_until)
         status: dict[str, dict[str, Any]] = {}
-        for plugin_id, count in timeouts.items():
-            remaining = max(0.0, until.get(plugin_id, 0.0) - now)
-            status[plugin_id] = {
-                "consecutive_timeouts": count,
-                "quarantined": remaining > 0.0,
-                "cooldown_remaining_seconds": round(remaining, 1),
-            }
+        for (plugin_id, board_key), count in timeouts.items():
+            remaining = max(0.0, until.get((plugin_id, board_key), 0.0) - now)
+            entry = status.setdefault(
+                plugin_id,
+                {"consecutive_timeouts": 0, "quarantined": False, "cooldown_remaining_seconds": 0.0},
+            )
+            entry["consecutive_timeouts"] = max(entry["consecutive_timeouts"], count)
+            entry["quarantined"] = entry["quarantined"] or remaining > 0.0
+            entry["cooldown_remaining_seconds"] = round(
+                max(entry["cooldown_remaining_seconds"], remaining),
+                1,
+            )
         return status
 
     def build_template_contexts_for(

--- a/src/plugins/routes.py
+++ b/src/plugins/routes.py
@@ -232,9 +232,13 @@ async def get_all_plugin_variables() -> AllPluginVariablesResponse:
         # Fall back to legacy variables rather than failing: the template
         # editor still has a vocabulary without the plugin system.
         template_engine = get_template_engine()
+        # Auto-discovery can fetch from a plugin, so this cannot run inline.
+        variables, max_lengths = await asyncio.to_thread(
+            lambda: (template_engine.get_available_variables(), template_engine.get_variable_max_lengths())
+        )
         return AllPluginVariablesResponse(
-            variables=template_engine.get_available_variables(),
-            max_lengths=template_engine.get_variable_max_lengths(),
+            variables=variables,
+            max_lengths=max_lengths,
             plugin_system_enabled=False,
         )
 

--- a/src/settings/routes.py
+++ b/src/settings/routes.py
@@ -1075,7 +1075,9 @@ async def detect_board_size(board_id: str):
             detail=f"Board {board_id} is not configured (missing credentials)",
         )
 
-    grid = client.read_current_message()
+    # A board READ is board network I/O like any other; it belongs on the
+    # bounded send pool, not inline on the event loop (#1878).
+    grid = await run_board_send(client.read_current_message)
     if grid is None:
         raise HTTPException(
             status_code=422,
@@ -1539,7 +1541,7 @@ async def get_hdmi_kiosk_status():
         return {"supported": False, "status": "unsupported", "enabled": None}
     status: dict = {"status": "unknown", "enabled": None}
     try:
-        resp = requests.get(f"{_updater_url()}/hdmi/status", timeout=3)
+        resp = await asyncio.to_thread(requests.get, f"{_updater_url()}/hdmi/status", timeout=3)
         if resp.status_code == 200:
             body = resp.json()
             if isinstance(body, dict):
@@ -1572,7 +1574,8 @@ async def set_hdmi_kiosk(request: HdmiKioskRequest):
         )
     verb = "enable" if request.enabled else "disable"
     try:
-        resp = requests.post(
+        resp = await asyncio.to_thread(
+            requests.post,
             f"{_updater_url()}/hdmi/{verb}",
             headers={"Authorization": f"Bearer {_updater_token()}"},
             timeout=10,

--- a/src/storage/json_store.py
+++ b/src/storage/json_store.py
@@ -143,11 +143,17 @@ class JsonStore:
 
     def save(self, data: Any) -> None:
         """Atomically persist *data*, stamping ``schema_version`` on
-        versioned dict payloads. Write errors propagate."""
+        versioned dict payloads. Write errors propagate.
+
+        A save whose bytes match what is already on disk is skipped: a PUT
+        that stores the value already stored used to cost a full fsynced
+        rewrite. The in-memory ``_data`` is still adopted either way, so the
+        store's own view never depends on whether the disk needed touching.
+        """
         with self._lock:
             if self._version and isinstance(data, dict):
                 data["schema_version"] = self._version
-            write_json_atomic(self._path, data)
+            write_json_atomic(self._path, data, if_changed=True)
             self._data = data
 
     def mutate(self, fn: Callable[[Any], Any]) -> Any:

--- a/src/system/update_service.py
+++ b/src/system/update_service.py
@@ -732,6 +732,36 @@ def _prune_settings_snapshots() -> None:
             logger.warning("Could not prune old settings snapshot %s", path)
 
 
+def prune_snapshot_dir(directory: Path) -> int:
+    """Apply the same retention to a snapshot directory named explicitly.
+
+    ``ConfigManager`` writes a pre-init snapshot on every version change, into
+    its own ``<config dir>/update-backups`` rather than through this module,
+    and had no retention at all — 58 files / 1.3 MB observed on a live
+    instance. It cannot call :func:`_prune_settings_snapshots` because that
+    resolves the directory from ``get_data_dir()``, which need not be the
+    directory its config lives in.
+
+    Returns the number of files deleted.
+    """
+    try:
+        candidates = sorted(
+            (p for p in directory.glob("pre-update-*.json") if _SETTINGS_SNAPSHOT_NAME_RE.match(p.name)),
+            key=lambda p: p.name,
+            reverse=True,
+        )
+    except OSError:
+        return 0
+    deleted = 0
+    for stale in candidates[SETTINGS_SNAPSHOT_RETENTION:]:
+        try:
+            stale.unlink()
+            deleted += 1
+        except OSError:
+            logger.warning("Could not prune old settings snapshot %s", stale)
+    return deleted
+
+
 def _resolve_snapshot_name(name: str | None) -> Path | None:
     """Return the absolute path of the named snapshot, or the newest one
     if *name* is None.  Returns ``None`` when no valid snapshot exists.

--- a/src/templates/engine.py
+++ b/src/templates/engine.py
@@ -188,7 +188,11 @@ class TemplateEngine:
             Rendered string with all substitutions applied
         """
         if context is None:
-            context = self._build_context()
+            # Demand-driven, exactly as PageService.render_page already is
+            # (#1751): fetch only the plugins this template's variables name.
+            # ``extract_template_plugin_ids`` returns None for a formula page,
+            # which keeps the safe fetch-everything fallback.
+            context = self._build_context(plugin_ids=extract_template_plugin_ids(template))
 
         result = template
 
@@ -353,7 +357,10 @@ class TemplateEngine:
         # Build the BoardContext from the resolved dims so plugins receive the true
         # board size — including note arrays (no fixed DEVICE_DIMENSIONS entry).
         if context is None:
-            context = self._build_context(BoardContext(render_device_type, rows=dims.rows, cols=dims.cols))
+            context = self._build_context(
+                BoardContext(render_device_type, rows=dims.rows, cols=dims.cols),
+                plugin_ids=extract_template_plugin_ids(template_lines),
+            )
         num_rows = dims.rows
         board_width = dims.cols
 
@@ -823,12 +830,16 @@ class TemplateEngine:
 
         return lines
 
-    def _build_context(self, board: BoardContext | None = None) -> dict[str, Any]:
-        """Build context by fetching all available data from enabled plugins.
+    def _build_context(self, board: BoardContext | None = None, plugin_ids: "set[str] | None" = None) -> dict[str, Any]:
+        """Build context by fetching data from enabled plugins.
 
         Args:
             board: Board being rendered on, forwarded to plugins so board-aware
                 ones can adapt their data. ``None`` keeps board-agnostic behavior.
+            plugin_ids: Fetch only these plugins (plus trigger plugins, which
+                the registry adds itself). ``None`` fetches everything — the
+                safe fallback for a template whose variable owners cannot be
+                determined statically.
 
         Returns:
             Dictionary mapping plugin_id to plugin data
@@ -836,7 +847,9 @@ class TemplateEngine:
         if not self._plugin_registry:
             return {}
 
-        return self._plugin_registry.build_template_context(board)
+        if plugin_ids is None:
+            return self._plugin_registry.build_template_context(board)
+        return self._plugin_registry.build_template_context(board, plugin_ids=plugin_ids)
 
     def _render_variables(self, template: str, context: dict[str, Any]) -> str:
         """Replace {{source.field}} variables with values from context.

--- a/src/templates/routes.py
+++ b/src/templates/routes.py
@@ -13,6 +13,7 @@ module binds it — ``src.templates.routes.<name>`` — not
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from fastapi import APIRouter, HTTPException
@@ -61,12 +62,25 @@ async def get_template_variables():
     template_engine = get_template_engine()
     registry = get_plugin_registry()
 
+    # ``get_all_variables_with_metadata`` builds a FETCH-ALL template context,
+    # and ``get_available_variables`` can trigger an auto-discovery fetch, so
+    # this route can block for the full context-build budget. It is an
+    # ``async def``, which means that block would be the whole event loop.
+    variables, max_lengths, metadata, groups = await asyncio.to_thread(
+        lambda: (
+            template_engine.get_available_variables(),
+            template_engine.get_variable_max_lengths(),
+            registry.get_all_variables_with_metadata(),
+            registry.get_all_variable_groups(),
+        )
+    )
+
     return TemplateVariablesResponse.model_validate(
         {
-            "variables": template_engine.get_available_variables(),
-            "max_lengths": template_engine.get_variable_max_lengths(),
-            "variable_metadata": registry.get_all_variables_with_metadata(),
-            "variable_groups": registry.get_all_variable_groups(),
+            "variables": variables,
+            "max_lengths": max_lengths,
+            "variable_metadata": metadata,
+            "variable_groups": groups,
             "colors": {
                 "red": 63,
                 "orange": 64,
@@ -175,12 +189,17 @@ async def render_template(request: TemplateRenderRequest):
     line_metadata = request.line_metadata
 
     try:
+        # Rendering fetches plugin data, so it belongs on a worker thread, not
+        # on the event loop. The engine's own fetch is demand-driven, so a
+        # template naming four variables fetches four plugins, not every one.
         if isinstance(template, list):
             logger.info(f"Rendering template lines: {template}")
-            rendered = template_engine.render_lines(template, line_metadata=line_metadata, device_type=device_type)
+            rendered = await asyncio.to_thread(
+                template_engine.render_lines, template, line_metadata=line_metadata, device_type=device_type
+            )
         else:
             logger.info(f"Rendering template string: {template}")
-            rendered = template_engine.render(template)
+            rendered = await asyncio.to_thread(template_engine.render, template)
 
         lines = rendered.split("\n")
         return TemplateRenderResponse(rendered=rendered, lines=lines, line_count=len(lines))
@@ -225,7 +244,9 @@ async def render_template_live(request: TemplateRenderLiveRequest):
                     sent_to_board=False,
                     board_id=board_id,
                 )
-            rendered = template_engine.render_lines(template, line_metadata=line_metadata, device_type=device_type)
+            rendered = await asyncio.to_thread(
+                template_engine.render_lines, template, line_metadata=line_metadata, device_type=device_type
+            )
         else:
             if not template.strip():
                 return TemplateRenderLiveResponse(
@@ -235,7 +256,7 @@ async def render_template_live(request: TemplateRenderLiveRequest):
                     sent_to_board=False,
                     board_id=board_id,
                 )
-            rendered = template_engine.render(template)
+            rendered = await asyncio.to_thread(template_engine.render, template)
     except Exception as e:
         logger.error(f"Template rendering error: {e}", exc_info=True)
         raise HTTPException(status_code=400, detail=f"Template rendering failed: {str(e)}") from e

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -554,6 +554,13 @@ class TestCollectionStorage:
         assert storage.count() == 1
         original_bytes = path.read_bytes()
 
+        # The pending save must be a REAL one: an unchanged save is now
+        # correctly skipped as a no-op (write_json_atomic if_changed), so a
+        # crash test that re-saves identical bytes would never reach the
+        # crash it exists to test.
+        only = next(iter(storage._collections))
+        storage._collections[only] = storage._collections[only].model_copy(update={"name": "Renamed"})
+
         real_dump = json.dump
 
         def crashing_dump(obj, fh, *args, **kwargs):

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1237,6 +1237,11 @@ def test_save_internal_is_atomic_on_mid_write_crash(tmp_path, monkeypatch):
     cm._save_internal()  # normalize on-disk content
     original_bytes = config_path.read_bytes()
 
+    # The pending save must be a REAL one: an unchanged save is now correctly
+    # skipped as a no-op (write_json_atomic if_changed), so a crash test that
+    # re-saves identical bytes would never reach the crash it exists to test.
+    cm._config.setdefault("general", {})["instance_name"] = "Changed in memory only"
+
     real_dump = json.dump
 
     def crashing_dump(obj, fh, *args, **kwargs):

--- a/tests/test_demand_driven_fetch.py
+++ b/tests/test_demand_driven_fetch.py
@@ -19,16 +19,18 @@ these tests must pass WITHOUT any golden changing.
 """
 
 import threading
+from datetime import timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 import src.plugins.registry as registry_module
+from src.devices import BoardContext
 from src.pages.models import Page
 from src.pages.service import PageService
 from src.pages.storage import PageStorage
-from src.plugins.base import PluginBase, PluginResult
+from src.plugins.base import DEFAULT_REFRESH_SECONDS, PluginBase, PluginResult
 from src.plugins.registry import PluginRegistry
 from src.templates.engine import TemplateEngine
 
@@ -284,3 +286,147 @@ class TestTriggerFetchedOncePerTick:
         assert contexts[next(k for k in contexts if not k.startswith("\x00"))].get("trig") == {"value": "TRIG"}
 
         assert _fetched_ids(registry) == {"alpha": 1, "beta": 1, "gamma": 1, "trig": 1}
+
+
+# ==========================================================================
+# The calling-thread fast path for already-cached plugins
+# ==========================================================================
+
+
+class _CountingPlugin(PluginBase):
+    """A real PluginBase, so its real cache decides what a fetch costs."""
+
+    def __init__(self, plugin_id: str, manifest_extra: dict | None = None):
+        self._pid = plugin_id
+        self.fetches = 0
+        super().__init__({"id": plugin_id, "name": plugin_id, "version": "1.0.0", **(manifest_extra or {})})
+
+    @property
+    def plugin_id(self) -> str:
+        return self._pid
+
+    def fetch_data(self) -> PluginResult:
+        self.fetches += 1
+        return PluginResult(available=True, data={"value": f"V{self.fetches}"})
+
+
+@pytest.fixture
+def counted_pool(monkeypatch):
+    """Count every submission to the shared plugin-fetch pool."""
+    executor = registry_module._get_fetch_executor()
+    submits = []
+    real_submit = executor.submit
+
+    def counting_submit(fn, *args, **kwargs):
+        submits.append(args[0] if args else None)
+        return real_submit(fn, *args, **kwargs)
+
+    monkeypatch.setattr(executor, "submit", counting_submit)
+    return submits
+
+
+def _install_real_plugin(registry, plugin, enabled: bool = True):
+    registry._plugins[plugin.plugin_id] = plugin
+    registry._enabled[plugin.plugin_id] = enabled
+    return plugin
+
+
+class TestCachedFetchFastPath:
+    """A plugin whose own cache is fresh must not be dispatched to a thread.
+
+    Measured against doing the identical work inline, the dispatch — Future
+    allocation, queue put, worker wakeup, condvar wait, done-callback and
+    three lock round-trips — costs 21x what the in-memory dict read it wraps
+    costs. The second-order win matters more: a fully cached tick that never
+    submits also never enters ``futures_wait``, so it can never pay the
+    context-build timeout for a plugin it was not going to talk to.
+    """
+
+    def test_a_cached_plugin_is_served_without_touching_the_pool(self, counted_pool):
+        registry = _make_registry()
+        plugin = _install_real_plugin(registry, _CountingPlugin("cached"))
+
+        first = registry.build_template_context(plugin_ids=["cached"])
+        submits_after_first = len(counted_pool)
+        second = registry.build_template_context(plugin_ids=["cached"])
+
+        assert first == {"cached": {"value": "V1"}}
+        assert second == {"cached": {"value": "V1"}}, "the cached payload must still reach the context"
+        assert submits_after_first == 1, "the cold build must dispatch"
+        assert len(counted_pool) == 1, "the warm build must not dispatch"
+        assert plugin.fetches == 1
+
+    def test_a_cached_build_never_enters_the_context_build_wait(self, monkeypatch):
+        """This is what decouples a fully-cached tick from the fetch timeout."""
+        registry = _make_registry()
+        _install_real_plugin(registry, _CountingPlugin("cached"))
+        registry.build_template_context(plugin_ids=["cached"])
+
+        waits = []
+        real_wait = registry_module.futures_wait
+        monkeypatch.setattr(
+            registry_module,
+            "futures_wait",
+            lambda *a, **k: (waits.append(1), real_wait(*a, **k))[1],
+        )
+        assert registry.build_template_context(plugin_ids=["cached"]) == {"cached": {"value": "V1"}}
+        assert waits == []
+
+    def test_a_live_data_plugin_never_takes_the_fast_path(self, counted_pool):
+        """live_data means "stale is wrong by definition" — it has no cache."""
+        registry = _make_registry()
+        plugin = _install_real_plugin(registry, _CountingPlugin("clock", {"live_data": True}))
+
+        registry.build_template_context(plugin_ids=["clock"])
+        registry.build_template_context(plugin_ids=["clock"])
+
+        assert len(counted_pool) == 2
+        assert plugin.fetches == 2
+
+    def test_an_expired_cache_is_refetched_through_the_pool(self, counted_pool, monkeypatch):
+        registry = _make_registry()
+        plugin = _install_real_plugin(registry, _CountingPlugin("stale"))
+        registry.build_template_context(plugin_ids=["stale"])
+
+        # Age the cache past the default refresh interval.
+        with plugin._cache_lock:
+            for key in plugin._last_fetch_times:
+                plugin._last_fetch_times[key] -= timedelta(seconds=DEFAULT_REFRESH_SECONDS + 1)
+
+        assert registry.build_template_context(plugin_ids=["stale"]) == {"stale": {"value": "V2"}}
+        assert len(counted_pool) == 2
+        assert plugin.fetches == 2
+
+    def test_a_disabled_plugin_is_never_served_from_cache(self):
+        registry = _make_registry()
+        _install_real_plugin(registry, _CountingPlugin("off"))
+        registry.build_template_context(plugin_ids=["off"])
+        registry._enabled["off"] = False
+
+        assert registry.get_cached_plugin_data("off") is None
+
+    def test_a_plugin_returning_a_non_result_falls_through_to_a_real_fetch(self, counted_pool):
+        """Only a genuine PluginResult may stand in for a fetch.
+
+        Without this guard any ``MagicMock(spec=PluginBase)`` — the shape half
+        this suite's doubles take — would satisfy the fast path and put a mock
+        object into the template context.
+        """
+        registry = _make_registry()
+        plugin = _install_real_plugin(registry, _CountingPlugin("liar"))
+        plugin.cached_result = lambda board=None: {"not": "a result"}
+
+        assert registry.build_template_context(plugin_ids=["liar"]) == {"liar": {"value": "V1"}}
+        assert len(counted_pool) == 1
+
+    def test_cached_result_is_keyed_by_board_geometry(self):
+        """A Flagship's cached payload must never answer a Note's probe."""
+        registry = _make_registry()
+        _install_real_plugin(registry, _CountingPlugin("board_aware"))
+        flagship = BoardContext("flagship", rows=6, cols=22)
+        note = BoardContext("note", rows=3, cols=15)
+
+        registry.build_template_context(flagship, plugin_ids=["board_aware"])
+
+        assert registry.get_cached_plugin_data("board_aware", flagship) is not None
+        assert registry.get_cached_plugin_data("board_aware", note) is None

--- a/tests/test_no_blocking_on_event_loop.py
+++ b/tests/test_no_blocking_on_event_loop.py
@@ -1,0 +1,256 @@
+"""Blocking work must not run on the event loop.
+
+Every handler in this app is ``async def``, so anything blocking called
+directly from one stalls the WHOLE process for its duration — every other
+request, the health check, the MCP stream. The template routes were the worst
+of them: ``GET /templates/variables`` and both render endpoints ran a
+fetch-all ``build_template_context``, which waits on external HTTP for up to
+the full context-build budget.
+
+Two kinds of test here, because neither alone is enough:
+
+* **behavioural** — the blocking callable is replaced by a probe that asks
+  whether a loop is running on the thread it was called from. On the event
+  loop thread ``asyncio.get_running_loop()`` succeeds; on a worker thread it
+  raises. That is an exact answer, not a timing measurement, so it cannot
+  flake and cannot pass by accident.
+* **a ratchet** — an AST scan counting blocking calls that appear directly in
+  an ``async def`` body (not inside a nested ``def`` that some ``to_thread``
+  will run). The behavioural tests cover the routes we fixed; the ratchet is
+  what stops a new one appearing next to them.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+
+
+@pytest.fixture
+def client(_isolated_data_dir):
+    from src.api_server import app
+
+    return TestClient(app)
+
+
+class LoopThreadViolation(AssertionError):
+    """Raised from inside a probe that finds itself on the event loop."""
+
+
+def off_loop(return_value):
+    """A stand-in that fails loudly if it is called on the event loop thread."""
+
+    def probe(*_args, **_kwargs):
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return return_value() if callable(return_value) else return_value
+        raise LoopThreadViolation("blocking work ran on the event loop thread")
+
+    return probe
+
+
+# ---------------------------------------------------------------------------
+# Behavioural: the routes that fetch plugin data
+# ---------------------------------------------------------------------------
+
+
+def test_templates_variables_builds_its_context_off_the_loop(client, monkeypatch):
+    from src.plugins.registry import PluginRegistry
+
+    monkeypatch.setattr(PluginRegistry, "get_all_variables_with_metadata", off_loop(dict))
+
+    response = client.get("/templates/variables")
+
+    assert response.status_code == 200
+    assert response.json()["variable_metadata"] == {}
+
+
+def test_templates_render_fetches_off_the_loop(client, monkeypatch):
+    from src.plugins.registry import PluginRegistry
+
+    monkeypatch.setattr(PluginRegistry, "build_template_context", off_loop(dict))
+
+    response = client.post("/templates/render", json={"template": ["{{weather.temperature}}"]})
+
+    assert response.status_code == 200
+
+
+def test_templates_render_live_fetches_off_the_loop(client, monkeypatch):
+    from src.plugins.registry import PluginRegistry
+
+    monkeypatch.setattr(PluginRegistry, "build_template_context", off_loop(dict))
+
+    response = client.post("/templates/render/live", json={"template": ["{{weather.temperature}}"]})
+
+    assert response.status_code == 200
+
+
+def test_display_get_fetches_off_the_loop(client, monkeypatch):
+    from src.displays.service import DisplayResult
+    from src.displays.service import DisplayService as DisplaysService
+
+    stub = DisplayResult(display_type="date_time", formatted="STUB", raw={}, available=True)
+    monkeypatch.setattr(DisplaysService, "get_display", off_loop(stub))
+
+    response = client.get("/displays/date_time")
+
+    assert response.status_code == 200
+    assert response.json()["message"] == "STUB"
+
+
+# ---------------------------------------------------------------------------
+# Demand-driven render: /templates/render must not fetch every plugin
+# ---------------------------------------------------------------------------
+
+
+def test_templates_render_fetches_only_the_plugins_the_template_names(client, monkeypatch):
+    """Rendering four variables must not fetch every installed plugin."""
+    from src.plugins.registry import PluginRegistry
+
+    seen: list = []
+
+    def spy(self, board=None, plugin_ids=None, include_trigger_plugins=True, fingerprints=None):
+        seen.append(plugin_ids)
+        return {}
+
+    monkeypatch.setattr(PluginRegistry, "build_template_context", spy)
+
+    response = client.post("/templates/render", json={"template": ["{{weather.temperature}}"]})
+
+    assert response.status_code == 200
+    assert seen, "the render did not build a context at all"
+    assert seen[0] == {"weather"}, f"render fetched {seen[0]} instead of just the referenced plugin"
+
+
+def test_a_formula_template_still_falls_back_to_fetching_everything(client, monkeypatch):
+    """A formula's variable owners are not statically knowable — fetch all."""
+    from src.plugins.registry import PluginRegistry
+
+    seen: list = []
+
+    def spy(self, board=None, plugin_ids=None, include_trigger_plugins=True, fingerprints=None):
+        seen.append(plugin_ids)
+        return {}
+
+    monkeypatch.setattr(PluginRegistry, "build_template_context", spy)
+
+    response = client.post("/templates/render", json={"template": ["{{= weather.temperature + 1 }}"]})
+
+    assert response.status_code == 200
+    assert seen and seen[0] is None, f"formula render narrowed the fetch to {seen[0]}"
+
+
+# ---------------------------------------------------------------------------
+# The ratchet
+# ---------------------------------------------------------------------------
+
+BLOCKING_NAMES = {
+    "requests.get",
+    "requests.post",
+    "requests.put",
+    "requests.delete",
+    "http_requests.get",
+    "http_requests.post",
+    "build_template_context",
+    "get_all_variables_with_metadata",
+    "get_available_variables",
+    "read_current_message",
+    "send_characters",
+    "get_display",
+    "render_lines",
+}
+BOARD_RENDER_RECEIVERS = {"board_client", "vb_client", "client"}
+
+# ``src/v1`` is a separate slice; its one remaining site is tracked there.
+KNOWN_REMAINING = {("src/v1/routes_plugins.py", "get_display")}
+
+
+def _dotted(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _dotted(node.value)
+        return f"{base}.{node.attr}" if base else node.attr
+    return ""
+
+
+class _LoopScan(ast.NodeVisitor):
+    """Collect calls made directly in an ``async def`` body."""
+
+    def __init__(self) -> None:
+        self.hits: list[tuple[int, str]] = []
+        self._in_async = 0
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        outer, self._in_async = self._in_async, self._in_async + 1
+        for child in node.body:
+            self.visit(child)
+        self._in_async = outer
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        # A nested sync def is what gets handed to to_thread / run_board_send.
+        outer, self._in_async = self._in_async, 0
+        for child in node.body:
+            self.visit(child)
+        self._in_async = outer
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        outer, self._in_async = self._in_async, 0
+        self.generic_visit(node)
+        self._in_async = outer
+
+    def visit_Await(self, node: ast.Await) -> None:
+        return  # awaited work is off the loop by construction
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if self._in_async:
+            name = _dotted(node.func)
+            tail = name.rsplit(".", 1)[-1]
+            head = name.rsplit(".", 2)[0] if "." in name else ""
+            if (
+                name in BLOCKING_NAMES
+                or tail in BLOCKING_NAMES
+                or (tail == "render" and head in BOARD_RENDER_RECEIVERS)
+            ):
+                self.hits.append((node.lineno, tail))
+        self.generic_visit(node)
+
+
+def _scan_src() -> set[tuple[str, str]]:
+    found: set[tuple[str, str]] = set()
+    for path in sorted(SRC.rglob("*.py")):
+        scan = _LoopScan()
+        scan.visit(ast.parse(path.read_text(encoding="utf-8")))
+        rel = path.relative_to(SRC.parent).as_posix()
+        for _lineno, name in scan.hits:
+            found.add((rel, name))
+    return found
+
+
+def test_no_new_blocking_call_appears_directly_in_an_async_handler():
+    """16 sites before this change; 1, in another slice, after it."""
+    assert _scan_src() == KNOWN_REMAINING
+
+
+def test_the_ratchet_can_actually_see_a_blocking_call():
+    """Non-vacuity: the scanner must flag the thing it claims to flag."""
+    source = "async def handler():\n    return requests.get('http://x')\n"
+    scan = _LoopScan()
+    scan.visit(ast.parse(source))
+    assert [name for _lineno, name in scan.hits] == ["get"]
+
+
+def test_the_ratchet_does_not_flag_work_handed_to_a_thread():
+    source = (
+        "async def handler():\n    def _work():\n        return requests.get('http://x')\n    return await run(_work)\n"
+    )
+    scan = _LoopScan()
+    scan.visit(ast.parse(source))
+    assert scan.hits == []

--- a/tests/test_no_op_writes.py
+++ b/tests/test_no_op_writes.py
@@ -1,0 +1,245 @@
+"""Writes that change nothing (Pi audit, P8).
+
+Two findings, both counted rather than timed:
+
+* ``ConfigManager`` called ``_save_internal()`` unconditionally after the
+  defaults merge, so every restart fsynced and renamed config.json — with an
+  md5 identical to the one already on disk. The same shape applies to any PUT
+  that stores the value already stored.
+* The pre-init snapshot ``ConfigManager`` writes on a version change had no
+  retention at all, unlike the pre-update snapshots it shares a directory and
+  a filename shape with. 58 files / 1.3 MB observed on a live instance.
+
+Size this honestly: it is tens of fsyncs per boot, not per hour. Nothing in
+this codebase writes on a timer — 92 s of the real display loop performs zero
+atomic writes and zero fsyncs — so this is not why an SD card dies. It is
+still a write with no upside, which is the one class worth removing outright.
+
+The non-vacuity half is what makes these tests worth having: a save that
+skips too much is a lost setting, so every "does not write" test here has a
+"still writes when it must" twin.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from src.atomic_io import write_json_atomic
+
+
+@pytest.fixture
+def fsyncs(monkeypatch):
+    """Count every fsync the process performs."""
+    counted: list[int] = []
+    real = os.fsync
+
+    def counting(fd):
+        counted.append(fd)
+        return real(fd)
+
+    monkeypatch.setattr(os, "fsync", counting)
+    return counted
+
+
+# ---------------------------------------------------------------------------
+# The primitive
+# ---------------------------------------------------------------------------
+
+
+def test_if_changed_skips_a_byte_identical_rewrite(tmp_path, fsyncs):
+    target = tmp_path / "x.json"
+    write_json_atomic(target, {"a": 1})
+    fsyncs.clear()
+
+    wrote = write_json_atomic(target, {"a": 1}, if_changed=True)
+
+    assert wrote is False
+    assert fsyncs == []
+    assert json.loads(target.read_text()) == {"a": 1}
+
+
+def test_if_changed_still_writes_a_real_change(tmp_path, fsyncs):
+    target = tmp_path / "x.json"
+    write_json_atomic(target, {"a": 1})
+    fsyncs.clear()
+
+    wrote = write_json_atomic(target, {"a": 2}, if_changed=True)
+
+    assert wrote is True
+    assert len(fsyncs) == 1
+    assert json.loads(target.read_text()) == {"a": 2}
+
+
+def test_if_changed_writes_when_the_target_does_not_exist(tmp_path):
+    target = tmp_path / "nested" / "x.json"
+
+    assert write_json_atomic(target, {"a": 1}, if_changed=True) is True
+    assert json.loads(target.read_text()) == {"a": 1}
+
+
+def test_if_changed_writes_when_the_target_cannot_be_read(tmp_path, monkeypatch):
+    """The failure mode must be a needless write, never a skipped one."""
+    target = tmp_path / "x.json"
+    write_json_atomic(target, {"a": 1})
+
+    def unreadable(*_args, **_kwargs):
+        raise OSError("nope")
+
+    monkeypatch.setattr(Path, "read_text", unreadable)
+
+    assert write_json_atomic(target, {"a": 1}, if_changed=True) is True
+
+
+def test_the_default_is_still_an_unconditional_write(tmp_path, fsyncs):
+    target = tmp_path / "x.json"
+    write_json_atomic(target, {"a": 1})
+    fsyncs.clear()
+
+    assert write_json_atomic(target, {"a": 1}) is True
+    assert len(fsyncs) == 1
+
+
+# ---------------------------------------------------------------------------
+# ConfigManager boot
+# ---------------------------------------------------------------------------
+
+
+def _fresh_manager(config_path: Path):
+    from src.config_manager import ConfigManager
+
+    ConfigManager._instance = None
+    return ConfigManager(config_path=str(config_path))
+
+
+def test_a_restart_against_an_unchanged_config_does_not_rewrite_it(tmp_path, fsyncs):
+    config_path = tmp_path / "config.json"
+    _fresh_manager(config_path)
+    before = config_path.read_bytes()
+    fsyncs.clear()
+
+    _fresh_manager(config_path)
+
+    assert fsyncs == [], "the defaults merge rewrote a config it did not change"
+    assert config_path.read_bytes() == before
+
+
+def test_a_restart_that_does_change_the_config_still_writes_it(tmp_path, fsyncs):
+    """Non-vacuity: a config missing a default key must still be filled in."""
+    config_path = tmp_path / "config.json"
+    _fresh_manager(config_path)
+    stored = json.loads(config_path.read_text())
+    stored.pop("general", None)
+    config_path.write_text(json.dumps(stored, indent=2))
+    fsyncs.clear()
+
+    _fresh_manager(config_path)
+
+    assert len(fsyncs) >= 1
+    assert "general" in json.loads(config_path.read_text())
+
+
+def test_a_no_op_save_still_bumps_the_config_generation(tmp_path):
+    """Generation-keyed caches must not start trusting the disk write.
+
+    ``config_generation`` says "what this process reads has moved". Tying it
+    to whether the bytes on disk changed would let a render short-circuit keep
+    serving a value the config manager no longer holds.
+    """
+    manager = _fresh_manager(tmp_path / "config.json")
+    before = manager.config_generation
+
+    manager._save_internal()
+
+    assert manager.config_generation == before + 1
+
+
+# ---------------------------------------------------------------------------
+# JsonStore
+# ---------------------------------------------------------------------------
+
+
+def test_storing_the_value_already_stored_does_not_fsync(tmp_path, fsyncs):
+    from src.storage.json_store import JsonStore
+
+    store = JsonStore(tmp_path / "probe.json", current_schema_version=1)
+    store.save({"a": 1})
+    fsyncs.clear()
+
+    store.save({"a": 1})
+
+    assert fsyncs == []
+
+
+def test_storing_a_new_value_still_fsyncs(tmp_path, fsyncs):
+    from src.storage.json_store import JsonStore
+
+    store = JsonStore(tmp_path / "probe.json", current_schema_version=1)
+    store.save({"a": 1})
+    fsyncs.clear()
+
+    store.save({"a": 2})
+
+    assert len(fsyncs) == 1
+    assert json.loads((tmp_path / "probe.json").read_text())["a"] == 2
+
+
+def test_a_skipped_save_still_updates_the_store_s_own_view(tmp_path):
+    from src.storage.json_store import JsonStore
+
+    path = tmp_path / "probe.json"
+    store = JsonStore(path, current_schema_version=1)
+    store.save({"a": 1})
+    payload = {"a": 1}
+
+    store.save(payload)
+
+    assert store._data is payload
+
+
+# ---------------------------------------------------------------------------
+# Snapshot retention
+# ---------------------------------------------------------------------------
+
+
+def test_boot_snapshots_are_pruned_to_the_retention_limit(tmp_path):
+    from src.system.update_service import SETTINGS_SNAPSHOT_RETENTION, prune_snapshot_dir
+
+    for i in range(12):
+        (tmp_path / f"pre-update-2026010{i % 10}T00000{i % 10}.000Z.json").write_text("{}")
+    made = len(list(tmp_path.glob("pre-update-*.json")))
+
+    deleted = prune_snapshot_dir(tmp_path)
+
+    assert made > SETTINGS_SNAPSHOT_RETENTION
+    assert deleted == made - SETTINGS_SNAPSHOT_RETENTION
+    assert len(list(tmp_path.glob("pre-update-*.json"))) == SETTINGS_SNAPSHOT_RETENTION
+
+
+def test_pruning_keeps_the_newest_snapshots(tmp_path):
+    from src.system.update_service import prune_snapshot_dir
+
+    names = [f"pre-update-2026010{i}T000000.000Z.json" for i in range(1, 8)]
+    for name in names:
+        (tmp_path / name).write_text("{}")
+
+    prune_snapshot_dir(tmp_path)
+
+    assert sorted(p.name for p in tmp_path.glob("pre-update-*.json")) == sorted(names[-5:])
+
+
+def test_pruning_ignores_files_that_are_not_snapshots(tmp_path):
+    from src.system.update_service import prune_snapshot_dir
+
+    for i in range(1, 8):
+        (tmp_path / f"pre-update-2026010{i}T000000.000Z.json").write_text("{}")
+    (tmp_path / "pages.json").write_text("{}")
+    (tmp_path / "pre-update-not-a-timestamp.json").write_text("{}")
+
+    prune_snapshot_dir(tmp_path)
+
+    assert (tmp_path / "pages.json").exists()
+    assert (tmp_path / "pre-update-not-a-timestamp.json").exists()

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -1915,6 +1915,12 @@ class TestAtomicSave:
         assert storage.count() == 1
         original_bytes = Path(temp_storage_file).read_bytes()
 
+        # The pending save must be a REAL one: an unchanged save is now
+        # correctly skipped as a no-op (write_json_atomic if_changed), so a
+        # crash test that re-saves identical bytes would never reach the
+        # crash it exists to test.
+        storage._pages[page.id] = page.model_copy(update={"name": "Renamed in memory only"})
+
         def crashing_dump(obj, fh, *args, **kwargs):
             fh.write('{"pages": [{"id": "abc", "name": "Impor')
             fh.flush()

--- a/tests/test_plugin_fetch_breaker.py
+++ b/tests/test_plugin_fetch_breaker.py
@@ -28,8 +28,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import src.plugins.registry as registry_module
+from src.devices import BoardContext
 from src.plugins.base import PluginBase, PluginResult
 from src.plugins.registry import PluginRegistry
+from src.settings.service import PollingSettings
 
 WEDGED = 8
 HEALTHY = 4
@@ -164,3 +166,135 @@ class TestWedgedPluginRenderStall:
         assert all(d < TIMEOUT / 2 for d in after), (
             f"renders still wait for the wedged plugin after the breaker opened: {after}"
         )
+
+
+# ==========================================================================
+# The three defects the Pi audit found in the machinery above
+# ==========================================================================
+
+
+class TestContextBuildBudget:
+    def test_the_fetch_budget_stays_below_the_shortest_poll_interval(self):
+        """The budget and the tick period must not be the same number.
+
+        ``build_template_context`` blocks the single service thread, which also
+        runs the 1 Hz silence-boundary detector and the collection-cadence gate
+        (src/main.py). While the budget EQUALLED the default 15s interval, one
+        slow plugin consumed an entire tick period and delayed silence
+        entry/exit by up to a full 15 seconds.
+
+        Pinned against the FLOOR the settings service will accept, not just the
+        default, so a user who polls as fast as the product allows still gets a
+        tick that finishes inside its own period.
+        """
+        floor = PollingSettings.from_dict({"interval_seconds": 1}).interval_seconds
+        assert floor > registry_module.CONTEXT_BUILD_TIMEOUT_SECONDS
+        assert PollingSettings().interval_seconds > registry_module.CONTEXT_BUILD_TIMEOUT_SECONDS
+
+
+class TestBreakerIsPerBoardGeometry:
+    """The breaker measures fetches; a fetch is one plugin ON one geometry.
+
+    Keyed by plugin_id alone, the counters crossed geometries in both
+    directions — and the direction that actually fires in the field is the one
+    that never quarantines anything.
+    """
+
+    def test_a_plugin_wedged_on_one_geometry_keeps_serving_the_other(self, registry, release):
+        def wedge_flagship_only(board=None):
+            if board is not None and board.device_type == "flagship":
+                release.wait(timeout=30)
+                return PluginResult(available=False, error="released")
+            return PluginResult(available=True, data={"value": "NOTE_OK"})
+
+        _install(registry, "dual", get_data=wedge_flagship_only)
+        flagship = BoardContext("flagship", rows=6, cols=22)
+        note = BoardContext("note", rows=3, cols=15)
+
+        note_contexts = []
+        for _ in range(SETTLE_TICKS):
+            registry.build_template_context(flagship, plugin_ids=["dual"])
+            note_contexts.append(registry.build_template_context(note, plugin_ids=["dual"]))
+
+        assert all(c.get("dual") == {"value": "NOTE_OK"} for c in note_contexts), (
+            "the healthy geometry lost its data to the other geometry's quarantine"
+        )
+
+    def test_a_healthy_geometry_does_not_cancel_the_wedged_one_s_streak(self, registry, release):
+        """The stall the breaker exists to end must still end.
+
+        Pre-fix the Note build's success popped the shared plugin_id streak
+        every tick, so the Flagship fetch never reached the threshold and every
+        Flagship render kept paying the full context-build timeout forever.
+        """
+
+        def wedge_flagship_only(board=None):
+            if board is not None and board.device_type == "flagship":
+                release.wait(timeout=30)
+                return PluginResult(available=False, error="released")
+            return PluginResult(available=True, data={"value": "NOTE_OK"})
+
+        _install(registry, "dual", get_data=wedge_flagship_only)
+        flagship = BoardContext("flagship", rows=6, cols=22)
+        note = BoardContext("note", rows=3, cols=15)
+
+        for _ in range(SETTLE_TICKS):
+            registry.build_template_context(flagship, plugin_ids=["dual"])
+            registry.build_template_context(note, plugin_ids=["dual"])
+
+        assert registry.get_fetch_breaker_status()["dual"]["quarantined"] is True
+
+        started = time.monotonic()
+        registry.build_template_context(flagship, plugin_ids=["dual"])
+        assert time.monotonic() - started < TIMEOUT / 2
+
+    def test_a_second_board_does_not_charge_two_timeouts_per_tick(self, registry, release):
+        """Two geometries used to trip a threshold-3 breaker in two ticks."""
+        _install(registry, "slow", get_data=_wedge(release))
+        flagship = BoardContext("flagship", rows=6, cols=22)
+        note = BoardContext("note", rows=3, cols=15)
+
+        for _ in range(registry_module.PLUGIN_FETCH_BREAKER_THRESHOLD - 1):
+            registry.build_template_context(flagship, plugin_ids=["slow"])
+            registry.build_template_context(note, plugin_ids=["slow"])
+
+        status = registry.get_fetch_breaker_status()["slow"]
+        assert status["consecutive_timeouts"] == registry_module.PLUGIN_FETCH_BREAKER_THRESHOLD - 1
+        assert status["quarantined"] is False, "two boards quarantined a plugin one tick early"
+
+
+class _SlowButHonestPlugin(PluginBase):
+    """A real PluginBase that always answers, just later than the budget."""
+
+    def __init__(self, delay: float):
+        self._delay = delay
+        self.fetches = 0
+        super().__init__({"id": "slow_honest", "name": "slow", "version": "1.0.0"})
+
+    @property
+    def plugin_id(self) -> str:
+        return "slow_honest"
+
+    def fetch_data(self) -> PluginResult:
+        self.fetches += 1
+        time.sleep(self._delay)
+        return PluginResult(available=True, data={"value": "LATE"})
+
+
+class TestSlowIsNotWedged:
+    def test_a_plugin_that_answers_after_the_budget_is_never_quarantined(self, registry):
+        """Shortening the budget must not turn slow data sources into dead ones.
+
+        The abandoned fetch still lands and fills PluginBase's cache, so the
+        next tick serves it inline — which is proof the plugin answered, and
+        ends its timeout streak.
+        """
+        plugin = _SlowButHonestPlugin(delay=TIMEOUT * 3)
+        registry._plugins["slow_honest"] = plugin
+        registry._enabled["slow_honest"] = True
+
+        contexts = [registry.build_template_context(plugin_ids=["slow_honest"]) for _ in range(SETTLE_TICKS)]
+
+        assert contexts[-1] == {"slow_honest": {"value": "LATE"}}, "late data never reached the board"
+        assert registry.get_fetch_breaker_status() == {}, "a slow-but-answering plugin was quarantined"
+        assert plugin.fetches == 1, "the cached answer was refetched instead of served"

--- a/tests/test_render_fingerprint_cost.py
+++ b/tests/test_render_fingerprint_cost.py
@@ -1,0 +1,431 @@
+"""What the render fingerprint costs, counted rather than timed (#1883 tail).
+
+``tests/test_render_short_circuit.py`` pins that the short-circuit FIRES
+correctly. This file pins what deciding it COSTS, because the Pi audit found
+the deciding cost carried two independent multipliers the short-circuit itself
+does not:
+
+* **per board** — four same-size boards on one page serialised the identical
+  ``(page, context)`` pair four times per tick, so the cost of deciding "no
+  render needed" scaled with board count even though the answer could not;
+* **per payload byte** — the whole plugin payload was re-serialised into the
+  hash every board every tick, so a single 64 KB plugin multiplied the idle
+  tick by 6.4x and a 256 KB one by 23x.
+
+Both are counted here (``json.dumps`` calls, bytes handed to ``json.dumps``,
+``Page.model_dump_json`` calls), never timed: counts transfer to a Raspberry
+Pi, wall-clock does not.
+
+The safety half matters more than the win. A memo that fired too eagerly, or a
+payload hash that missed a change, would strand a board on a stale frame — so
+every input that must still move the fingerprint has a test here, and the
+fallback that protects an uncovered hash map has one too.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from src.main import DisplayService
+from src.pages.models import Page
+from src.pages.service import PageService
+from src.pages.storage import PageStorage
+from src.plugins.base import PluginResult
+
+PAGE_ID = "page:fingerprint"
+
+
+class _MemoryStorage(PageStorage):
+    def __init__(self, pages):
+        self._pages = {p.id: p for p in pages}
+
+    def get(self, page_id):
+        return self._pages.get(page_id)
+
+    def list_all(self):
+        return list(self._pages.values())
+
+
+class _Registry:
+    """Fetch-layer double that models PluginBase's cache the way it matters here.
+
+    Each plugin's payload lives on ONE ``PluginResult`` object which is handed
+    back to every build until :meth:`set_data` replaces it — exactly as
+    ``PluginBase`` holds a cached result across ticks. That is what makes the
+    payload hash a once-per-data-change cost rather than a per-tick one, so
+    the byte counts below measure the production shape and not the double.
+    """
+
+    def __init__(self, data, *, per_board=None, record_fingerprints=True):
+        self.record_fingerprints = record_fingerprints
+        self.trigger_plugins: dict = {}
+        self.builds = 0
+        self.boards_seen: list = []
+        self._results = {None: {pid: PluginResult(available=True, data=payload) for pid, payload in data.items()}}
+        for device_type, payloads in (per_board or {}).items():
+            self._results[device_type] = {
+                pid: PluginResult(available=True, data=payload) for pid, payload in payloads.items()
+            }
+
+    def set_data(self, plugin_id: str, payload: dict, *, device_type=None) -> None:
+        """Replace a plugin's payload, as a fresh upstream fetch would."""
+        self._results[device_type][plugin_id] = PluginResult(available=True, data=payload)
+
+    def _source(self, board):
+        device_type = None if board is None else board.device_type
+        return self._results.get(device_type, self._results[None])
+
+    @property
+    def enabled_plugins(self) -> dict:
+        return dict.fromkeys(self._results[None])
+
+    def build_template_context(self, board=None, plugin_ids=None, include_trigger_plugins=True, fingerprints=None):
+        self.builds += 1
+        self.boards_seen.append(None if board is None else (board.device_type, board.rows, board.cols))
+        source = self._source(board)
+        if plugin_ids is None:
+            selected = dict(source)
+        else:
+            wanted = {str(p).lower() for p in plugin_ids}
+            selected = {k: v for k, v in source.items() if k.lower() in wanted}
+        built = {}
+        for plugin_id, result in selected.items():
+            built[plugin_id] = result.data
+            if fingerprints is not None and self.record_fingerprints:
+                fingerprints[plugin_id] = result.data_fingerprint()
+        return built
+
+
+class _ConfigManager:
+    def __init__(self):
+        self.config_generation = 1
+
+
+def _page(template=None, *, device_type="flagship", updated_at=None, **extra) -> Page:
+    return Page(
+        id=PAGE_ID,
+        name="Test",
+        type="template",
+        device_type=device_type,
+        template=template or ["{{stub.value}}", "", "", "", "", ""],
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        updated_at=updated_at or datetime(2026, 1, 1, tzinfo=UTC),
+        **extra,
+    )
+
+
+@pytest.fixture
+def rig(monkeypatch):
+    """Real ``PageService.shared_context_for`` over a stub fetch layer."""
+
+    def _make(data=None, *, per_board=None, record_fingerprints=True):
+        registry = _Registry(
+            data if data is not None else {"stub": {"value": "HELLO"}},
+            per_board=per_board,
+            record_fingerprints=record_fingerprints,
+        )
+        config = _ConfigManager()
+        pages = PageService(storage=_MemoryStorage([]))
+        monkeypatch.setattr("src.plugins.registry.get_plugin_registry", lambda: registry)
+        monkeypatch.setattr("src.config_manager.get_config_manager", lambda: config)
+        return registry, config, pages
+
+    return _make
+
+
+class _Counter:
+    """Counts ``json.dumps`` calls, bytes serialised, and page dumps."""
+
+    def __init__(self, monkeypatch):
+        self.dumps = 0
+        self.bytes = 0
+        self.page_dumps = 0
+        real_dumps = json.dumps
+        real_mdj = Page.model_dump_json
+
+        def counting_dumps(obj, **kwargs):
+            self.dumps += 1
+            out = real_dumps(obj, **kwargs)
+            self.bytes += len(out)
+            return out
+
+        def counting_mdj(page_self, **kwargs):
+            self.page_dumps += 1
+            return real_mdj(page_self, **kwargs)
+
+        monkeypatch.setattr(json, "dumps", counting_dumps)
+        monkeypatch.setattr(Page, "model_dump_json", counting_mdj)
+
+
+def _fingerprint(page, pages, contexts, *, override=False, page_id=PAGE_ID):
+    return DisplayService._render_fingerprint(page, page_id, pages, contexts, override_active=override)
+
+
+# --------------------------------------------------------------------------
+# The per-board multiplier
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("boards", [1, 2, 4, 8])
+def test_same_size_boards_fingerprint_the_page_once_per_tick(rig, monkeypatch, boards):
+    """N same-size boards on one page cost ONE serialisation, not N.
+
+    Before: json.dumps calls per tick tracked board count exactly
+    (1 -> 1, 2 -> 2, 4 -> 4, 8 -> 8).
+    """
+    _registry, _config, pages = rig()
+    page = _page()
+    # One warm tick first: PluginBase hashes a payload when it CACHES it, so
+    # in production that cost lands once per refresh interval, not per tick.
+    _fingerprint(page, pages, {})
+    counter = _Counter(monkeypatch)
+
+    contexts: dict = {}
+    results = [_fingerprint(page, pages, contexts) for _ in range(boards)]
+
+    assert len(set(results)) == 1, "same inputs must produce one fingerprint"
+    assert results[0] is not None
+    assert counter.dumps == 1, f"{boards} boards serialised the fingerprint {counter.dumps} times"
+    assert counter.page_dumps == 1, f"{boards} boards dumped the page {counter.page_dumps} times"
+
+
+def test_the_memo_dies_with_the_tick(rig, monkeypatch):
+    """A fresh ``contexts`` dict — i.e. the next tick — recomputes."""
+    _registry, _config, pages = rig()
+    page = _page()
+    # One warm tick first: PluginBase hashes a payload when it CACHES it, so
+    # in production that cost lands once per refresh interval, not per tick.
+    _fingerprint(page, pages, {})
+    counter = _Counter(monkeypatch)
+
+    for _ in range(3):
+        _fingerprint(page, pages, {})
+
+    assert counter.dumps == 3
+
+
+# --------------------------------------------------------------------------
+# The payload multiplier
+# --------------------------------------------------------------------------
+
+
+def _payload(kilobytes: int) -> dict:
+    filler = "y" * 200
+    return {"value": "HELLO", "blob": {f"k{i}": filler for i in range(max(1, (kilobytes * 1024) // 210))}}
+
+
+@pytest.mark.parametrize("kilobytes", [64, 256])
+def test_plugin_payload_size_does_not_enter_the_fingerprint(rig, monkeypatch, kilobytes):
+    """A big plugin payload costs the fingerprint a 32-char hash, not the payload.
+
+    Before: bytes handed to json.dumps per tick were 65,978 at 64 KB and
+    262,786 at 256 KB against a 559-byte floor.
+    """
+    _registry, _config, pages = rig({"stub": _payload(kilobytes)})
+    page = _page()
+
+    # One warm tick so the payload's own hash is memoised on its result, as it
+    # is in production the moment PluginBase caches that result.
+    _fingerprint(page, pages, {})
+    counter = _Counter(monkeypatch)
+    _fingerprint(page, pages, {})
+
+    assert counter.bytes < 4096, f"{kilobytes} KB payload put {counter.bytes} bytes through json.dumps"
+
+
+# --------------------------------------------------------------------------
+# Safety: everything that must still move the fingerprint
+# --------------------------------------------------------------------------
+
+
+def test_changed_plugin_payload_moves_the_fingerprint(rig):
+    registry, _config, pages = rig()
+    page = _page()
+
+    before = _fingerprint(page, pages, {})
+    registry.set_data("stub", {"value": "GOODBYE"})
+    after = _fingerprint(page, pages, {})
+
+    assert before != after
+
+
+def test_a_payload_change_within_one_tick_is_not_hidden_by_the_memo(rig):
+    """The memo keys on page + generation, so it must not span a data change.
+
+    Within one tick the context is built once and shared, so this asserts the
+    memo cannot serve a fingerprint for data the shared context no longer
+    holds: a second page id gets its own memo entry and its own hash.
+    """
+    registry, _config, pages = rig({"stub": {"value": "A"}, "other": {"value": "B"}})
+    contexts: dict = {}
+    one = _fingerprint(_page(["{{stub.value}}", "", "", "", "", ""]), pages, contexts)
+    two = _fingerprint(
+        _page(["{{other.value}}", "", "", "", "", ""]),
+        pages,
+        contexts,
+        page_id="page:other",
+    )
+    assert one != two
+    assert registry.builds >= 1
+
+
+def test_edited_page_moves_the_fingerprint_within_the_same_tick(rig):
+    """The memo must not survive a page edit that lands mid-pass."""
+    _registry, _config, pages = rig()
+    contexts: dict = {}
+    before = _fingerprint(_page(), pages, contexts)
+    edited = _page(["{{stub.value}}!", "", "", "", "", ""], updated_at=datetime(2026, 2, 2, tzinfo=UTC))
+    after = _fingerprint(edited, pages, contexts)
+    assert before != after
+
+
+def test_config_generation_moves_the_fingerprint_within_the_same_tick(rig):
+    _registry, config, pages = rig()
+    page = _page()
+    contexts: dict = {}
+    before = _fingerprint(page, pages, contexts)
+    config.config_generation += 1
+    after = _fingerprint(page, pages, contexts)
+    assert before != after
+
+
+def test_override_branch_moves_the_fingerprint_within_the_same_tick(rig):
+    _registry, _config, pages = rig()
+    page = _page()
+    contexts: dict = {}
+    normal = _fingerprint(page, pages, contexts, override=False)
+    overridden = _fingerprint(page, pages, contexts, override=True)
+    assert normal != overridden
+
+
+def test_board_sizes_never_share_a_memo(rig):
+    """Board-aware plugins return different data per geometry (#1243).
+
+    Collapsing the memo across sizes would hand a Note board the Flagship's
+    fingerprint, which is exactly the per-board isolation this must not break.
+    """
+    _registry, _config, pages = rig(
+        per_board={
+            "flagship": {"stub": {"value": "WIDE"}},
+            "note": {"stub": {"value": "NARROW"}},
+        }
+    )
+    contexts: dict = {}
+    flagship = _fingerprint(_page(device_type="flagship"), pages, contexts)
+    note = _fingerprint(_page(["{{stub.value}}", "", ""], device_type="note"), pages, contexts)
+    assert flagship != note
+
+
+def test_a_registry_that_records_no_hashes_still_detects_a_data_change(rig):
+    """The fallback is what makes a partial hash map safe.
+
+    A context whose payload hashes are not provably complete must be hashed
+    the old way — payloads and all — because treating an unrecorded plugin as
+    "contributed nothing" would swallow a real change.
+    """
+    registry, _config, pages = rig(record_fingerprints=False)
+    page = _page()
+
+    before = _fingerprint(page, pages, {})
+    registry.set_data("stub", {"value": "MOVED"})
+    after = _fingerprint(page, pages, {})
+
+    assert before is not None
+    assert before != after
+
+
+def test_a_partially_recorded_hash_map_still_detects_a_data_change(rig, monkeypatch):
+    """Half a hash map is treated as no hash map, not as half the truth."""
+    registry, _config, pages = rig({"stub": {"value": "A"}, "extra": {"value": "B"}})
+
+    real_build = registry.build_template_context
+
+    def half_recording(board=None, plugin_ids=None, include_trigger_plugins=True, fingerprints=None):
+        built = real_build(board, plugin_ids, include_trigger_plugins, fingerprints)
+        if fingerprints is not None:
+            fingerprints.pop("extra", None)
+        return built
+
+    monkeypatch.setattr(registry, "build_template_context", half_recording)
+    page = _page(["{{stub.value}}{{extra.value}}", "", "", "", "", ""])
+
+    before = _fingerprint(page, pages, {})
+    registry.set_data("extra", {"value": "MOVED"})
+    after = _fingerprint(page, pages, {})
+
+    assert before is not None
+    assert before != after
+
+
+# --------------------------------------------------------------------------
+# The hash itself
+# --------------------------------------------------------------------------
+
+
+def test_data_fingerprint_is_computed_once_per_result(monkeypatch):
+    result = PluginResult(available=True, data={"a": 1, "b": [1, 2, 3]})
+    calls = {"n": 0}
+    real_dumps = json.dumps
+
+    def counting(obj, **kwargs):
+        calls["n"] += 1
+        return real_dumps(obj, **kwargs)
+
+    monkeypatch.setattr(json, "dumps", counting)
+    first = result.data_fingerprint()
+    second = result.data_fingerprint()
+
+    assert first == second
+    assert calls["n"] == 1
+
+
+def test_data_fingerprint_separates_different_payloads():
+    a = PluginResult(available=True, data={"value": 1})
+    b = PluginResult(available=True, data={"value": 2})
+    assert a.data_fingerprint() != b.data_fingerprint()
+
+
+def test_data_fingerprint_is_insensitive_to_key_order():
+    a = PluginResult(available=True, data={"x": 1, "y": 2})
+    b = PluginResult(available=True, data={"y": 2, "x": 1})
+    assert a.data_fingerprint() == b.data_fingerprint()
+
+
+def test_hashing_does_not_change_result_equality():
+    a = PluginResult(available=True, data={"value": 1})
+    b = PluginResult(available=True, data={"value": 1})
+    a.data_fingerprint()
+    assert a == b
+
+
+def test_unhashable_payload_still_produces_a_fingerprint():
+    """``default=str`` keeps a datetime-carrying payload hashable."""
+    result = PluginResult(available=True, data={"when": datetime(2026, 1, 1, tzinfo=UTC)})
+    assert isinstance(result.data_fingerprint(), str)
+
+
+def test_fingerprint_is_none_when_the_context_cache_is_absent(rig):
+    """Direct callers (MQTT, /refresh) pass no per-pass cache and must render."""
+    _registry, _config, pages = rig()
+    assert _fingerprint(_page(), pages, None) is None
+
+
+def test_registry_construction_is_not_required_for_the_memo_key(rig):
+    """A note-array page keys its memo on its true geometry, not its type."""
+    _registry, _config, pages = rig()
+    contexts: dict = {}
+    wide = _fingerprint(
+        _page(["{{stub.value}}"] * 3, device_type="note_array", notes_wide=2, notes_tall=1),
+        pages,
+        contexts,
+    )
+    tall = _fingerprint(
+        _page(["{{stub.value}}"] * 6, device_type="note_array", notes_wide=1, notes_tall=2),
+        pages,
+        contexts,
+    )
+    assert wide is not None and tall is not None
+    assert wide != tall

--- a/tests/test_render_short_circuit.py
+++ b/tests/test_render_short_circuit.py
@@ -32,6 +32,7 @@ from src.main import BoardRuntime, DisplayService
 from src.pages.models import Page
 from src.pages.service import PageService
 from src.pages.storage import PageStorage
+from src.plugins.base import PluginResult
 from src.templates.engine import get_template_engine, reset_template_engine
 from tests.fake_clock import FakeClock, install_fake_time_service
 
@@ -79,12 +80,20 @@ class StubRegistry:
     def enabled_plugins(self) -> dict:
         return dict.fromkeys(self.data)
 
-    def build_template_context(self, board=None, plugin_ids=None, include_trigger_plugins=True):
+    def build_template_context(self, board=None, plugin_ids=None, include_trigger_plugins=True, fingerprints=None):
         self.builds += 1
         if plugin_ids is None:
-            return {k: dict(v) for k, v in self.data.items()}
-        wanted = {str(p).lower() for p in plugin_ids}
-        return {k: dict(v) for k, v in self.data.items() if k.lower() in wanted}
+            built = {k: dict(v) for k, v in self.data.items()}
+        else:
+            wanted = {str(p).lower() for p in plugin_ids}
+            built = {k: dict(v) for k, v in self.data.items() if k.lower() in wanted}
+        # Mirror the real registry's contract: fingerprints covers EXACTLY the
+        # ids this build put in the context, so the render short-circuit
+        # exercises its hash-composition path rather than its fallback.
+        if fingerprints is not None:
+            for plugin_id, payload in built.items():
+                fingerprints[plugin_id] = PluginResult(available=True, data=payload).data_fingerprint()
+        return built
 
     def get_manifest(self, _plugin_id):
         return None

--- a/tests/test_schedules_storage.py
+++ b/tests/test_schedules_storage.py
@@ -477,6 +477,12 @@ class TestScheduleStorage:
         assert storage.count() == 1
         original_bytes = Path(temp_storage_file).read_bytes()
 
+        # The pending save must be a REAL one: an unchanged save is now
+        # correctly skipped as a no-op (write_json_atomic if_changed), so a
+        # crash test that re-saves identical bytes would never reach the
+        # crash it exists to test.
+        storage._schedules["keep-me"] = schedule.model_copy(update={"end_time": "18:00"})
+
         # Simulate mid-write crash: json.dump writes a truncated prefix
         # then raises before the file is fully serialized.
         real_dump = json.dump

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -329,6 +329,12 @@ class TestSettingsServiceInit:
         settings_service._save_to_file()
         original_bytes = Path(settings_file).read_bytes()
 
+        # The pending save must be a REAL one: an unchanged save is now
+        # correctly skipped as a no-op (write_json_atomic if_changed), so a
+        # crash test that re-saves identical bytes would never reach the
+        # crash it exists to test.
+        settings_service._polling.interval_seconds += 5
+
         real_dump = json.dump
 
         def crashing_dump(obj, fh, *args, **kwargs):

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -317,6 +317,11 @@ class TestSettingsServiceInit:
         This asserted "should not raise" until #1887: swallowing it made ~20
         endpoints answer HTTP 200 having persisted nothing.
         """
+        # The pending save must be a REAL one: an unchanged save is now
+        # correctly skipped as a no-op (write_json_atomic if_changed), and a
+        # save that never opens the file cannot observe a refused open.
+        settings_service._polling.interval_seconds += 5
+
         with patch("builtins.open", side_effect=OSError("write error")), pytest.raises(OSError):
             settings_service._save_to_file()
 

--- a/tests/test_tick_shared_context.py
+++ b/tests/test_tick_shared_context.py
@@ -46,7 +46,7 @@ class CountingRegistry:
         # differs between board=None and board-aware builds override this.
         self.payload = lambda board: {}
 
-    def build_template_context(self, board=None, plugin_ids=None):
+    def build_template_context(self, board=None, plugin_ids=None, include_trigger_plugins=True, fingerprints=None):
         self.build_calls += 1
         self.boards_seen.append(board)
         return self.payload(board)


### PR DESCRIPTION
Closes the measured Raspberry Pi performance findings in the engine (P3–P8 of
the "Is this the right shape for a Pi?" section of the API-ergonomics design).

**None of this will be visible to a user as speed, and it is not meant to be.**
The tick is already the right shape and is not restructured here: plugin fetches
per tick are exactly R, a static page still costs 0 renders and 0 sends, the
loop still performs 0 disk writes over 92 s, and engine CPU is still ~0.2 ms per
15 s poll. What this removes is waste that scales with plugin payload size and
board count, plus two correctness-adjacent defects in the fetch-timeout
machinery.

`tests/golden/engine/` and `tests/golden/api_routes.json` are byte-identical.

---

## Measurements — counts first, timings second

Everything below is counted (`json.dumps` calls, bytes serialised, executor
submissions, fetches, fsyncs, blocking call sites). Counts transfer to a Pi;
wall-clock is a ratio only. All measured in `fb-test` on aarch64.

### P3 — the render fingerprint (steady state, on the real path)

| boards | payload | `json.dumps`/tick | bytes/tick | `model_dump_json`/tick | ms/tick |
|---|---|---|---|---|---|
| 1 | — | 1 → **1** | 559 → **565** | 1 → **1** | 0.043 → **0.015** |
| 2 | — | 2 → **1** | 1,118 → **565** | 2 → **1** | 0.078 → **0.017** |
| 4 | — | 4 → **1** | 2,236 → **565** | 4 → **1** | 0.099 → **0.020** |
| 8 | — | 8 → **1** | 4,472 → **565** | 8 → **1** | 0.148 → **0.027** |
| 1 | 64 KB | 1 → **1** | 65,978 → **565** | 1 → **1** | 0.197 → **0.014** |
| 1 | 256 KB | 1 → **1** | 262,786 → **565** | 1 → **1** | 0.598 → **0.014** |

Both multipliers are gone: bytes/tick is now flat at 565 in both board count
and payload size. Hashing a payload still costs one `json.dumps` of it — once,
when `PluginBase` caches the result, i.e. once per refresh interval rather than
once per board per tick.

### P4 — executor dispatch for an already-cached plugin

| | before | after |
|---|---|---|
| executor submissions per steady-state tick | 1.00 | **0.00** |
| `fetch_data` calls per steady-state tick | 0.00 | 0.00 |
| enters `futures_wait` on a fully cached tick | yes | **no** |

### P5 — fetch-timeout machinery

| | before | after |
|---|---|---|
| `CONTEXT_BUILD_TIMEOUT_SECONDS` vs default poll interval | 15 vs 15 (**equal**) | **5** vs 15 |
| ticks to quarantine a plugin wedged on 2 geometries | 2 | **3** (= the threshold) |
| streak charged per tick, 2 geometries | 2 | **1** |
| plugin wedged on Flagship, healthy on Note: breaker | **never opens** (Note's success clears the streak) | opens on Flagship after 3 ticks |
| …and the Flagship render | pays the full budget **forever** | returns immediately once quarantined |
| …and the Note render | keeps its data | keeps its data |

### P6 — blocking calls made directly in an `async def` body

AST scan over `src/`, counting only calls not inside a nested `def` that a
`to_thread`/`run_board_send` will run:

| | before | after |
|---|---|---|
| blocking call sites on the event loop | **16** | **1** |

The remaining one is `src/v1/routes_plugins.py` — another agent owns that
directory; it is pinned in the ratchet's `KNOWN_REMAINING` so it cannot be
forgotten.

`/templates/render` also stops fetching every plugin to render four variables:

| template | plugins fetched (before → after) |
|---|---|
| `{{weather.temperature}}` | all enabled → **`{weather}`** |
| `{{= weather.temperature + 1 }}` | all enabled → all enabled (correct: a formula's variable owners are not statically knowable) |

### P8 — writes that change nothing

| | fsyncs before | fsyncs after |
|---|---|---|
| warm boot (config.json md5 identical before and after) | 1 | **0** |
| `JsonStore.save` of the value already stored | 1 | **0** |
| `JsonStore.save` of a **new** value | 1 | 1 |
| boot snapshots kept after 12 version changes | 12 files | **5 files** |

Sized honestly: tens of fsyncs per boot, not per hour. Nothing writes on a
timer. This is not why an SD card dies — it is simply a write with no upside.

---

## Skipped, because it does not reproduce

**P5's third defect — `PLUGIN_FETCH_LOST_WORKER_LIMIT = MAX_WORKERS // 2 = 4`
"means a 6-plugin install can sit at 4/8 workers permanently occupied without
ever triggering the pool rotation."** Measured on this tree, rotation fires at
exactly 4 written-off workers (`if _fetch_workers_lost < LIMIT: return` — 4 is
not less than 4), so the highest sustainable occupancy without rotation is 3/8,
not 4/8:

```
  MAX_WORKERS=8 LIMIT=4
  1 wedged of 6 plugins: lost=1  no rotation
  2 wedged of 6 plugins: lost=2  no rotation
  3 wedged of 6 plugins: lost=3  no rotation
  4 wedged of 6 plugins: rotated ("4 of 8 workers are permanently occupied")
  6 wedged of 6 plugins: rotated ("6 of 8 workers are permanently occupied")
```

At 3/8 lost the constant's stated invariant still holds — healthy plugins keep
`MAX_WORKERS - LIMIT = 4` workers, and a 6-plugin install with 3 wedged has 3
healthy plugins competing for 5 free workers. There is no starvation to fix, so
nothing was changed. Reporting the off-by-one seemed more useful than inventing
a change around it.

## Left open, deliberately

**The fingerprint still covers whole payloads, not referenced fields.** A page
showing only `{{date_time.date}}` still re-renders every minute, because
`date_time`'s payload carries minute-resolution `time`. This PR makes that
cheap (one memoised hash instead of a per-board re-encode) but does not make it
stop happening. Fixing it properly needs field-path extraction, and
`extract_template_plugin_ids` deliberately returns plugin **roots** — an
extractor that under-approximates a field set strands a board on a stale frame,
which is a strictly worse failure than a needless render. Worth a separate
change with its own safety argument.

---

## Fail-first evidence

Each new test was run against the unmodified `src/` (`git stash push -- src/`).
Observed output, verbatim:

### `tests/test_render_fingerprint_cost.py` — 10 failed, 12 passed

```
E   AssertionError: 2 boards serialised the fingerprint 2 times
E   assert 2 == 1
E   AssertionError: 4 boards serialised the fingerprint 4 times
E   assert 4 == 1
E   AssertionError: 8 boards serialised the fingerprint 8 times
E   assert 8 == 1
E   AssertionError: 64 KB payload put 66001 bytes through json.dumps
E   assert 66001 < 4096
E   AssertionError: 256 KB payload put 262809 bytes through json.dumps
E   assert 262809 < 4096
E   AttributeError: 'PluginResult' object has no attribute 'data_fingerprint'
```

### `tests/test_demand_driven_fetch.py::TestCachedFetchFastPath` — 4 failed, 3 passed

```
E   AssertionError: the warm build must not dispatch
E   assert 2 == 1
E    +  where 2 = len(['cached', 'cached'])
E   assert [1] == []
E     Left contains one more item: 1
E   AttributeError: 'PluginRegistry' object has no attribute 'get_cached_plugin_data'.
    Did you mean: 'fetch_plugin_data'?
```

### `tests/test_plugin_fetch_breaker.py` — 3 failed, 5 passed

```
E   assert 15 < 10
E    +  where 15 = registry_module.CONTEXT_BUILD_TIMEOUT_SECONDS
E   KeyError: 'dual'
E   assert 3 == (3 - 1)
E    +  where 3 = registry_module.PLUGIN_FETCH_BREAKER_THRESHOLD
```

(`KeyError: 'dual'` is the interesting one: pre-fix the breaker had *no entry
at all* for a plugin wedged on Flagship, because the healthy Note geometry
cleared its streak every tick.)

### `tests/test_no_blocking_on_event_loop.py` — 6 failed, 3 passed

```
E   tests.test_no_blocking_on_event_loop.LoopThreadViolation: blocking work ran on the event loop thread
E   AssertionError: render fetched None instead of just the referenced plugin
E   assert None == {'weather'}
E   AssertionError: assert {('src/board_..., 'get'), ...} == {('src/v1/rou...get_display')}
E     Extra items in the left set:
E     ('src/plugins/routes.py', 'get_available_variables')
E     ('src/templates/routes.py', 'get_all_variables_with_metadata')
E     ('src/templates/routes.py', 'get_available_variables')
E     ('src/displays/routes.py', 'get_display')
E     ('src/settings/routes.py', 'post')...
```

### `tests/test_no_op_writes.py` — 10 failed, 4 passed

```
E   TypeError: write_json_atomic() got an unexpected keyword argument 'if_changed'
E   AssertionError: the defaults merge rewrote a config it did not change
E   assert [11] == []
E     Left contains one more item: 11
E   ImportError: cannot import name 'prune_snapshot_dir' from 'src.system.update_service'
```

---

## Correctness constraints honoured

- `rt.last_render` still carries its own validity proof and is still re-checked
  against the live dedupe cache at the call site. Nothing about invalidation
  changed, so every existing cache-clearing site keeps invalidating it for free.
- The new fingerprint memo is keyed by board **size**, never globally.
  `test_board_sizes_never_share_a_memo` pins it.
- The hash composition is guarded: if the payload-hash map does not provably
  cover every referenced plugin the context holds data for, the fingerprint
  falls back to hashing the payloads.
  `test_a_partially_recorded_hash_map_still_detects_a_data_change` pins it.
- The breaker's constants (`PLUGIN_FETCH_BREAKER_THRESHOLD`,
  `..._COOLDOWN_SECONDS`, "started and timed out, not never-started") are
  unchanged. Only the **key** changed.
- `registry._lock` and `registry._inflight_lock` remain separate.
  `tests/test_registry_lock_discipline.py` passes.
- Not touched, as measured-and-already-right: the JSON stores' design, the
  fetch fan-out, the linear board scans, the pool sizes, FastAPI's threadpool,
  `BoardRuntime`'s per-board duplication.

## Six existing tests had their SETUP changed — and only their setup

`if_changed` means a save of unchanged bytes performs no write. Six tests
depended, incidentally, on every save writing:

| test | it re-saved | now |
|---|---|---|
| `test_pages.py::test_save_is_atomic_on_mid_write_crash` | bytes already on disk | renames the page in memory first |
| `test_collections.py::test_save_is_atomic_on_mid_write_crash` | " | renames the collection first |
| `test_schedules_storage.py::test_save_is_atomic_on_mid_write_crash` | " | changes `end_time` first |
| `test_settings_service.py::test_save_to_file_is_atomic_on_mid_write_crash` | " | changes the poll interval first |
| `test_config_manager.py::test_save_internal_is_atomic_on_mid_write_crash` | " | changes `instance_name` first |
| `test_settings_service.py::test_save_to_file_propagates_io_error` | " | changes the poll interval first |

Not one assertion changed. Each still asserts exactly what it asserted before
(the target survives a crash byte-identical; a refused write reaches the
caller) — and each now actually reaches the crash it exists to test, instead
of passing while re-writing bytes that were already there.

Relatedly, `write_json_atomic` keeps serialising with **`json.dump`** streaming
into the staging file rather than `json.dumps`-then-write.
`tests/test_storage_kernel.py` crashes `json.dump` partway through to prove a
serialisation failure leaves a partial *staging* file (unlinked on the way out)
and never a partial target. The `if_changed` comparison serialises separately
rather than reusing the write's output.

## Suite

Both runs: `docker run --rm -m 3g … fb-test:latest python -m pytest tests/ -q`.

| | before (`origin/next` @ 497f825ae) | after |
|---|---|---|
| passed | 6874 | **6931** |
| failed | 1 | **1** |
| skipped | 2 | 2 |
| data-dir leak | 0 | **0** |

The one failure is the same test before and after, and is environmental rather
than a test failure: `test_no_tracked_file_in_this_repo_reaches_a_vulnerable_parser`
shells out to `git ls-files`, which exits 128 inside the container because this
is a git *worktree* whose `.git` file points outside the mount. It fails
identically on unmodified `origin/next`.

`ruff==0.16.5` clean over `src/ plugins/ tests/ scripts/`. Markdown lint, spell
check, docs contract and frontmatter lint all clean.
