### PR TITLE
feat(api): start the sunset clock on the 25 endpoints /v1 supersedes

### DIFF
--- a/docs/internal/reference/API_CONVENTIONS.md
+++ b/docs/internal/reference/API_CONVENTIONS.md
@@ -226,6 +226,41 @@ days, so a release count is not a window an outside integrator can plan
 against — and callers this repo cannot see are the entire reason these routes
 still exist.
 
+### The second cohort: what `/v1` supersedes
+
+The same rule was then applied to the routes `/v1` replaced. #1934 moved every
+web-client call `/v1` supersedes onto `/v1` and left **33** internal endpoints
+with no product caller; #1936 closed five of the ten gaps that migration found.
+**25 of the 33** carry the notice from #1941, on the same clock
+(`Sunset: Tue, 01 Dec 2026 00:00:00 GMT`) — one appliance, one removal date,
+because two countdowns a few weeks apart means an integrator has to track both
+to learn when their script stops working. The cohort is
+`SUPERSEDED_BY_V1` in `src/api_deprecation.py` and
+`tests/test_superseded_route_headers.py` pins it in both directions.
+
+**The eight that were excluded are the reviewable half.** A
+`successor-version` link is a promise that following it loses nothing, so a
+route whose v1 equivalent still drops a field is *not* superseded and does not
+get one:
+
+| Not deprecated | What its v1 equivalent still drops |
+|---|---|
+| `POST /pages/{id}/send` | `paused` and `target`; a paused board is a 409 on v1, not a 200 that says so |
+| `POST /displays/{type}/send` | nothing in `POST /v1/boards/{b}/message` accepts a plugin id at all |
+| `GET`/`PUT /schedules/enabled` | both answer for the *install* when no `board_id` is given; `GET`/`PATCH /v1/boards/{board}` has no board-less form, and the write 404s where these fall back to the global mirror |
+| `GET`/`PUT /schedules/default-page` | same |
+| `GET /displays` | `source`; and it 503s where this answers 200 with an empty list |
+| `POST /settings/board/{id}/pause` | the embedded `board_settings` block — `BoardDetail` deliberately carries no credentials, tiles, colour or transport fields |
+
+**Known limitation of the mechanism, shared with the first cohort.**
+`deprecation_notice` stamps the `Response` FastAPI injects into the handler,
+and FastAPI merges that object's headers only into a response built from a
+returned value. A route that raises `HTTPException` is answered from a fresh
+response and the notice is dropped, so a caller who only ever sees 4xx never
+sees it. Pinned by
+`test_a_refusal_carries_no_notice__inherited_limitation` rather than left to be
+rediscovered as a bug.
+
 ## Identifiers
 
 - Resource ids are validated against reserved route words so

--- a/src/api_deprecation.py
+++ b/src/api_deprecation.py
@@ -86,3 +86,112 @@ def deprecation_notice(
 #: does — ``src/v1/routes_boards.py`` calls ``refresh_display`` outright. A
 #: ``Link`` relation names a resource, not a method, so the two share one.
 V1_BOARD_MESSAGE_SUCCESSOR = "/api/v1/boards/{board}/message"
+
+
+# ---------------------------------------------------------------------------
+# The v1-superseded cohort (#1941)
+# ---------------------------------------------------------------------------
+#
+# #1934 moved every web-client call that ``/v1`` supersedes onto ``/v1`` and
+# left 33 internal endpoints with no product caller. #1936 then closed five of
+# the ten places where a v1 route dropped something its internal twin carried.
+#
+# The 25 below are what survives both a caller audit (``src/mcp_server.py``,
+# ``src/ops/executors.py``, ``src/mqtt/commands.py`` and the bundled plugins
+# all reach their domains through *services*, not these paths) and an
+# exactness audit: for each one, the successor named here answers every fact
+# the legacy response carries, accepts every input the legacy route accepts,
+# and refuses nothing the legacy route answered. The eight of the 33 that
+# failed that test are listed in the PR and on #1941 and are deliberately
+# **not** here — a ``successor-version`` link to a route that drops a field is
+# worse than no link, because a caller who follows it loses data silently.
+#
+# These routes are already ``include_in_schema=False`` (#1935), so the notice
+# is invisible to a reader of the published document by design. The audience
+# is a caller who is *already calling them* — a script in another repo, a
+# cron job — and the only place such a caller will ever see a deprecation is
+# on the response it is already reading.
+
+#: Removal date for the cohort. Deliberately the same date as the eleven
+#: plugin-specific routes (``DEPRECATED_ROUTES_SUNSET`` in
+#: ``src/api_server.py``): FiestaBoard cuts a minor release every few days —
+#: v8.30.0 to v8.34.0 spans twelve days — so "two releases" is about a week
+#: and is not a window an outside integrator can plan against. A quarter is.
+#: Two clocks for one appliance would also mean an integrator has to track two
+#: dates to find out when their script stops working, so this cohort joins the
+#: existing one rather than starting a second countdown a few weeks later.
+SUPERSEDED_BY_V1_SUNSET = "Tue, 01 Dec 2026 00:00:00 GMT"
+
+#: ``"<METHOD> <path>"`` -> the ``/v1`` operation that supersedes it, as the
+#: URI a caller would use (nginx strips ``/api``, so ``/api/v1/...`` is what
+#: goes in the ``Link``). Spelled once here rather than inline at 25 decorators
+#: so the cohort can be read, reviewed and deleted as one list.
+#:
+#: ``tests/test_superseded_route_headers.py`` pins this both ways: every key
+#: must name a route the app actually serves and that route must carry the
+#: notice, and every route carrying the notice must be a key.
+SUPERSEDED_BY_V1: dict[str, str] = {
+    # Pages — /v1 delegates to these very handlers.
+    "GET /pages": "/api/v1/pages",
+    "POST /pages": "/api/v1/pages",
+    "GET /pages/{page_id}": "/api/v1/pages/{page_id}",
+    "PUT /pages/{page_id}": "/api/v1/pages/{page_id}",
+    "DELETE /pages/{page_id}": "/api/v1/pages/{page_id}",
+    # Schedules — the five CRUD operations only. The four board-scoped
+    # settings routes (enabled / default-page) are excluded: they accept a
+    # request with no board at all and answer for the install, and
+    # PATCH/GET /v1/boards/{board} has no board-less form.
+    "GET /schedules": "/api/v1/schedules",
+    "POST /schedules": "/api/v1/schedules",
+    "GET /schedules/{schedule_id}": "/api/v1/schedules/{schedule_id}",
+    "PUT /schedules/{schedule_id}": "/api/v1/schedules/{schedule_id}",
+    "DELETE /schedules/{schedule_id}": "/api/v1/schedules/{schedule_id}",
+    # Collections — /v1 delegates to these very handlers.
+    "GET /collections": "/api/v1/collections",
+    "POST /collections": "/api/v1/collections",
+    "GET /collections/{collection_id}": "/api/v1/collections/{collection_id}",
+    "PUT /collections/{collection_id}": "/api/v1/collections/{collection_id}",
+    "DELETE /collections/{collection_id}": "/api/v1/collections/{collection_id}",
+    # Plugins. The three writes collapse into one PATCH, which answers the
+    # full PluginDetail — a superset of {plugin_id, config} and of
+    # {plugin_id, enabled}, with the same masking.
+    "GET /plugins/{plugin_id}": "/api/v1/plugins/{plugin_id}",
+    "PUT /plugins/{plugin_id}/config": "/api/v1/plugins/{plugin_id}",
+    "POST /plugins/{plugin_id}/enable": "/api/v1/plugins/{plugin_id}",
+    "POST /plugins/{plugin_id}/disable": "/api/v1/plugins/{plugin_id}",
+    "GET /plugins/{plugin_id}/data": "/api/v1/plugins/{plugin_id}/data",
+    # The display read is the same fetch seen twice: v1 carries `lines` and
+    # `text`, and `line_count` is len(lines).
+    "GET /displays/{display_type}": "/api/v1/plugins/{plugin_id}/data",
+    # Template vocabulary. GET /v1/variables is the merge of both of these:
+    # both sides read PluginRegistry.get_all_variables() / get_all_max_lengths()
+    # (TemplateEngine forwards to them verbatim), and v1 adds the fields
+    # neither one had on its own.
+    "GET /plugins/variables/all": "/api/v1/variables",
+    "GET /templates/variables": "/api/v1/variables",
+    "GET /templates/formula-functions": "/api/v1/functions",
+    # Service state — same handler, same model.
+    "GET /status": "/api/v1/status",
+}
+
+
+def superseded_by_v1(operation: str) -> Callable:
+    """Deprecation notice for one of the :data:`SUPERSEDED_BY_V1` operations.
+
+    *operation* is the ``"<METHOD> <path>"`` key, repeated at the decorator so
+    a route and its entry in the table cannot drift apart unnoticed: a typo is
+    a ``KeyError`` at import, and a route removed from the table without its
+    decorator being removed fails the same way.
+
+    Args:
+        operation: ``"<METHOD> <path>"``, e.g. ``"GET /pages"``.
+
+    Returns:
+        A ``Depends(...)`` for the route's ``dependencies=`` list.
+    """
+    successor = SUPERSEDED_BY_V1[operation]
+    dependency = deprecation_notice(successor=successor, sunset=SUPERSEDED_BY_V1_SUNSET)
+    # Read back by tests/test_superseded_route_headers.py so the cohort can be
+    # identified on the live route table rather than trusted from this file.
+    dependency.dependency.superseded_operation = operation  # type: ignore[attr-defined]
+    return dependency

--- a/src/collections/routes.py
+++ b/src/collections/routes.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException
 
+from src.api_deprecation import superseded_by_v1
 from src.api_errors import errors
 from src.pages.service import get_page_service
 from src.templates.engine import get_template_engine
@@ -83,7 +84,11 @@ def _validate_collection_payload(
             )
 
 
-@router.get("/collections", response_model=CollectionListResponse)
+@router.get(
+    "/collections",
+    response_model=CollectionListResponse,
+    dependencies=[superseded_by_v1("GET /collections")],
+)
 async def list_collections():
     """List all collections."""
     collection_service = get_collection_service()
@@ -96,6 +101,7 @@ async def list_collections():
     response_model=CollectionResponse,
     status_code=201,
     responses=errors(400),
+    dependencies=[superseded_by_v1("POST /collections")],
 )
 async def create_collection(data: CollectionCreate):
     """Create a new collection."""
