### PR TITLE
test(isolation): make the singleton-rebuild test deterministic, not timed

### DIFF
--- a/tests/test_singleton_isolation.py
+++ b/tests/test_singleton_isolation.py
@@ -76,9 +76,20 @@ def test_a_dropped_services_poll_thread_stops_rebuilding_the_settings_singleton(
 
     _drop_all_singletons()
 
-    # A construction already in flight when the reset landed may still assign;
-    # let it, then re-drop. What must not happen is a *new* one after this.
-    time.sleep(0.05)
+    # Join before clearing, rather than allowing a fixed grace period for a
+    # construction already in flight. A 50ms grace outran the poll thread on an
+    # unloaded machine and lost to it on a loaded xdist worker, which made this
+    # test flake in CI twice — and sleeping longer would make the race rarer,
+    # not absent. Once the thread has exited nothing can reassign the global,
+    # so the observation below is deterministic.
+    #
+    # This also sharpens the failure: revert the conftest fix and the join times
+    # out here, naming the live thread, instead of surfacing as a mystery
+    # reassignment 250ms later.
+    service._poll_thread.join(timeout=5)
+    assert not service._poll_thread.is_alive(), (
+        "board-state-poll outlived the singleton reset, so it can still rebuild the settings global inside a later test"
+    )
     settings_service_module._settings_service = None
 
     # Long enough for a 1ms-interval loop to have rebuilt it a hundred times.


### PR DESCRIPTION
Two agents hit this in CI on unrelated branches this session — one whose diff was **100% `web/`** — and both correctly worked out it wasn't theirs. That is two wasted re-run cycles and two diagnoses of the same thing, which is the cost of leaving it.

## The race

```python
_drop_all_singletons()
time.sleep(0.05)                    # grace for an in-flight construction
settings_service_module._settings_service = None
time.sleep(0.25)                    # observation window
assert settings_service_module._settings_service is None
```

The 50 ms grace outruns the poll thread on an idle machine and loses to it on a loaded xdist worker. A construction already in flight then assigns *after* the clear, and the assertion fails even though the behaviour under test is working correctly.

## Why not just sleep longer

That makes the race rarer, not absent — and a test that fails once a fortnight is worse than one that fails every time, because nobody trusts it and everybody reruns it.

The deterministic primitive was already sitting one function up in the same file: `service._poll_thread.join(timeout=5)`. Once the thread has exited, nothing can reassign the global, so the observation that follows actually means something.

## It also sharpens the failure

Reverting #1921's conftest fix now stops at the join and names the culprit:

```
AssertionError: board-state-poll outlived the singleton reset, so it can still
rebuild the settings global inside a later test
assert not True
 +  where True = <Thread(board-state-poll, started daemon)>.is_alive()
```

instead of surfacing as a mystery reassignment 250 ms later.

## Non-vacuity

Sabotaged `tests/conftest.py`'s `running = False` stop seam and confirmed **both** tests in the file fail, with the message above; restored, all 3 pass. Output in the commit body.

Full suite **6874 passed, 2 skipped**, 0 data-dir leaks. The single failure is the environmental `test_check_image_formats` (`git ls-files` cannot read a worktree `.git` from inside the container) and is identical on `next`.