@@ -114,6 +120,7 @@ async def create_collection(data: CollectionCreate):
     "/collections/{collection_id}",
     response_model=CollectionResponse,
     responses=errors(404),
+    dependencies=[superseded_by_v1("GET /collections/{collection_id}")],
 )
 async def get_collection(collection_id: str):
     """Get a collection by ID."""
@@ -128,6 +135,7 @@ async def get_collection(collection_id: str):
     "/collections/{collection_id}",
     response_model=CollectionResponse,
     responses=errors(400, 404),
+    dependencies=[superseded_by_v1("PUT /collections/{collection_id}")],
 )
 async def update_collection(collection_id: str, data: CollectionUpdate):
     """Update an existing collection."""
@@ -149,6 +157,7 @@ async def update_collection(collection_id: str, data: CollectionUpdate):
     "/collections/{collection_id}",
     response_model=CollectionDeleteResponse,
     responses=errors(404),
+    dependencies=[superseded_by_v1("DELETE /collections/{collection_id}")],
 )
 async def delete_collection(collection_id: str):
     """Delete a collection."""

--- a/src/displays/routes.py
+++ b/src/displays/routes.py
@@ -19,6 +19,7 @@ import logging
 
 from fastapi import APIRouter, HTTPException, Response
 
+from src.api_deprecation import superseded_by_v1
 from src.api_errors import errors
 from src.board_guards import _board_is_paused
 from src.board_send_executor import run_board_send
@@ -64,7 +65,12 @@ async def list_displays():
     )
 
 
-@router.get("/displays/{display_type}", response_model=DisplayResponse, responses=errors(400, 503))
+@router.get(
+    "/displays/{display_type}",
+    response_model=DisplayResponse,
+    responses=errors(400, 503),
+    dependencies=[superseded_by_v1("GET /displays/{display_type}")],
+)
 async def get_display(display_type: str):
     """
     Get formatted output for a specific display type.

--- a/src/pages/routes.py
+++ b/src/pages/routes.py
@@ -26,6 +26,7 @@ import logging
 
 from fastapi import APIRouter, HTTPException, Query
 
+from src.api_deprecation import superseded_by_v1
 from src.api_errors import errors
 from src.board_guards import _board_dims, _board_is_paused, _require_board, _silence_active
 from src.collections.models import is_collection_id
@@ -97,7 +98,11 @@ def _reject_plugin_strategy_when_beta_off(strategy: str | None) -> None:
 
 # No 4xx of its own: an empty instance is an empty list, not an error. See the
 # declared_errors exception in tests/conventions_manifest.json.
-@router.get("/pages", response_model=PageListResponse)
+@router.get(
+    "/pages",
+    response_model=PageListResponse,
+    dependencies=[superseded_by_v1("GET /pages")],
+)
 async def list_pages():
     """List all saved pages."""
     page_service = get_page_service()
@@ -173,7 +178,13 @@ async def get_current_display():
     )
 
 
-@router.post("/pages", response_model=PageModel, status_code=201, responses=errors(400))
+@router.post(
+    "/pages",
+    response_model=PageModel,
+    status_code=201,
+    responses=errors(400),
+    dependencies=[superseded_by_v1("POST /pages")],
+)
 async def create_page(page_data: PageCreate):
     """
     Create a new page.
@@ -192,7 +203,12 @@ async def create_page(page_data: PageCreate):
         raise HTTPException(status_code=400, detail=str(e)) from e
 
 
-@router.get("/pages/{page_id}", response_model=PageModel, responses=errors(404))
+@router.get(
+    "/pages/{page_id}",
+    response_model=PageModel,
+    responses=errors(404),
+    dependencies=[superseded_by_v1("GET /pages/{page_id}")],
+)
 async def get_page(page_id: str):
     """Get a page by ID."""
     page_service = get_page_service()
@@ -208,6 +224,7 @@ async def get_page(page_id: str):
     "/pages/{page_id}",
     response_model=PageUpdateResponse,
     responses=errors(400, 404),
+    dependencies=[superseded_by_v1("PUT /pages/{page_id}")],
 )
 async def update_page(page_id: str, page_data: PageUpdate):
     """Update an existing page.
@@ -238,7 +255,12 @@ async def update_page(page_id: str, page_data: PageUpdate):
     return PageUpdateResponse(page=page, incompatible_references=incompatible)
 
 
-@router.delete("/pages/{page_id}", response_model=PageDeleteResponse, responses=errors(404))
+@router.delete(
+    "/pages/{page_id}",
+    response_model=PageDeleteResponse,
+    responses=errors(404),
+    dependencies=[superseded_by_v1("DELETE /pages/{page_id}")],
+)
 async def delete_page(page_id: str):
     """Delete a page.
 

--- a/src/plugins/routes.py
+++ b/src/plugins/routes.py
@@ -49,6 +49,7 @@ from typing import Any, TypeVar
 
 from fastapi import APIRouter, HTTPException, Request
 
+from src.api_deprecation import superseded_by_v1
 from src.api_errors import errors
 from src.config_manager import get_config_manager, unmask_sensitive_values
 from src.displays.service import reset_display_service
@@ -225,7 +226,11 @@ async def list_plugins() -> PluginListResponse:
     )
 
 
-@router.get("/plugins/variables/all", response_model=AllPluginVariablesResponse)
+@router.get(
+    "/plugins/variables/all",
+    response_model=AllPluginVariablesResponse,
+    dependencies=[superseded_by_v1("GET /plugins/variables/all")],
+)
 async def get_all_plugin_variables() -> AllPluginVariablesResponse:
     """Every template variable exposed by the plugin system, for the editor."""
     if not PLUGIN_SYSTEM_AVAILABLE:
@@ -313,6 +318,7 @@ async def get_plugin_updates() -> PluginUpdatesResponse:
     "/plugins/{plugin_id}",
     response_model=PluginDetail,
     responses=errors(404, 503),
+    dependencies=[superseded_by_v1("GET /plugins/{plugin_id}")],
 )
 async def get_plugin(plugin_id: str) -> PluginDetail:
     """Manifest, configuration and status for one plugin."""
@@ -391,6 +397,7 @@ async def get_plugin_manifest(plugin_id: str) -> PluginManifestResponse:
     "/plugins/{plugin_id}/config",
     response_model=PluginConfigUpdateResponse,
     responses=errors(400, 404, 503),
+    dependencies=[superseded_by_v1("PUT /plugins/{plugin_id}/config")],
 )
 @plugin_errors_to_http
 async def update_plugin_config(plugin_id: str, request: PluginConfigRequest) -> PluginConfigUpdateResponse:
@@ -410,6 +417,7 @@ async def update_plugin_config(plugin_id: str, request: PluginConfigRequest) -> 
     "/plugins/{plugin_id}/enable",
     response_model=PluginEnablementResponse,
     responses=errors(400, 404, 503),
+    dependencies=[superseded_by_v1("POST /plugins/{plugin_id}/enable")],
 )
 @plugin_errors_to_http
 async def enable_plugin(plugin_id: str) -> PluginEnablementResponse:
@@ -424,6 +432,7 @@ async def enable_plugin(plugin_id: str) -> PluginEnablementResponse:
     "/plugins/{plugin_id}/disable",
     response_model=PluginEnablementResponse,
     responses=errors(400, 404, 503),
+    dependencies=[superseded_by_v1("POST /plugins/{plugin_id}/disable")],
 )
 @plugin_errors_to_http
 async def disable_plugin(plugin_id: str) -> PluginEnablementResponse:
@@ -438,6 +447,7 @@ async def disable_plugin(plugin_id: str) -> PluginEnablementResponse:
     "/plugins/{plugin_id}/data",
     response_model=PluginDataResponse,
     responses=errors(400, 404, 503),
+    dependencies=[superseded_by_v1("GET /plugins/{plugin_id}/data")],
 )
 async def get_plugin_data(plugin_id: str) -> PluginDataResponse:
     """Fetch current data from a plugin.

--- a/src/schedules/routes.py
+++ b/src/schedules/routes.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException
 
+from src.api_deprecation import superseded_by_v1
 from src.api_errors import errors
 from src.board_guards import _require_board
 from src.collections.models import is_collection_id
@@ -138,7 +139,11 @@ def _with_compat_warnings(response: dict, schedule) -> dict:
     return response
 
 
-@router.get("/schedules", response_model=ScheduleListResponse)
+@router.get(
+    "/schedules",
+    response_model=ScheduleListResponse,
+    dependencies=[superseded_by_v1("GET /schedules")],
+)
 async def list_schedules(board_id: str | None = None):
     """List schedule entries, optionally for one board (query: board_id=).
 
@@ -171,6 +176,7 @@ async def list_schedules(board_id: str | None = None):
     response_model=ScheduleWriteResponse,
     status_code=201,
     responses=errors(400, 404),
+    dependencies=[superseded_by_v1("POST /schedules")],
 )
 async def create_schedule(schedule_data: ScheduleCreate):
     """Create a new schedule entry."""
@@ -302,6 +308,7 @@ async def set_schedule_enabled(request: ScheduleEnabledUpdate):
     "/schedules/{schedule_id}",
     response_model=ScheduleResponse,
     responses=errors(404),
+    dependencies=[superseded_by_v1("GET /schedules/{schedule_id}")],
 )
 async def get_schedule(schedule_id: str):
     """Get a schedule entry by ID."""
@@ -318,6 +325,7 @@ async def get_schedule(schedule_id: str):
     "/schedules/{schedule_id}",
     response_model=ScheduleWriteResponse,
     responses=errors(400, 404),
+    dependencies=[superseded_by_v1("PUT /schedules/{schedule_id}")],
 )
 async def update_schedule(schedule_id: str, schedule_data: ScheduleUpdate):
     """Update an existing schedule entry."""
@@ -339,6 +347,7 @@ async def update_schedule(schedule_id: str, schedule_data: ScheduleUpdate):
     "/schedules/{schedule_id}",
     response_model=ScheduleDeleteResponse,
     responses=errors(404),
+    dependencies=[superseded_by_v1("DELETE /schedules/{schedule_id}")],
 )
 async def delete_schedule(schedule_id: str):
     """Delete a schedule entry."""

--- a/src/service_api/routes.py
+++ b/src/service_api/routes.py
@@ -36,7 +36,7 @@ from fastapi import APIRouter, HTTPException
 
 from src import __version__
 from src import display_runtime as runtime
-from src.api_deprecation import V1_BOARD_MESSAGE_SUCCESSOR, deprecation_notice
+from src.api_deprecation import V1_BOARD_MESSAGE_SUCCESSOR, deprecation_notice, superseded_by_v1
 from src.api_errors import errors
 from src.board_guards import _require_board
 from src.board_send_executor import run_board_send
@@ -104,7 +104,12 @@ async def health_head():
 # ---------------------------------------------------------------------------
 
 
-@router.get("/status", response_model=StatusResponse, responses=errors(503))
+@router.get(
+    "/status",
+    response_model=StatusResponse,
+    responses=errors(503),
+    dependencies=[superseded_by_v1("GET /status")],
+)
 async def get_status():
     """Get current service status."""
     service = runtime.get_service()

--- a/src/templates/routes.py
+++ b/src/templates/routes.py
@@ -18,6 +18,7 @@ import logging
 
 from fastapi import APIRouter, HTTPException
 
+from src.api_deprecation import superseded_by_v1
 from src.api_errors import errors
 from src.board_client import board_client_from_board_dict
 from src.board_guards import _board_is_paused, _require_board
@@ -49,7 +50,11 @@ router = APIRouter(tags=["templates"])
 # registry, both of which always exist — an install with no plugins answers
 # empty catalogs. See the declared_errors exception in
 # tests/conventions_manifest.json.
-@router.get("/templates/variables", response_model=TemplateVariablesResponse)
+@router.get(
+    "/templates/variables",
+    response_model=TemplateVariablesResponse,
+    dependencies=[superseded_by_v1("GET /templates/variables")],
+)
 async def get_template_variables():
     """
     Get available template variables by source.
@@ -145,7 +150,11 @@ async def validate_template(request: TemplateValidateRequest):
 # No 4xx of its own: the function table is a module-level constant, so this
 # route cannot fail on anything the caller controls. See the declared_errors
 # exception in tests/conventions_manifest.json.
-@router.get("/templates/formula-functions", response_model=FormulaFunctionsResponse)
+@router.get(
+    "/templates/formula-functions",
+    response_model=FormulaFunctionsResponse,
+    dependencies=[superseded_by_v1("GET /templates/formula-functions")],
+)
 async def get_formula_functions():
     """
     Return metadata for every built-in formula function.

--- a/tests/test_superseded_route_headers.py
+++ b/tests/test_superseded_route_headers.py
@@ -1,0 +1,248 @@
+"""The 25 internal endpoints ``/v1`` supersedes announce their removal.
+
+#1934 moved every web-client call that ``/v1`` supersedes onto ``/v1``, which
+left 33 internal endpoints with no product caller. #1936 then closed five of
+the ten places where a v1 route dropped something its internal twin carried.
+Twenty-five of the 33 survive both a caller audit and an exactness audit; they
+are the cohort :data:`src.api_deprecation.SUPERSEDED_BY_V1` names, and #1941
+tracks their deletion.
+
+They are already ``include_in_schema=False`` (#1935), so the notice is
+deliberately invisible in the published document — the audience is a caller
+who is already calling them, and the only place such a caller looks is the
+response it is already reading. That makes an over-the-wire assertion the
+*only* assertion worth making here: a test that read the decorator would pass
+on a route whose headers never reach a response.
+
+The eight excluded endpoints are as load-bearing as the twenty-five included
+ones, so :func:`test_the_eight_endpoints_v1_does_not_fully_replace_send_no_notice`
+pins them by name. A future change that "completes the set" has to delete that
+test, which is where the reviewer will ask why.
+"""
+
+from __future__ import annotations
+
+from email.utils import parsedate_to_datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api_deprecation import SUPERSEDED_BY_V1, SUPERSEDED_BY_V1_SUNSET
+from src.api_server import DEPRECATED_ROUTES_SUNSET, app
+from src.v1.visibility import iter_api_routes
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """A client without the app lifespan.
+
+    None of these routes need anything the lifespan starts, and starting it
+    costs ~11 seconds of service/registry/mDNS boot per test.
+    """
+    return TestClient(app)
+
+
+def _wired_notices() -> dict[str, tuple[str | None, str | None]]:
+    """``"<METHOD> <path>"`` -> ``(successor_uri, sunset)`` for the live app.
+
+    Read off the route table rather than off the table in
+    ``src/api_deprecation.py``, so the two can be compared against each other.
+    """
+    found: dict[str, tuple[str | None, str | None]] = {}
+    for path, route in iter_api_routes(app.routes):
+        for dependency in route.dependencies or []:
+            if getattr(dependency.dependency, "superseded_operation", None) is None:
+                continue
+            for method in sorted(set(route.methods or ()) - {"HEAD", "OPTIONS"}):
+                found[f"{method} {path}"] = (
+                    dependency.dependency.successor_uri,
+                    dependency.dependency.sunset,
+                )
+    return found
+
+
+def test_every_operation_in_the_table_carries_the_notice():
+    """The table is the cohort; a route that drops out must drop out of both."""
+    assert sorted(_wired_notices()) == sorted(SUPERSEDED_BY_V1)
+
+
+def test_no_route_carries_a_notice_the_table_does_not_name():
+    """A decorator added without a table entry is an unreviewed deprecation."""
+    for operation, (successor, sunset) in sorted(_wired_notices().items()):
+        assert successor == SUPERSEDED_BY_V1[operation]
+        assert sunset == SUPERSEDED_BY_V1_SUNSET
+
+
+def test_no_v1_route_announces_its_own_removal():
+    """The successors must never carry the notice — that would be circular."""
+    assert not [operation for operation in _wired_notices() if " /v1" in operation]
+
+
+@pytest.mark.parametrize("operation,successor", sorted(SUPERSEDED_BY_V1.items()))
+def test_each_successor_is_an_operation_this_app_actually_serves(operation, successor):
+    """A ``successor-version`` link to a path that does not exist is worse than none.
+
+    ``/api`` is stripped by nginx, so the served path is the link minus that
+    prefix.
+    """
+    served = {path for path, _ in iter_api_routes(app.routes)}
+    assert successor.startswith("/api/v1/"), operation
+    assert successor.removeprefix("/api") in served, f"{operation} -> {successor}"
+
+
+def test_the_sunset_is_a_valid_http_date():
+    """``Sunset`` is an HTTP-date (RFC 8594 §3); a free-form string is unusable."""
+    parsed = parsedate_to_datetime(SUPERSEDED_BY_V1_SUNSET)
+    assert parsed.tzinfo is not None
+    assert (parsed.year, parsed.month, parsed.day) == (2026, 12, 1)
+
+
+def test_the_cohort_shares_the_clock_the_plugin_routes_already_started():
+    """One appliance, one removal date.
+
+    A second date a few weeks from the first would mean an integrator has to
+    track two countdowns to learn when their script stops working.
+    """
+    assert SUPERSEDED_BY_V1_SUNSET == DEPRECATED_ROUTES_SUNSET
+
+
+# ---------------------------------------------------------------------------
+# Over the wire
+# ---------------------------------------------------------------------------
+
+#: ``(method, path, status, body)`` for the reads that answer deterministically
+#: on an empty install. The bodies are what unmodified ``next`` answers,
+#: captured before the dependencies were added and pinned verbatim: this is the
+#: "behaviour must not change" half of the contract, and it is worthless unless
+#: the expected value came from the tree without the change in it.
+UNCHANGED_READS = [
+    ("GET", "/pages", 200, {"pages": [], "total": 0}),
+    ("GET", "/collections", 200, {"collections": [], "total": 0}),
+    (
+        "GET",
+        "/schedules",
+        200,
+        {"schedules": [], "total": 0, "default_page_id": None, "enabled": False},
+    ),
+    (
+        "GET",
+        "/plugins/variables/all",
+        200,
+        {"variables": {}, "max_lengths": {}, "plugin_system_enabled": True},
+    ),
+]
+
+
+@pytest.mark.parametrize("method,path,status,body", UNCHANGED_READS)
+def test_a_superseded_route_answers_exactly_as_before_and_says_so(client, method, path, status, body):
+    """Same status, same body, plus three headers. Nothing else changed."""
+    response = client.request(method, path)
+
+    assert response.status_code == status, response.text
+    assert response.json() == body
+
+    assert response.headers["Deprecation"] == "true"
+    assert response.headers["Sunset"] == SUPERSEDED_BY_V1_SUNSET
+    assert response.headers["Link"] == f'<{SUPERSEDED_BY_V1[f"{method} {path}"]}>; rel="successor-version"'
+
+
+def _create_page(client: TestClient) -> str:
+    """A saved page, so the collection write below has a member to point at."""
+    created = client.post(
+        "/pages",
+        json={"name": "notice", "type": "template", "template": ["HELLO"]},
+    )
+    assert created.status_code == 201, created.text
+    return created.json()["id"]
+
+
+def test_the_notice_reaches_a_write_and_leaves_its_body_alone(client):
+    """A ``Depends`` on a POST/DELETE is a different code path from a GET.
+
+    ``POST /pages`` also answers 201 rather than 200, which is the case where
+    a header stamped on the injected ``Response`` is easiest to lose.
+    """
+    page_id = _create_page(client)
+
+    created = client.post("/collections", json={"name": "notice", "page_ids": [page_id]})
+    assert created.status_code == 201, created.text
+    assert created.json()["name"] == "notice"
+    assert created.json()["page_ids"] == [page_id]
+    assert created.headers["Deprecation"] == "true"
+    assert created.headers["Sunset"] == SUPERSEDED_BY_V1_SUNSET
+    assert created.headers["Link"] == '</api/v1/collections>; rel="successor-version"'
+
+    collection_id = created.json()["id"]
+    deleted = client.delete(f"/collections/{collection_id}")
+    assert deleted.status_code == 200, deleted.text
+    assert deleted.headers["Deprecation"] == "true"
+    assert deleted.headers["Link"] == '</api/v1/collections/{collection_id}>; rel="successor-version"'
+
+
+def test_a_successor_link_is_readable_as_a_uri_template(client):
+    """RFC 6570 templating is deliberate on a parameterised successor.
+
+    The replacement for a route with a path parameter is itself parameterised,
+    and a ``Link`` naming a resource cannot fill the parameter in for the
+    caller — so the template is what gets sent, unsubstituted.
+    """
+    page_id = _create_page(client)
+
+    response = client.get(f"/pages/{page_id}")
+    assert response.status_code == 200, response.text
+    assert response.json()["id"] == page_id
+    assert response.headers["Link"] == '</api/v1/pages/{page_id}>; rel="successor-version"'
+
+
+def test_a_refusal_carries_no_notice__inherited_limitation(client):
+    """Pinning what this mechanism does *not* do, so it is not mistaken for a bug.
+
+    ``deprecation_notice`` stamps the ``Response`` FastAPI injects into the
+    handler, and FastAPI merges that object's headers only into a response it
+    builds from a returned value. An ``HTTPException`` is answered by the
+    exception handler from a fresh response, so the notice is dropped.
+
+    The eleven plugin-specific routes (#1932) behave identically; this is the
+    shared mechanism's behaviour, not this cohort's. It costs little — a
+    caller that gets a 404 is being told something more urgent than "this is
+    going away" — but a caller who only ever sees errors never sees the
+    notice, which is recorded on #1941 as the one thing this PR leaves open.
+    """
+    response = client.get("/pages/no-such-page")
+    assert response.status_code == 404
+    assert "Deprecation" not in response.headers
+
+
+#: The eight of #1934's thirty-three that are **not** deprecated, and the fact
+#: each one's v1 equivalent still drops. Deprecating one of these would tell a
+#: caller to follow a link that loses data.
+NOT_SUPERSEDED = {
+    "POST /pages/{page_id}/send": "drops paused/target; a paused board is a 409 on v1, not a 200",
+    "POST /displays/{display_type}/send": "no v1 write form accepts a plugin id at all",
+    "GET /schedules/enabled": "answers for the install with no board named; v1 has no board-less form",
+    "PUT /schedules/enabled": "same, and 404s where this falls back to the global mirror",
+    "GET /schedules/default-page": "answers for the install with no board named",
+    "PUT /schedules/default-page": "same, and 404s on an install with no boards",
+    "GET /displays": "drops source; 503s where this answers 200 with an empty list",
+    "POST /settings/board/{board_id}/pause": "drops the embedded board_settings block",
+}
+
+
+@pytest.mark.parametrize("operation", sorted(NOT_SUPERSEDED))
+def test_the_eight_endpoints_v1_does_not_fully_replace_send_no_notice(operation):
+    """Excluded on purpose, and the exclusions are the reviewable half."""
+    assert operation not in SUPERSEDED_BY_V1, NOT_SUPERSEDED[operation]
+    assert operation not in _wired_notices()
+
+
+def test_a_route_kept_on_the_internal_surface_sends_nothing(client):
+    """``GET /displays`` is in #1934's thirty-three and deliberately not here.
+
+    It is the control for the whole change: if the notice had been applied by
+    sweeping a path prefix rather than by an audited list, this route would
+    carry it.
+    """
+    response = client.get("/displays")
+    assert response.status_code == 200, response.text
+    assert "Deprecation" not in response.headers
+    assert "Sunset" not in response.headers

--- a/web/tests/api.spec.ts
+++ b/web/tests/api.spec.ts
@@ -342,3 +342,88 @@ test.describe("API – Debug", () => {
     expect(typeof data.message).toBe("string");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Deprecation notices on the internal surface
+// ---------------------------------------------------------------------------
+
+// These specs are, deliberately, the internal surface's contract tests — the
+// web client itself moved onto /v1 wherever /v1 supersedes (#1934). A test
+// caller does not save an endpoint from deprecation, but it does have to know
+// what the endpoint now says: 25 of these paths carry RFC 9745 `Deprecation`,
+// RFC 8594 `Sunset` and an RFC 8288 `successor-version` link on every
+// successful response (#1941).
+//
+// This is the only layer that proves the headers survive nginx. The Python
+// suite exercises the ASGI app directly; nginx is what a real caller talks to,
+// and a proxy that dropped these would make the whole notice invisible.
+
+const SUNSET = "Tue, 01 Dec 2026 00:00:00 GMT";
+
+/** The v1 operation each of these announces as its replacement. */
+const SUPERSEDED: Array<[string, string]> = [
+  ["/pages", "/api/v1/pages"],
+  ["/collections", "/api/v1/collections"],
+  ["/schedules", "/api/v1/schedules"],
+  ["/status", "/api/v1/status"],
+  ["/templates/variables", "/api/v1/variables"],
+  ["/templates/formula-functions", "/api/v1/functions"],
+  ["/plugins/variables/all", "/api/v1/variables"],
+];
+
+/**
+ * Endpoints in #1934's inventory of 33 that are deliberately NOT deprecated,
+ * because their v1 equivalent still drops something. Asserting the absence is
+ * what stops the cohort growing by a sweep instead of by an audit.
+ */
+const NOT_SUPERSEDED = ["/displays", "/schedules/enabled", "/schedules/default-page"];
+
+test.describe("API – Deprecation notices", () => {
+  for (const [path, successor] of SUPERSEDED) {
+    test(`GET ${path} announces ${successor} on the wire`, async () => {
+      const res = await fetch(`${API()}${path}`);
+      expect(res.ok).toBe(true);
+      expect(res.headers.get("deprecation")).toBe("true");
+      expect(res.headers.get("sunset")).toBe(SUNSET);
+      expect(res.headers.get("link")).toBe(`<${successor}>; rel="successor-version"`);
+    });
+  }
+
+  for (const path of NOT_SUPERSEDED) {
+    test(`GET ${path} sends no deprecation notice`, async () => {
+      const res = await fetch(`${API()}${path}`);
+      expect(res.ok).toBe(true);
+      expect(res.headers.get("deprecation")).toBeNull();
+      expect(res.headers.get("sunset")).toBeNull();
+    });
+  }
+
+  test("the /v1 successors do not announce their own removal", async () => {
+    for (const successor of ["/api/v1/pages", "/api/v1/collections", "/api/v1/status"]) {
+      // API() already ends in /api, so strip the duplicate prefix.
+      const res = await fetch(`${API()}${successor.replace(/^\/api/, "")}`);
+      expect(res.ok).toBe(true);
+      expect(res.headers.get("deprecation")).toBeNull();
+    }
+  });
+
+  test("a deprecated write announces its successor too", async () => {
+    const created = await fetch(`${API()}/pages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: `Deprecation Notice ${Date.now()}`,
+        type: "template",
+        template: ["HELLO"],
+      }),
+    });
+    expect(created.status).toBe(201);
+    expect(created.headers.get("deprecation")).toBe("true");
+    expect(created.headers.get("link")).toBe('</api/v1/pages>; rel="successor-version"');
+
+    const { id } = await created.json();
+    const deleted = await fetch(`${API()}/pages/${id}`, { method: "DELETE" });
+    expect(deleted.ok).toBe(true);
+    expect(deleted.headers.get("link")).toBe('</api/v1/pages/{page_id}>; rel="successor-version"');
+  });
+});


### PR DESCRIPTION
Starts the retirement clock on the internal endpoints `/v1` has superseded and
nothing in the product calls any more. **Mark and schedule — nothing is
deleted.** Deletion is tracked in **#1941** and happens at a named release, by
someone who can see the sunset date has passed.

## The set: 25, not 33

#1934 reported 33 internal endpoints no longer called by `web/src/lib/api/`. I
verified rather than trusted it, then subtracted on two grounds.

**Caller audit — subtracted nothing.** `src/mcp_server.py` imports only
`src.ops`; `src/ops/executors.py` reaches its domains through *services*, and
the only route handlers it calls are `src.settings.routes.set_active_page` and
`src.system.routes.system_update_apply` — neither in the 33.
`src/mqtt/commands.py` is services and `src.api_server` seams only. No bundled
plugin makes an HTTP call to the app. `web/tests/**` calls many of them, but a
test caller is not a product caller.

Two repo scripts do call these paths — `scripts/seed_screenshot_data.py` and
`scripts/create_test_schedule.py`. Neither is shipped and neither saves an
endpoint, but both break silently at deletion, so they are step 5 of #1941's
removal plan.

**Exactness audit — subtracted eight.** #1936 closed five of the ten v1 gaps
the web migration found; five are still open, and one of those (gap 10) lands
squarely on a route in the 33. Auditing the other 32 against the v1 successors
found three more of the same kind. The rule I applied:

> A route is superseded only when the successor answers **every fact** the
> legacy response carries, accepts **every input** the legacy route accepts,
> and refuses **nothing** the legacy route answered.

A `successor-version` link is a promise that following it loses nothing. A
link to a route that drops a field is worse than no link, because the caller
who follows it loses data without being told.

### Deprecated — 25

| # | Deprecated | Successor | Why it is exact |
|---|---|---|---|
| 1–5 | `GET`/`POST /pages`, `GET`/`PUT`/`DELETE /pages/{page_id}` | the matching `/api/v1/pages` operation | `src/v1/routes_content.py` calls these very handlers; identical response models and status codes |
| 6–10 | `GET`/`POST /schedules`, `GET`/`PUT`/`DELETE /schedules/{schedule_id}` | the matching `/api/v1/schedules` operation | same handlers, incl. sun-time enrichment and #1245 `warnings` |
| 11–15 | `GET`/`POST /collections`, `GET`/`PUT`/`DELETE /collections/{collection_id}` | the matching `/api/v1/collections` operation | same handlers |
| 16 | `GET /plugins/{plugin_id}` | `GET /api/v1/plugins/{plugin_id}` | same handler, same `PluginDetail`, same `***` masking |
| 17 | `PUT /plugins/{plugin_id}/config` | `PATCH /api/v1/plugins/{plugin_id}` | v1 dispatches to `update_plugin_config` then `get_plugin`; `PluginDetail` ⊇ `{plugin_id, config}` with the same masked value |
| 18–19 | `POST /plugins/{plugin_id}/enable` / `disable` | `PATCH /api/v1/plugins/{plugin_id}` | same handlers; `PluginDetail` ⊇ `{plugin_id, enabled}` |
| 20 | `GET /plugins/{plugin_id}/data` | `GET /api/v1/plugins/{plugin_id}/data` | `formatted_lines` → `lines`, plus `text`; #1936 made v1 *refuse less* (200 + `available: false` where this raises 400/503), so nothing is lost |
| 21 | `GET /displays/{display_type}` | `GET /api/v1/plugins/{plugin_id}/data` | v1's handler falls back to `DisplayService.get_display().formatted` for exactly this case, so `lines` and `text` are the same strings; `line_count` is `len(lines)` |
| 22 | `GET /plugins/variables/all` | `GET /api/v1/variables` | provable superset — see below |
| 23 | `GET /templates/variables` | `GET /api/v1/variables` | provable superset — see below |
| 24 | `GET /templates/formula-functions` | `GET /api/v1/functions` | same handler, same `FormulaFunctionsResponse` |
| 25 | `GET /status` | `GET /api/v1/status` | same `service_routes.get_status()`, same `StatusResponse` |

**The `/v1/variables` merge, checked rather than assumed.**
`TemplateEngine.get_available_variables()` and `get_variable_max_lengths()`
are one-line forwarders to `PluginRegistry.get_all_variables()` /
`get_all_max_lengths()` (`src/templates/engine.py:1430-1432`, `1624-1626`) —
the same calls `GET /plugins/variables/all` makes. `VariableCatalog`'s
`setdefault` merge therefore cannot drop a key from either source, and it adds
`plugin_system_enabled` to the templates view and seven fields to the plugins
view.

### Excluded — 8, and this is the more useful list

| Not deprecated | What its v1 equivalent still drops |
|---|---|
| `POST /pages/{page_id}/send` | `paused` and `target`. A paused board answers **200 with `paused: true`** here and **409** on `POST /v1/boards/{b}/message` — a refusal where the legacy route reported |
| `POST /displays/{display_type}/send` | **no v1 write form accepts a plugin id at all.** `MessageRequest` takes `text`/`lines`/`characters`/`page_id`/`fill`. Replacing this means two calls, not one. Also drops `paused`/`target` |
| `GET /schedules/enabled` | `board_id` is an *optional* query param — with none it answers for the install. `GET /v1/boards/{board}` has no board-less form, and 404s an unknown board where this read falls back (`API_CONVENTIONS.md`, "reads fall back") |
| `PUT /schedules/enabled` | same, plus #1934's still-open **gap 10**: `PATCH /v1/boards/{b}` 404s on an install with no boards, where this writes the global `schedule.enabled` mirror |
| `GET /schedules/default-page` | same board-less/fallback difference |
| `PUT /schedules/default-page` | same |
| `GET /displays` | `source` (constant `"plugin"`, whose own field description says "kept for older clients"); and `GET /v1/plugins` calls `_require_plugin_system()` → 503 where this answers 200 with `[]` |
| `POST /settings/board/{board_id}/pause` | the embedded `board_settings` block. `BoardDetail` deliberately carries no credentials, `tiles`, `board_color`, `code62_glyph`, `notes_wide/tall`, `api_mode`, `host` or `port` |

25 + 8 = 33, so every row of #1934's inventory is accounted for.

## The date: `Tue, 01 Dec 2026 00:00:00 GMT`

Matched to #1932's date rather than invented. The reasoning holds unchanged —
FiestaBoard cuts a minor release every few days (v8.30.0 → v8.34.0 spans twelve
days), so "two releases" is about a week, which is not a window an outside
integrator can plan against.

The additional reason for matching rather than picking a new date: **one
appliance, one countdown.** A second date a few weeks after the first would
mean an integrator has to track two to learn when their script stops working.
`test_the_cohort_shares_the_clock_the_plugin_routes_already_started` pins the
two constants equal.

## How

Reuses `deprecation_notice()` from `src/api_deprecation.py` — the mechanism
#1932 built and #1935 lifted out — as its third user. No second mechanism.

The cohort is a table, `SUPERSEDED_BY_V1`, spelled once next to the machinery,
and each route names its own key at the decorator
(`dependencies=[superseded_by_v1("GET /pages")]`). A typo is a `KeyError` at
import; a route dropped from the table without its decorator fails the same
way. A post-hoc sweep like `src/v1/visibility.py` is not available here —
FastAPI builds a route's `dependant` at construction, so mutating
`route.dependencies` afterwards stamps nothing.

**Not** flagged `deprecated=True` in the OpenAPI document. All 25 are already
`include_in_schema=False` (#1935), so the flag would show only in
`/api/internal/openapi.json`, and the brief is "headers and nothing else". The
published document is byte-identical: still 33 operations, still exactly
`POST /send-message` and `POST /refresh` outside `/v1`, still exactly two
`deprecated` flags — measured against a running container, below.

## Behaviour did not change

`tests/golden/api_routes.json` is **byte-identical** (`git diff` empty). It
records `path`/`methods`/`name`/`kind` and nothing about headers, so there was
nothing for it to record.

The four response-shape goldens (`tests/golden/responses/*.json`) are also
byte-identical — they snapshot status codes and full key sets for every
pages / schedules / collections / plugins route, which covers 20 of the 25.

Before writing the tests I captured eight of these responses from **unmodified
`next`** and diffed them against the same eight on this branch:

| Operation | status | body identical |
|---|---|---|
| `GET /pages` | 200 → 200 | yes |
| `GET /collections` | 200 → 200 | yes |
| `GET /schedules` | 200 → 200 | yes |
| `GET /plugins/variables/all` | 200 → 200 | yes |
| `GET /templates/variables` | 200 → 200 | yes |
| `GET /templates/formula-functions` | 200 → 200 | yes |
| `GET /displays` (control, excluded) | 200 → 200 | yes |
| `GET /status` | 200 → 200 | one field: a freshly generated board UUID |

The four small deterministic bodies from that capture are pinned verbatim in
`test_a_superseded_route_answers_exactly_as_before_and_says_so`, which asserts
the body **and** the three headers in the same test — the expected values came
from the tree without the change in it, which is the only thing that makes the
assertion worth anything.

## Headers verified over the wire, not by reading the decorator

`docker build --target runtime`, one container, requests through **nginx**:

```
/api/pages                        deprecation: true  sunset: Tue, 01 Dec 2026 00:00:00 GMT  link: </api/v1/pages>; rel="successor-version"
/api/collections                  deprecation: true  sunset: Tue, 01 Dec 2026 00:00:00 GMT  link: </api/v1/collections>; rel="successor-version"
/api/schedules                    deprecation: true  sunset: Tue, 01 Dec 2026 00:00:00 GMT  link: </api/v1/schedules>; rel="successor-version"
/api/status                       deprecation: true  sunset: Tue, 01 Dec 2026 00:00:00 GMT  link: </api/v1/status>; rel="successor-version"
/api/templates/variables          deprecation: true  sunset: Tue, 01 Dec 2026 00:00:00 GMT  link: </api/v1/variables>; rel="successor-version"
/api/templates/formula-functions  deprecation: true  sunset: Tue, 01 Dec 2026 00:00:00 GMT  link: </api/v1/functions>; rel="successor-version"
/api/plugins/variables/all        deprecation: true  sunset: Tue, 01 Dec 2026 00:00:00 GMT  link: </api/v1/variables>; rel="successor-version"
/api/displays                     (nothing — deliberately excluded)
/api/v1/pages                     (nothing — a successor must not announce its own removal)

POST   /api/pages          201  link: </api/v1/pages>; rel="successor-version"
GET    /api/pages/{id}     200  link: </api/v1/pages/{page_id}>; rel="successor-version"
DELETE /api/pages/{id}     200  link: </api/v1/pages/{page_id}>; rel="successor-version"

published ops: 33
non-v1 visible: ['POST /refresh', 'POST /send-message']
deprecated flags: ['post /refresh', 'post /send-message']
```

The parameterised links stay URI Templates (RFC 6570) unsubstituted: a `Link`
relation names a resource, and the mechanism has no per-request value to fill
in. Same choice #1932 made for `options_id`.

`web/tests/api.spec.ts` gains a `describe` block asserting exactly this,
because the Python suite drives the ASGI app directly and **nginx** is what a
real caller talks to. It also asserts the absence of the notice on
`/displays`, `/schedules/enabled` and `/schedules/default-page` — if the cohort
had been applied by sweeping a path prefix instead of from an audited list,
those three would carry it.

## Non-vacuity — three deliberate breakages, verbatim

**1. Remove one route's dependency** (`GET /pages`):

```
tests/test_superseded_route_headers.py:66: in test_every_operation_in_the_table_carries_the_notice
    assert sorted(_wired_notices()) == sorted(SUPERSEDED_BY_V1)
E   AssertionError: assert ['DELETE /col...y_type}', ...] == ['DELETE /col...y_type}', ...]
E     At index 6 diff: 'GET /pages/{page_id}' != 'GET /pages'

tests/test_superseded_route_headers.py:144: in test_a_superseded_route_answers_exactly_as_before_and_says_so
    assert response.headers["Deprecation"] == "true"
E   KeyError: 'Deprecation'

FAILED ...::test_every_operation_in_the_table_carries_the_notice
FAILED ...::test_a_superseded_route_answers_exactly_as_before_and_says_so[GET-/pages-200-body0]
2 failed, 44 passed
```

**2. Point `GET /status` at a successor that does not exist:**

```
tests/test_superseded_route_headers.py:90: in test_each_successor_is_an_operation_this_app_actually_serves
E   AssertionError: GET /status -> /api/v1/service-status
E   assert '/v1/service-status' in {'/', '/ai/operations', '/auth/change-password', ...}
FAILED ...::test_each_successor_is_an_operation_this_app_actually_serves[GET /status-/api/v1/service-status]
```

**3. The excluded eight** are pinned by name in `NOT_SUPERSEDED` with the fact
each one's v1 equivalent drops. "Completing the set" means deleting that test,
which is where a reviewer gets to ask why.

## Verification

| | `origin/next` @ `de82d4935` | this branch |
|---|---|---|
| pytest | 6942 passed, 2 failed, 2 skipped | **6989 passed**, 1 failed, 2 skipped |
| collected nodes | 6946 | **6992** |
| nodes removed | — | **0** (`comm -23` of the sorted lists is empty) |
| nodes added | — | **46** — all in `tests/test_superseded_route_headers.py` |
| data-dir leak | 0 files | **0 files** |
| `tests/golden/api_routes.json` | — | **byte-identical** |
| `tests/golden/responses/*.json` | — | **byte-identical** |

Strict superset. `6989 − 6942 = 47` = the 46 new nodes plus
`test_display_loop_timing.py::TestScheduleBoundary::test_the_new_page_reaches_the_board_within_one_polling_interval`,
a timing flake that failed on the baseline run and passed here — it is not
touched by this change.

The remaining failure on both sides is
`test_check_image_formats.py::TestRepositoryIsClean::test_no_tracked_file_in_this_repo_reaches_a_vulnerable_parser`,
which shells out to `git ls-files` inside the container; a worktree's `.git` is
a file pointing outside the mount. Identical on unmodified `next`.

```
ruff==0.16.5 check  src plugins tests scripts   All checks passed!
ruff==0.16.5 format src plugins tests scripts   480 files already formatted
npm run docs:lint                               frontmatter ✓  contract ✓  markdownlint 0 issues  cspell 0 issues
prettier --check web/tests/api.spec.ts          clean
scripts/generate_api_reference.py --check       docs/reference/api-endpoints.md is up to date
```

## Left open

**The notice is dropped on refusals.** `deprecation_notice` stamps the
`Response` FastAPI injects into the handler, and FastAPI merges that object's
headers only into a response built from a *returned value*. A route that
raises `HTTPException` is answered from a fresh response, so a caller who only
ever sees 4xx never sees the notice. The eleven routes on #1915 behave
identically — this is the shared mechanism, not this cohort — so rather than
fix it silently here it is pinned by
`test_a_refusal_carries_no_notice__inherited_limitation` and recorded on #1941.

**`GET /displays/{display_type}/raw` still hand-rolls its own headers.** It is
tracked separately (#1911), is not in #1934's 33, and its link is
`</plugins/{id}/data>` — missing the `/api` prefix every other successor link
carries. Out of scope here; noted on #1941 to fold into the one mechanism when
#1911 is picked up.

**Two v1 gaps would close two of the eight exclusions**, if anyone wants the
full 33: a plugin-data content form (and a non-409 "not sent because paused")
on `POST /v1/boards/{board}/message`, and an install-scoped form of
`schedule_enabled` / `default_page_id`. Both written up on #1941.

Closes nothing. Tracked by #1941.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mYPdfxvAKCmztHasToHzH
