### PR TITLE
fix: triage sweep — MQTT send limit & external-write detection, schedule/SSRF validation, test isolation, fetch-pool breaker

### DIFF
--- a/docs/features/home-assistant-control.md
+++ b/docs/features/home-assistant-control.md
@@ -99,7 +99,7 @@ Once connected, FiestaBoard appears as a device with **24 entities** — control
 | **Display Service** | Switch | Start/stop the FiestaBoard display service |
 | **Active Page** | Select | Choose which page to display (dynamically populated from your pages). Selecting a page always re-sends it, even if it is already the active page — that is how you put the page back after a manual message. The list also carries a `None` option so "no page is active" is a state HA can show; as a *command* it only applies to secondary boards, since the primary board never goes dark. |
 | **Transition Style** | Select | Board transition animation (column, reverse-column, edges-to-center, row, diagonal, random) |
-| **Send Message** | Text | Send a text message to the board (up to 132 characters) |
+| **Send Message** | Text | Send a text message to the board (up to 255 characters — Home Assistant's text-entity ceiling; markup like `{red}` counts as characters here but as one flap on the board) |
 | **Refresh Display** | Button | Force a display refresh. This is a *force* refresh: unchanged content is re-sent, so it restores the active page after something else wrote to the board. |
 | **Blank Board** | Button | Clear the board display (all blank) |
 | **Next Page** | Button | Navigate to the next page in the page list (wraps around) |

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -7418,6 +7418,16 @@ def _find_board(board_id: str) -> dict | None:
     return None
 
 
+def _require_board(board_id: str | None) -> None:
+    """Raise 404 when board_id names a board that is not configured (issue #1888).
+
+    ``None`` (no board targeted) and ``""`` (the legacy default-board sentinel,
+    see ``src.schedules.models.DEFAULT_BOARD_ID``) pass through untouched.
+    """
+    if board_id and _find_board(board_id) is None:
+        raise HTTPException(status_code=404, detail=f"Board not found: {board_id}")
+
+
 def _board_dims(board: dict):
     """Resolved dimensions for a settings.boards entry (flagship fallback).
 
@@ -8735,6 +8745,7 @@ async def create_schedule(schedule_data: ScheduleCreate):
     Returns:
         Created schedule entry
     """
+    _require_board(schedule_data.board_id)
     schedule_service = get_schedule_service()
 
     try:
@@ -8813,6 +8824,7 @@ async def set_default_page(request: dict):
         raise HTTPException(status_code=400, detail="page_id parameter required")
     page_id = request["page_id"]
     board_id = request.get("board_id")
+    _require_board(board_id)
     if page_id is not None:
         if is_collection_id(page_id):
             collection_service = get_collection_service()
@@ -8843,6 +8855,7 @@ async def set_schedule_enabled(request: dict):
     if not isinstance(enabled, bool):
         raise HTTPException(status_code=400, detail="enabled must be boolean")
     board_id = request.get("board_id")
+    _require_board(board_id)
     settings_service = get_settings_service()
     settings_service.set_schedule_enabled(enabled, board_id=board_id)
     return {
@@ -8905,6 +8918,7 @@ async def update_schedule(schedule_id: str, schedule_data: ScheduleUpdate):
     Returns:
         Updated schedule entry
     """
+    _require_board(schedule_data.board_id)
     schedule_service = get_schedule_service()
 
     try:

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -4062,14 +4062,10 @@ async def test_board_connection(request: BoardTestRequest):
         api_key = request.local_api_key
         use_cloud = False
         host = request.host
-        try:
-            _validate_board_host(host)
-        except HTTPException as _exc:
-            return {
-                "success": False,
-                "message": "Invalid board host",
-                "error": _exc.detail,
-            }
+        # SSRF guard: raises HTTPException(400) for invalid hosts. Let it
+        # propagate — downgrading it to a 200 body hides the rejection from
+        # status-code-based clients (issue #1887).
+        _validate_board_host(host)
 
     try:
         # Create temporary client with provided credentials
@@ -4285,16 +4281,11 @@ async def enable_local_api(request: EnablementTokenRequest):
         }
 
     # Validate the host before composing the URL so an attacker can't
-    # redirect this request away from the local board (SSRF).
-    try:
-        _validate_board_host(request.host)
-        _validate_board_host_is_local_network(request.host)
-    except HTTPException as exc:
-        return {
-            "success": False,
-            "message": "Invalid board host",
-            "error": exc.detail,
-        }
+    # redirect this request away from the local board (SSRF). These raise
+    # HTTPException(400) — let it propagate rather than downgrading the
+    # rejection to a 200 body (issue #1887).
+    _validate_board_host(request.host)
+    _validate_board_host_is_local_network(request.host)
 
     # Resolve the host to a concrete IPv4 address and ensure it is a private/
     # loopback/link-local address.  Using the ``ipaddress`` module's

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -54,6 +54,7 @@ from .pages.service import (  # noqa: E402
 from .pages.share import decode_page, encode_page  # noqa: E402
 from .panels.models import PanelCreate, PanelUpdate  # noqa: E402
 from .panels.service import get_panel_service  # noqa: E402
+from .paths import get_data_dir  # noqa: E402
 from .schedules.models import ScheduleCreate, ScheduleUpdate  # noqa: E402
 from .schedules.service import get_schedule_service  # noqa: E402
 from .settings.service import VALID_OUTPUT_TARGETS, VALID_STRATEGIES, get_settings_service  # noqa: E402
@@ -1949,7 +1950,20 @@ def _is_newer_version(latest: str, current: str) -> bool:
 # Path to the small JSON file that persists the auto-update toggle and
 # bookkeeping (last check, last update).  Kept separate from settings.json
 # because this state is system-level, not display-level.
-SYSTEM_UPDATE_STATE_FILE = Path("data/.system-update.json")
+#
+# ``SYSTEM_UPDATE_STATE_FILE`` is a *test seam*: production leaves it ``None``
+# and ``_system_update_state_file()`` resolves lazily through
+# ``src.paths.get_data_dir()`` (honoring ``FIESTABOARD_DATA_DIR``, #1762).
+# Tests that need a specific file keep monkeypatching the module attribute.
+SYSTEM_UPDATE_STATE_FILE: Path | None = None
+
+
+def _system_update_state_file() -> Path:
+    """Resolve the system-update state file path at call time."""
+    if SYSTEM_UPDATE_STATE_FILE is not None:
+        return Path(SYSTEM_UPDATE_STATE_FILE)
+    return get_data_dir() / ".system-update.json"
+
 
 # Serialises the read-modify-write of the state file.  Three writers share it —
 # the hourly auto-update loop, ``POST /system/update`` and
@@ -1962,14 +1976,15 @@ _SYSTEM_UPDATE_STATE_LOCK = threading.RLock()
 def _system_update_state_load() -> dict[str, Any]:
     """Read the system-update state file.  Returns a fresh dict on any error."""
     with _SYSTEM_UPDATE_STATE_LOCK:
+        state_file = _system_update_state_file()
         try:
-            if SYSTEM_UPDATE_STATE_FILE.exists():
-                with SYSTEM_UPDATE_STATE_FILE.open("r", encoding="utf-8") as f:
+            if state_file.exists():
+                with state_file.open("r", encoding="utf-8") as f:
                     data = json.load(f)
                     if isinstance(data, dict):
                         return data
         except Exception as e:
-            logger.debug(f"Failed to read {SYSTEM_UPDATE_STATE_FILE}: {e}")
+            logger.debug(f"Failed to read {state_file}: {e}")
         return {}
 
 
@@ -1981,10 +1996,11 @@ def _system_update_state_save(state: dict[str, Any]) -> None:
     which silently resets the auto-update toggle to its default (#1745).
     """
     with _SYSTEM_UPDATE_STATE_LOCK:
+        state_file = _system_update_state_file()
         try:
-            write_json_atomic(SYSTEM_UPDATE_STATE_FILE, state)
+            write_json_atomic(state_file, state)
         except Exception as e:
-            logger.warning(f"Failed to write {SYSTEM_UPDATE_STATE_FILE}: {e}")
+            logger.warning(f"Failed to write {state_file}: {e}")
 
 
 def _system_update_state_update(**changes: Any) -> dict[str, Any]:
@@ -2191,7 +2207,19 @@ def _updater_last_update() -> dict[str, Any]:
 # document (the same format the BackupService uses for hand-rolled backups)
 # named ``pre-update-<timestamp>.json``.  Kept under data/ so they survive
 # container recreates via the ``./data:/app/data`` bind mount.
-SETTINGS_SNAPSHOT_DIR = Path("data/update-backups")
+#
+# ``SETTINGS_SNAPSHOT_DIR`` is a *test seam*: production leaves it ``None``
+# and ``_settings_snapshot_dir()`` resolves lazily through
+# ``src.paths.get_data_dir()`` (honoring ``FIESTABOARD_DATA_DIR``, #1762).
+SETTINGS_SNAPSHOT_DIR: Path | None = None
+
+
+def _settings_snapshot_dir() -> Path:
+    """Resolve the settings-snapshot directory at call time."""
+    if SETTINGS_SNAPSHOT_DIR is not None:
+        return Path(SETTINGS_SNAPSHOT_DIR)
+    return get_data_dir() / "update-backups"
+
 
 # How many pre-update snapshots to retain.  Older ones are pruned after each
 # successful snapshot.  Five mirrors the user's ".json.bak" rotation request.
@@ -2261,13 +2289,14 @@ def _take_settings_snapshot(
             )
 
     try:
-        SETTINGS_SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
+        snapshot_dir = _settings_snapshot_dir()
+        snapshot_dir.mkdir(parents=True, exist_ok=True)
         # Millisecond precision so multiple snapshots within the same
         # second (e.g. tests, or a user retrying immediately) don't
         # collide on filename and silently overwrite each other.
         now = datetime.now(UTC)
         ts = now.strftime("%Y%m%dT%H%M%S") + f".{now.microsecond // 1000:03d}Z"
-        target = SETTINGS_SNAPSHOT_DIR / f"pre-update-{ts}.json"
+        target = snapshot_dir / f"pre-update-{ts}.json"
         # Belt-and-braces against same-millisecond collisions: bump the
         # millisecond field forward until we find a free name.  1000 is
         # the natural upper bound (one full second of ms slots); we treat
@@ -2278,7 +2307,7 @@ def _take_settings_snapshot(
                 break
             ms = (now.microsecond // 1000 + bump) % _MAX_MS_SLOTS
             ts = now.strftime("%Y%m%dT%H%M%S") + f".{ms:03d}Z"
-            target = SETTINGS_SNAPSHOT_DIR / f"pre-update-{ts}.json"
+            target = snapshot_dir / f"pre-update-{ts}.json"
         else:  # pragma: no cover - effectively unreachable
             logger.warning("Could not find a free snapshot filename")
             return None
@@ -2334,11 +2363,12 @@ def _list_settings_snapshots() -> list[dict[str, Any]]:
     Each entry includes the recorded ``previous_digest`` / ``previous_image``
     so the UI can label snapshots with the version they will roll back to.
     """
-    if not SETTINGS_SNAPSHOT_DIR.exists():
+    snapshot_dir = _settings_snapshot_dir()
+    if not snapshot_dir.exists():
         return []
     out: list[dict[str, Any]] = []
     try:
-        entries = sorted(SETTINGS_SNAPSHOT_DIR.iterdir(), reverse=True)
+        entries = sorted(snapshot_dir.iterdir(), reverse=True)
     except OSError:
         return []
     for entry in entries:
@@ -2542,7 +2572,7 @@ def _prune_settings_snapshots() -> None:
     if len(snapshots) <= SETTINGS_SNAPSHOT_RETENTION:
         return
     for stale in snapshots[SETTINGS_SNAPSHOT_RETENTION:]:
-        path = SETTINGS_SNAPSHOT_DIR / stale["name"]
+        path = _settings_snapshot_dir() / stale["name"]
         try:
             path.unlink()
         except OSError:
@@ -2565,8 +2595,9 @@ def _resolve_snapshot_name(name: str | None) -> Path | None:
         name = snaps[0]["name"]
     if not _SETTINGS_SNAPSHOT_NAME_RE.fullmatch(name):
         return None
-    candidate = (SETTINGS_SNAPSHOT_DIR / name).resolve()
-    base = SETTINGS_SNAPSHOT_DIR.resolve()
+    snapshot_dir = _settings_snapshot_dir()
+    candidate = (snapshot_dir / name).resolve()
+    base = snapshot_dir.resolve()
     try:
         candidate.relative_to(base)
     except ValueError:
@@ -7897,8 +7928,7 @@ async def update_panel(panel_id: str, data: PanelUpdate):
     incompatible_references: list[dict] | None = None
     updates = data.model_dump(exclude_unset=True)
     screen_changed = any(
-        updates.get(field) is not None
-        for field in ("screen_diagonal_inches", "screen_aspect_w", "screen_aspect_h")
+        updates.get(field) is not None for field in ("screen_diagonal_inches", "screen_aspect_w", "screen_aspect_h")
     )
     if screen_changed:
         settings_service = get_settings_service()
@@ -9389,9 +9419,7 @@ async def force_refresh():
         logger.debug(f"Board content invalidation failed: {e}")
 
     try:
-        sent, error = _send_with_status(
-            service, "check_and_send_active_page_with_status", "check_and_send_active_page"
-        )
+        sent, error = _send_with_status(service, "check_and_send_active_page_with_status", "check_and_send_active_page")
         if error:
             raise HTTPException(status_code=500, detail=f"Failed to force refresh: {error}")
         return {

--- a/src/auth/service.py
+++ b/src/auth/service.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import Any
 
 from src.atomic_io import staging_path
+from src.paths import get_data_dir
 
 logger = logging.getLogger(__name__)
 
@@ -344,8 +345,8 @@ def _now_ms() -> int:
 
 
 def _default_auth_file() -> Path:
-    # Mirror src/config_manager.py path resolution.
-    return Path(__file__).resolve().parent.parent.parent / "data" / "auth.json"
+    # Central data-dir seam (src/paths.py); honors FIESTABOARD_DATA_DIR.
+    return get_data_dir() / "auth.json"
 
 
 class AuthService:

--- a/src/backup/service.py
+++ b/src/backup/service.py
@@ -30,6 +30,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from src.paths import get_data_dir
+
 #: Strict allowlist for repository URLs read from a backup file.  We only
 #: clone HTTPS URLs that contain a conservative set of characters; anything
 #: Strict allowlist for plugin ids read from a backup file.  Mirrors the
@@ -70,8 +72,7 @@ class BackupService:
 
     def __init__(self, data_dir: Path | None = None) -> None:
         if data_dir is None:
-            project_root = Path(__file__).resolve().parent.parent.parent
-            data_dir = project_root / "data"
+            data_dir = get_data_dir()
         self.data_dir = Path(data_dir)
         self._lock = threading.Lock()
 

--- a/src/collections/storage.py
+++ b/src/collections/storage.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from pathlib import Path
 
 from src.atomic_io import staging_path
+from src.paths import get_data_dir
 
 from .models import COLLECTION_ID_PREFIX, Collection
 
@@ -67,10 +68,7 @@ class CollectionStorage:
 
     def __init__(self, storage_file: str | None = None):
         if storage_file is None:
-            project_root = Path(__file__).parent.parent.parent
-            data_dir = project_root / "data"
-            data_dir.mkdir(exist_ok=True)
-            self.storage_file = data_dir / "collections.json"
+            self.storage_file = get_data_dir() / "collections.json"
         else:
             self.storage_file = Path(storage_file)
 

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -17,6 +17,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Optional
 
+from src.paths import get_data_dir
+
 # Import TimeService for migration
 from .atomic_io import staging_path
 from .time_service import get_time_service
@@ -478,9 +480,7 @@ class ConfigManager:
             self._config_path = Path(config_path)
         else:
             # Default to data directory
-            data_dir = Path(__file__).parent.parent / "data"
-            data_dir.mkdir(exist_ok=True)
-            self._config_path = data_dir / "config.json"
+            self._config_path = get_data_dir() / "config.json"
 
         self._config: dict[str, Any] = {}
         self._raw_features: dict[str, Any] = {}

--- a/src/main.py
+++ b/src/main.py
@@ -661,16 +661,39 @@ class DisplayService:
         while self.running:
             interval = self._get_board_read_interval()
             try:
-                rt = self._primary_runtime()
-                if rt is not None and rt.client is not None:
-                    chars = rt.client.read_current_message()
-                    if chars:
-                        rt.polled_characters = chars
-                        rt.polled_at = time.time()
-                        logger.debug("Board state poll succeeded")
+                self._poll_board_state_once()
             except Exception as e:
                 logger.debug(f"Board state poll failed: {e}")
             time.sleep(interval)
+
+    def _poll_board_state_once(self) -> None:
+        """Read the primary board once, cache the result, and detect
+        external writes (issue #1946).
+
+        A fresh read that differs from what this process last wrote means
+        someone else wrote the board (Vestaboard app, direct API call), so
+        the runtime is marked out-of-band and MQTT/HA stops reporting the
+        stale active page. The baseline is snapshotted around the read: if
+        a send replaces it mid-read, the read is stale against the new
+        baseline and detection is skipped for this cycle. The poll never
+        clears the flag — a matching read only proves the board shows our
+        last write, which may itself be a manual out-of-band message
+        (issue #1831); the engine's own page sends clear it.
+        """
+        rt = self._primary_runtime()
+        if rt is None or rt.client is None:
+            return
+        baseline = getattr(rt.client, "_last_characters", None)
+        chars = rt.client.read_current_message()
+        if not chars:
+            return
+        rt.polled_characters = chars
+        rt.polled_at = time.time()
+        logger.debug("Board state poll succeeded")
+        current = getattr(rt.client, "_last_characters", None)
+        if current is not None and current is baseline and chars != current:
+            rt.showing_out_of_band = True
+            logger.info("Board content changed externally; marking out-of-band")
 
     def request_board_refresh(
         self,

--- a/src/main.py
+++ b/src/main.py
@@ -119,6 +119,12 @@ class BoardRuntime:
         # future per-board poll is a drop-in change.
         self.polled_characters: list[list[int]] | None = None
         self.polled_at: float | None = None
+        # External-write detection (issue #1946): the client's
+        # ``_last_characters`` object observed on a poll whose read
+        # mismatched it. A second consecutive mismatch against this same
+        # object (by identity — any send replaces it) confirms an external
+        # write; see ``DisplayService._poll_board_state_once``.
+        self.external_change_suspect_baseline: list[list[int]] | None = None
 
         # Adaptive post-send refresh thread + its cancel event.
         self.refresh_thread: threading.Thread | None = None
@@ -673,12 +679,22 @@ class DisplayService:
         A fresh read that differs from what this process last wrote means
         someone else wrote the board (Vestaboard app, direct API call), so
         the runtime is marked out-of-band and MQTT/HA stops reporting the
-        stale active page. The baseline is snapshotted around the read: if
-        a send replaces it mid-read, the read is stale against the new
-        baseline and detection is skipped for this cycle. The poll never
-        clears the flag — a matching read only proves the board shows our
-        last write, which may itself be a manual out-of-band message
-        (issue #1831); the engine's own page sends clear it.
+        stale active page.
+
+        Detection needs TWO consecutive mismatching polls against the same
+        unchanged baseline before flagging: a single mismatch can be our own
+        send still propagating — the cloud read API lags a POST by seconds
+        (the lag request_board_refresh absorbs), and send_characters assigns
+        ``_last_characters`` only after the POST returns, so one read can
+        race any of that. Lag resolves well before the next poll (30s local
+        / 3min cloud); a genuine external write persists. The baseline is
+        snapshotted around each read and remembered between polls by object
+        identity, so any send in between restarts the suspect cycle.
+
+        The poll never clears the flag — a matching read only proves the
+        board shows our last write, which may itself be a manual
+        out-of-band message (issue #1831); the engine's own page sends
+        clear it.
         """
         rt = self._primary_runtime()
         if rt is None or rt.client is None:
@@ -691,9 +707,22 @@ class DisplayService:
         rt.polled_at = time.time()
         logger.debug("Board state poll succeeded")
         current = getattr(rt.client, "_last_characters", None)
-        if current is not None and current is baseline and chars != current:
+        if current is None or current is not baseline:
+            # No baseline to judge against, or a send raced the read —
+            # whatever we saw proves nothing about external writers.
+            rt.external_change_suspect_baseline = None
+            return
+        if chars == current:
+            rt.external_change_suspect_baseline = None
+            return
+        if rt.external_change_suspect_baseline is current:
+            # Second consecutive mismatch with no send in between: this is
+            # a persistent external write, not our own send's read lag.
+            rt.external_change_suspect_baseline = None
             rt.showing_out_of_band = True
             logger.info("Board content changed externally; marking out-of-band")
+        else:
+            rt.external_change_suspect_baseline = current
 
     def request_board_refresh(
         self,

--- a/src/mqtt/client.py
+++ b/src/mqtt/client.py
@@ -167,28 +167,11 @@ class MQTTClient:
             page_names = [p.name for p in pages]
         except Exception:
             logger.debug("Could not retrieve page names for MQTT discovery")
-        max_message_length = None
-        try:
-            from src.devices import resolve_dimensions
-            from src.settings.service import get_settings_service
-
-            boards = get_settings_service().get_board_settings().boards or []
-            primary = next((b for b in boards if isinstance(b, dict) and b.get("id")), None)
-            if primary:
-                dims = resolve_dimensions(
-                    primary.get("device_type") or "flagship",
-                    primary.get("notes_wide") or 1,
-                    primary.get("notes_tall") or 1,
-                )
-                max_message_length = dims.rows * dims.cols
-        except Exception:
-            logger.debug("Could not resolve board capacity for MQTT discovery")
         messages = build_all_discovery_messages(
             self.config,
             sw_version=sw_version,
             configuration_url=configuration_url,
             page_names=page_names or [],
-            max_message_length=max_message_length,
         )
         for msg in messages:
             self._client.publish(

--- a/src/mqtt/discovery.py
+++ b/src/mqtt/discovery.py
@@ -179,9 +179,12 @@ ENTITY_DEFINITIONS: list[EntityDefinition] = [
         icon="mdi:send",
         has_command=True,
         min_length=1,
-        # Flagship capacity (6x22). Overridden per install from the primary
-        # board's real geometry by build_all_discovery_messages (issue #1793).
-        max_length=132,
+        # HA's text-entity ceiling. NOT the board's tile count: HA counts
+        # payload characters, and markup ({red}, {66}) spends 4-8 characters
+        # per tile, so a tile-count limit strands real messages (issue #1957).
+        # HA also rejects max > 255 outright, which broke note arrays with
+        # more than 255 tiles. Overflow is wrapped/clipped server-side.
+        max_length=255,
     ),
     # Number
     EntityDefinition(
@@ -419,7 +422,6 @@ def build_all_discovery_messages(
     sw_version: str = "1.0.0",
     configuration_url: str | None = None,
     page_names: list[str] | None = None,
-    max_message_length: int | None = None,
 ) -> list[dict[str, Any]]:
     """Build all discovery messages for FiestaBoard.
 
@@ -432,9 +434,6 @@ def build_all_discovery_messages(
         sw_version: FiestaBoard software version.
         configuration_url: URL to FiestaBoard web UI.
         page_names: Current list of page names (for active_page select options).
-        max_message_length: Characters the board can actually hold
-            (rows x cols). Advertised to HA as the Send Message text limit;
-            ``None`` keeps the flagship 132 default.
 
     Returns:
         List of dicts, each with 'topic' and 'payload' keys.
@@ -448,11 +447,6 @@ def build_all_discovery_messages(
         # (issue #1794).
         if entity.object_id == "active_page" and page_names is not None:
             entity = replace(entity, options=[NO_ACTIVE_PAGE_OPTION, *page_names])
-
-        # Advertise the board's real capacity, not the flagship default, so a
-        # Note owner is not offered 132 characters for a 45-tile board.
-        if entity.object_id == "send_message" and max_message_length is not None:
-            entity = replace(entity, max_length=max_message_length)
 
         topic = build_discovery_topic(config, entity)
         payload = build_discovery_payload(config, entity, device_info)

--- a/src/pages/storage.py
+++ b/src/pages/storage.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from src.atomic_io import staging_path
+from src.paths import get_data_dir
 from src.text_utils import extract_alignment_from_line as _extract_alignment_from_line
 
 from .models import Page
@@ -220,10 +221,7 @@ class PageStorage:
             storage_file: Path to JSON storage file. Defaults to data/pages.json
         """
         if storage_file is None:
-            project_root = Path(__file__).parent.parent.parent
-            data_dir = project_root / "data"
-            data_dir.mkdir(exist_ok=True)
-            self.storage_file = data_dir / "pages.json"
+            self.storage_file = get_data_dir() / "pages.json"
         else:
             self.storage_file = Path(storage_file)
 

--- a/src/panels/storage.py
+++ b/src/panels/storage.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from src.atomic_io import staging_path
+from src.paths import get_data_dir
 
 from .models import Panel
 
@@ -104,10 +105,7 @@ class PanelStorage:
             storage_file: Path to JSON storage file. Defaults to data/panels.json
         """
         if storage_file is None:
-            project_root = Path(__file__).parent.parent.parent
-            data_dir = project_root / "data"
-            data_dir.mkdir(exist_ok=True)
-            self.storage_file = data_dir / "panels.json"
+            self.storage_file = get_data_dir() / "panels.json"
         else:
             self.storage_file = Path(storage_file)
 

--- a/src/paths.py
+++ b/src/paths.py
@@ -1,0 +1,24 @@
+"""Central resolution of FiestaBoard's writable data directory.
+
+Every store historically resolved ``<repo>/data`` on its own via
+``Path(__file__)`` gymnastics (eleven independent copies). This module is
+the one seam: production resolves the same default, tests set
+``FIESTABOARD_DATA_DIR`` to a tmp_path, and containers may pin it.
+"""
+
+import os
+from pathlib import Path
+
+
+def get_data_dir() -> Path:
+    """Return the data directory, creating it if needed.
+
+    Resolution: ``FIESTABOARD_DATA_DIR`` env var if set, else
+    ``<repo-root>/data`` (this file's parent's parent / "data").
+    Read fresh on every call — never cached at import time — so tests
+    and runtime reconfiguration work without reload gymnastics.
+    """
+    env = os.environ.get("FIESTABOARD_DATA_DIR", "").strip()
+    base = Path(env) if env else Path(__file__).resolve().parent.parent / "data"
+    base.mkdir(parents=True, exist_ok=True)
+    return base

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -9,6 +9,7 @@ The PluginRegistry is the central point for:
 """
 
 import logging
+import random
 import re
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -60,6 +61,10 @@ CONTEXT_BUILD_TIMEOUT_SECONDS = 15
 # healthy plugins (and sparing every render the full timeout wait it caused).
 PLUGIN_FETCH_BREAKER_THRESHOLD = 3
 PLUGIN_FETCH_BREAKER_COOLDOWN_SECONDS = 60.0
+# A timed-out fetch only earns a strike when it held a worker for at least
+# this fraction of the context-build window: anything less means it started
+# late (queued behind wedged fetches) and is mid-flight, not wedged itself.
+PLUGIN_FETCH_BREAKER_MIN_HOLD = 0.8
 
 
 def _config_in_use(plugin_id: str, stored_configs: dict[str, dict[str, Any]]) -> bool:
@@ -1572,11 +1577,14 @@ class PluginRegistry:
 
         # Circuit breaker (#1884): skip plugins whose fetches have repeatedly
         # wedged, so they cannot occupy every pool worker and starve the rest.
+        # The skip itself logs at DEBUG — the trip (below) already logged a
+        # WARNING, and this branch re-fires on every render tick for the
+        # whole cooldown.
         now = time.monotonic()
-        tripped = [pid for pid in enabled if self._fetch_breaker_open_until.get(pid, 0.0) > now]
+        tripped = {pid for pid in enabled if self._fetch_breaker_open_until.get(pid, 0.0) > now}
         if tripped:
-            logger.warning(f"Skipping {len(tripped)} plugin(s) with an open fetch circuit breaker: {tripped}")
-            enabled = [pid for pid in enabled if pid not in set(tripped)]
+            logger.debug(f"Skipping {len(tripped)} plugin(s) with an open fetch circuit breaker: {sorted(tripped)}")
+            enabled = [pid for pid in enabled if pid not in tripped]
         if not enabled:
             return context
 
@@ -1585,7 +1593,17 @@ class PluginRegistry:
         max_workers = min(len(enabled), 8)
         executor = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="plugin-fetch")
         try:
-            futures = {executor.submit(self.fetch_plugin_data, plugin_id, board): plugin_id for plugin_id in enabled}
+            # Stamp when each fetch actually gets a worker: `running()` at
+            # the deadline cannot distinguish "wedged since the start" from
+            # "queued behind wedged fetches and started late" — only the
+            # former deserves a breaker strike.
+            fetch_started: dict[str, float] = {}
+
+            def _timed_fetch(plugin_id: str):
+                fetch_started[plugin_id] = time.monotonic()
+                return self.fetch_plugin_data(plugin_id, board)
+
+            futures = {executor.submit(_timed_fetch, plugin_id): plugin_id for plugin_id in enabled}
             done, not_done = futures_wait(futures, timeout=CONTEXT_BUILD_TIMEOUT_SECONDS)
 
             if not_done:
@@ -1594,22 +1612,31 @@ class PluginRegistry:
                     f"{len(not_done)} plugin(s) did not complete within the "
                     f"context-build timeout and will be skipped: {slow_ids}"
                 )
+                deadline = time.monotonic()
                 for future in not_done:
-                    if not future.running():
-                        # Never got a worker: this plugin was starved by the
-                        # pool, not wedged itself. Don't count it against the
-                        # breaker — that would ban the victims too.
-                        continue
                     plugin_id = futures[future]
+                    started = fetch_started.get(plugin_id)
+                    held_whole_window = (
+                        started is not None
+                        and deadline - started >= CONTEXT_BUILD_TIMEOUT_SECONDS * PLUGIN_FETCH_BREAKER_MIN_HOLD
+                    )
+                    if not future.running() or not held_whole_window:
+                        # Never got a worker, or got one late and is still
+                        # mid-flight: a starvation victim, not a wedged
+                        # fetch. Don't count it against the breaker — that
+                        # would ban the victims too.
+                        continue
                     strikes = self._fetch_timeout_counts.get(plugin_id, 0) + 1
                     self._fetch_timeout_counts[plugin_id] = strikes
                     if strikes >= PLUGIN_FETCH_BREAKER_THRESHOLD:
-                        self._fetch_breaker_open_until[plugin_id] = (
-                            time.monotonic() + PLUGIN_FETCH_BREAKER_COOLDOWN_SECONDS
-                        )
+                        # Jitter the cooldown so plugins tripped in the same
+                        # pass don't all re-probe on the same later tick and
+                        # re-occupy every worker at once.
+                        cooldown = PLUGIN_FETCH_BREAKER_COOLDOWN_SECONDS * (1.0 + 0.25 * random.random())
+                        self._fetch_breaker_open_until[plugin_id] = time.monotonic() + cooldown
                         logger.warning(
                             f"Plugin {plugin_id} timed out {strikes} consecutive time(s); "
-                            f"pausing its fetches for {PLUGIN_FETCH_BREAKER_COOLDOWN_SECONDS:.0f}s"
+                            f"pausing its fetches for {cooldown:.0f}s"
                         )
 
             for future in done:

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -10,6 +10,7 @@ The PluginRegistry is the central point for:
 
 import logging
 import re
+import time
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import wait as futures_wait
 from dataclasses import replace
@@ -49,6 +50,16 @@ _INSTANCE_LABEL_RE = re.compile(r"^[a-zA-Z0-9_-]{1,40}$")
 # rendering without it. A board that is a little stale beats a board that never
 # updates because one data source is wedged.
 CONTEXT_BUILD_TIMEOUT_SECONDS = 15
+
+# Per-plugin fetch circuit breaker (#1884). The fetch pool is bounded, so a
+# permanently wedged fetch occupies one worker for the full context-build
+# timeout on every tick; once pool-size distinct fetches are wedged, healthy
+# plugins queued behind them never get a worker and *all* plugin data starves.
+# After PLUGIN_FETCH_BREAKER_THRESHOLD consecutive timeouts a plugin's fetch
+# is skipped for PLUGIN_FETCH_BREAKER_COOLDOWN_SECONDS, freeing its worker for
+# healthy plugins (and sparing every render the full timeout wait it caused).
+PLUGIN_FETCH_BREAKER_THRESHOLD = 3
+PLUGIN_FETCH_BREAKER_COOLDOWN_SECONDS = 60.0
 
 
 def _config_in_use(plugin_id: str, stored_configs: dict[str, dict[str, Any]]) -> bool:
@@ -99,6 +110,12 @@ class PluginRegistry:
         # Set once initialize() has loaded the plugin set. Guards against a
         # repeat call rebuilding every live plugin (issue #1753).
         self._initialized = False
+
+        # Fetch circuit-breaker state (#1884): plugin_id -> consecutive
+        # context-build timeouts, and plugin_id -> monotonic deadline until
+        # which its fetch is skipped. Both cleared on a completed fetch.
+        self._fetch_timeout_counts: dict[str, int] = {}
+        self._fetch_breaker_open_until: dict[str, float] = {}
 
         logger.info("PluginRegistry initialized")
 
@@ -1553,6 +1570,16 @@ class PluginRegistry:
         if not enabled:
             return context
 
+        # Circuit breaker (#1884): skip plugins whose fetches have repeatedly
+        # wedged, so they cannot occupy every pool worker and starve the rest.
+        now = time.monotonic()
+        tripped = [pid for pid in enabled if self._fetch_breaker_open_until.get(pid, 0.0) > now]
+        if tripped:
+            logger.warning(f"Skipping {len(tripped)} plugin(s) with an open fetch circuit breaker: {tripped}")
+            enabled = [pid for pid in enabled if pid not in set(tripped)]
+        if not enabled:
+            return context
+
         # Fetch every plugin concurrently; cap the pool to avoid spawning an
         # unbounded number of threads when many plugins are enabled.
         max_workers = min(len(enabled), 8)
@@ -1567,9 +1594,28 @@ class PluginRegistry:
                     f"{len(not_done)} plugin(s) did not complete within the "
                     f"context-build timeout and will be skipped: {slow_ids}"
                 )
+                for future in not_done:
+                    if not future.running():
+                        # Never got a worker: this plugin was starved by the
+                        # pool, not wedged itself. Don't count it against the
+                        # breaker — that would ban the victims too.
+                        continue
+                    plugin_id = futures[future]
+                    strikes = self._fetch_timeout_counts.get(plugin_id, 0) + 1
+                    self._fetch_timeout_counts[plugin_id] = strikes
+                    if strikes >= PLUGIN_FETCH_BREAKER_THRESHOLD:
+                        self._fetch_breaker_open_until[plugin_id] = (
+                            time.monotonic() + PLUGIN_FETCH_BREAKER_COOLDOWN_SECONDS
+                        )
+                        logger.warning(
+                            f"Plugin {plugin_id} timed out {strikes} consecutive time(s); "
+                            f"pausing its fetches for {PLUGIN_FETCH_BREAKER_COOLDOWN_SECONDS:.0f}s"
+                        )
 
             for future in done:
                 plugin_id = futures[future]
+                self._fetch_timeout_counts.pop(plugin_id, None)
+                self._fetch_breaker_open_until.pop(plugin_id, None)
                 try:
                     result = future.result()
                     if result.available and result.data:

--- a/src/plugins/sources.py
+++ b/src/plugins/sources.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from src.paths import get_data_dir
+
 logger = logging.getLogger(__name__)
 
 # ── constants ────────────────────────────────────────────────────────────────
@@ -723,7 +725,12 @@ def get_external_plugins_dir(project_root: Path | None = None) -> Path:
     """
     if project_root is None:
         project_root = Path(__file__).parent.parent.parent
-    ext_dir = project_root / "data" / EXTERNAL_PLUGINS_DIR
+        # Default resolves through the central data-dir seam (src/paths.py)
+        # so FIESTABOARD_DATA_DIR redirects the clone cache too. The legacy
+        # fallback below stays relative to the repo root either way.
+        ext_dir = get_data_dir() / EXTERNAL_PLUGINS_DIR
+    else:
+        ext_dir = project_root / "data" / EXTERNAL_PLUGINS_DIR
     ext_dir.mkdir(parents=True, exist_ok=True)
 
     marker = ext_dir / _LEGACY_MIGRATION_MARKER

--- a/src/schedules/storage.py
+++ b/src/schedules/storage.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from src.atomic_io import staging_path
+from src.paths import get_data_dir
 
 from .models import DEFAULT_BOARD_ID, ScheduleEntry
 
@@ -101,10 +102,7 @@ class ScheduleStorage:
             storage_file: Path to JSON storage file. Defaults to data/schedules.json
         """
         if storage_file is None:
-            project_root = Path(__file__).parent.parent.parent
-            data_dir = project_root / "data"
-            data_dir.mkdir(exist_ok=True)
-            self.storage_file = data_dir / "schedules.json"
+            self.storage_file = get_data_dir() / "schedules.json"
         else:
             self.storage_file = Path(storage_file)
 

--- a/src/security/secrets.py
+++ b/src/security/secrets.py
@@ -27,16 +27,24 @@ from pathlib import Path
 
 from cryptography.fernet import Fernet, InvalidToken
 
+from src.paths import get_data_dir
+
 logger = logging.getLogger(__name__)
 
 # Versioned marker on every ciphertext. Lets us spot encrypted values in
 # config files and roll the scheme forward in the future without guessing.
 ENCRYPTED_PREFIX = "enc::v1::"
 
-# Path resolution mirrors src/config_manager.py — the canonical data
-# directory is ``<repo>/data``.
-_DATA_DIR = Path(__file__).resolve().parent.parent.parent / "data"
-_KEY_PATH = _DATA_DIR / ".secret_key"
+
+def _data_dir() -> Path:
+    """The canonical data directory, resolved lazily via the seam (#1762)."""
+    return get_data_dir()
+
+
+def _key_path() -> Path:
+    """Path of the on-disk Fernet key file, resolved lazily per call."""
+    return _data_dir() / ".secret_key"
+
 
 _ENV_VAR = "FIESTABOARD_SECRET_KEY"
 
@@ -58,15 +66,15 @@ def _load_or_generate_key() -> bytes:
             ) from exc
         return env_value.encode("utf-8")
 
-    _DATA_DIR.mkdir(parents=True, exist_ok=True)
+    key_path = _key_path()  # get_data_dir() creates the directory
 
-    if _KEY_PATH.exists():
-        key = _KEY_PATH.read_bytes().strip()
+    if key_path.exists():
+        key = key_path.read_bytes().strip()
         try:
             Fernet(key)
         except (ValueError, TypeError) as exc:
             raise RuntimeError(
-                f"Secret key file at {_KEY_PATH} is corrupt. "
+                f"Secret key file at {key_path} is corrupt. "
                 "Delete it to regenerate (encrypted values will need to "
                 f"be re-entered) or set {_ENV_VAR}."
             ) from exc
@@ -77,7 +85,7 @@ def _load_or_generate_key() -> bytes:
     # Write atomically with a 0600 mode so other users on the host cannot
     # read the key. ``os.open`` lets us set the mode at create time.
     fd = os.open(
-        str(_KEY_PATH),
+        str(key_path),
         os.O_WRONLY | os.O_CREAT | os.O_EXCL,
         stat.S_IRUSR | stat.S_IWUSR,
     )
@@ -89,14 +97,14 @@ def _load_or_generate_key() -> bytes:
         # If even the cleanup unlink fails, there's nothing useful to do —
         # the original write failure (re-raised below) is the actionable error.
         with contextlib.suppress(OSError):
-            _KEY_PATH.unlink(missing_ok=True)
+            key_path.unlink(missing_ok=True)
         raise
 
     logger.warning(
         "Generated new secret encryption key at %s. Back this file up "
         "(or set %s) — losing it makes existing encrypted secrets "
         "unrecoverable.",
-        _KEY_PATH,
+        key_path,
         _ENV_VAR,
     )
     return key

--- a/src/settings/service.py
+++ b/src/settings/service.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Literal, Optional
 
 from src.atomic_io import staging_path
+from src.paths import get_data_dir
 
 logger = logging.getLogger(__name__)
 
@@ -737,11 +738,8 @@ class SettingsService:
             settings_file: Path to settings JSON file. Defaults to data/settings.json
         """
         if settings_file is None:
-            # Default to data directory in project root
-            project_root = Path(__file__).parent.parent.parent
-            data_dir = project_root / "data"
-            data_dir.mkdir(exist_ok=True)
-            self.settings_file = data_dir / "settings.json"
+            # Default to the central data directory (src/paths.py seam)
+            self.settings_file = get_data_dir() / "settings.json"
         else:
             self.settings_file = Path(settings_file)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,50 @@
 # tests/conftest.py
 
+import os
+import shutil
+import tempfile
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+
+# Session-wide throwaway data dir, created in ``pytest_configure`` (below) and
+# removed in ``pytest_unconfigure``. Module-level so both hooks see it.
+_SESSION_DATA_ROOT: Path | None = None
+
+
+def pytest_configure(config):
+    """Point ``FIESTABOARD_DATA_DIR`` at a throwaway dir before collection (#1894).
+
+    Function-scoped fixtures cannot protect anything that resolves the data
+    directory at **import or collection time**: module-level work in a test
+    file (four modules build a ``TestClient(app)`` at module scope) runs
+    before any fixture is active. With ``FIESTABOARD_DATA_DIR`` unset in that
+    window, ``src.paths.get_data_dir()`` falls back to ``<repo>/data`` and the
+    suite writes the developer's real checkout — ``config.json``,
+    ``external_plugins/.legacy-migration-done`` — intermittently under xdist,
+    where collection and execution interleave differently per worker.
+
+    Setting the variable here, before collection, closes the window for the
+    whole session: every default data-dir resolution (they all route through
+    the ``src/paths.py`` seam, #1762) lands in a temp dir, whatever the import
+    order. Per-test fixtures can still layer narrower isolation on top.
+
+    The directory is keyed by ``PYTEST_XDIST_WORKER`` (pid when running
+    without xdist) so parallel workers never share one.
+    """
+    global _SESSION_DATA_ROOT
+    worker = os.environ.get("PYTEST_XDIST_WORKER") or f"pid{os.getpid()}"
+    _SESSION_DATA_ROOT = Path(tempfile.mkdtemp(prefix=f"fiestaboard-tests-{worker}-"))
+    os.environ["FIESTABOARD_DATA_DIR"] = str(_SESSION_DATA_ROOT / "data")
+
+
+def pytest_unconfigure(config):
+    """Remove the session data dir created in ``pytest_configure``."""
+    global _SESSION_DATA_ROOT
+    if _SESSION_DATA_ROOT is not None:
+        shutil.rmtree(_SESSION_DATA_ROOT, ignore_errors=True)
+        _SESSION_DATA_ROOT = None
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -1954,10 +1954,10 @@ class TestEnableLocalAPI:
                     "enablement_token": "test_token_xyz",
                 },
             )
-        # Returns 200 with success=False (this endpoint reports validation as a body field).
-        assert response.status_code == 200
-        body = response.json()
-        assert body["success"] is False
+        # Host validation is the SSRF guard — its rejection must surface as
+        # HTTP 400, not a 200 with success=False (issue #1887).
+        assert response.status_code == 400
+        assert "host" in response.json()["detail"]
         # No outbound HTTP request should have been issued.
         mock_post.assert_not_called()
 

--- a/tests/test_board_connection_test.py
+++ b/tests/test_board_connection_test.py
@@ -673,3 +673,18 @@ class TestBoardTestPort:
 
         assert response.status_code == 200
         assert mock_client_cls.call_args.kwargs["port"] is None
+
+
+class TestBoardTestHostValidation:
+    """SSRF host-validation failures surface as HTTP 400, not 200 (issue #1887)."""
+
+    @patch("src.api_server.requests.get")
+    def test_invalid_host_returns_400(self, mock_get, client):
+        """A host with URL delimiters is rejected with HTTP 400 and no outbound request."""
+        response = client.post(
+            "/config/board/test",
+            json={"api_mode": "local", "local_api_key": "key", "host": "evil.com/path"},
+        )
+        assert response.status_code == 400
+        assert "host" in response.json()["detail"]
+        mock_get.assert_not_called()

--- a/tests/test_data_dir_isolation.py
+++ b/tests/test_data_dir_isolation.py
@@ -1,0 +1,197 @@
+"""Every store's *default* path resolves through the data-dir seam (#1762).
+
+Historically each store resolved ``<repo>/data`` on its own via
+``Path(__file__)`` gymnastics — eleven independent copies — so nothing short
+of rebinding every constructor kept the test suite off the developer's real
+``data/`` directory. ``src.paths.get_data_dir()`` is the one seam: it honors
+``FIESTABOARD_DATA_DIR``, which ``pytest_configure`` in ``tests/conftest.py``
+points at a per-worker throwaway directory before collection (#1894).
+
+This test constructs each store with **defaults** (no explicit path kwarg)
+and asserts the resulting path landed under the isolated temp dir, not under
+the repo. Before the seam existed this failed for every store.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REPO_DATA_DIR = REPO_ROOT / "data"
+
+# Captured while this module is being *imported* — i.e. at collection time,
+# before any fixture has run. See TestSessionDataDirFloor below.
+ENV_AT_IMPORT_TIME = os.environ.get("FIESTABOARD_DATA_DIR")
+
+
+@pytest.fixture
+def isolated_env(tmp_path, monkeypatch):
+    """Point the seam at a throwaway dir and drop the ConfigManager singleton.
+
+    Self-contained on purpose: this file is the guard for the seam itself, so
+    it must not silently depend on the session-level conftest hook it exists
+    to verify.
+    """
+    from src.config_manager import ConfigManager
+
+    data_dir = tmp_path / "isolated-data"
+    monkeypatch.setenv("FIESTABOARD_DATA_DIR", str(data_dir))
+    ConfigManager._instance = None  # type: ignore[attr-defined]
+    yield data_dir
+    ConfigManager._instance = None  # type: ignore[attr-defined]
+
+
+def _assert_isolated(path: Path, data_dir: Path, what: str) -> None:
+    resolved = Path(path).resolve()
+    assert not resolved.is_relative_to(REPO_DATA_DIR), f"{what} default resolved into the repo data/: {resolved}"
+    assert resolved.is_relative_to(data_dir.resolve()), f"{what} default did not honor FIESTABOARD_DATA_DIR: {resolved}"
+
+
+def test_settings_service_default_is_isolated(isolated_env):
+    from src.settings.service import SettingsService
+
+    _assert_isolated(SettingsService().settings_file, isolated_env, "SettingsService")
+
+
+def test_page_storage_default_is_isolated(isolated_env):
+    from src.pages.storage import PageStorage
+
+    _assert_isolated(PageStorage().storage_file, isolated_env, "PageStorage")
+
+
+def test_schedule_storage_default_is_isolated(isolated_env):
+    from src.schedules.storage import ScheduleStorage
+
+    _assert_isolated(ScheduleStorage().storage_file, isolated_env, "ScheduleStorage")
+
+
+def test_collection_storage_default_is_isolated(isolated_env):
+    from src.collections.storage import CollectionStorage
+
+    _assert_isolated(CollectionStorage().storage_file, isolated_env, "CollectionStorage")
+
+
+def test_panel_storage_default_is_isolated(isolated_env):
+    from src.panels.storage import PanelStorage
+
+    _assert_isolated(PanelStorage().storage_file, isolated_env, "PanelStorage")
+
+
+def test_config_manager_default_is_isolated(isolated_env):
+    from src.config_manager import ConfigManager
+
+    _assert_isolated(ConfigManager()._config_path, isolated_env, "ConfigManager")
+
+
+def test_backup_service_default_is_isolated(isolated_env):
+    from src.backup.service import BackupService
+
+    _assert_isolated(BackupService().data_dir, isolated_env, "BackupService")
+
+
+def test_auth_service_default_is_isolated(isolated_env):
+    from src.auth.service import AuthService
+
+    _assert_isolated(AuthService()._path, isolated_env, "AuthService")
+
+
+def test_external_plugins_dir_default_is_isolated(isolated_env):
+    from src.plugins.sources import get_external_plugins_dir
+
+    _assert_isolated(get_external_plugins_dir(), isolated_env, "get_external_plugins_dir")
+
+
+class TestSessionDataDirFloor:
+    """``FIESTABOARD_DATA_DIR`` is set for the whole session, not just per test (#1894).
+
+    Function-scoped fixtures leave two windows uncovered — collection time
+    (module-level ``TestClient(app)`` in four test modules imports
+    ``src.api_server`` before any fixture runs) and the moment after a test's
+    ``monkeypatch`` teardown (background threads a test started keep running
+    and re-enter ``ConfigManager()``). In either window an unset variable
+    sent ``get_data_dir()`` at the checkout's ``data/``, writing
+    ``config.json`` into the repo.
+
+    These assertions are the non-vacuous half of this file: they fail if the
+    ``pytest_configure`` hook in ``tests/conftest.py`` is removed, even
+    though per-test isolation could still be in place.
+    """
+
+    def test_env_is_already_set_when_test_modules_are_imported(self):
+        assert ENV_AT_IMPORT_TIME, (
+            "FIESTABOARD_DATA_DIR was unset while this module was imported — "
+            "anything resolving the data dir at import/collection time writes the repo"
+        )
+        assert not Path(ENV_AT_IMPORT_TIME).resolve().is_relative_to(REPO_ROOT)
+
+    def test_a_floor_remains_when_no_function_fixture_is_active(self, tmp_path):
+        """The session-wide value must survive to the very end of the run.
+
+        This is the window a function-scoped fixture cannot cover: a
+        background thread a test started keeps running after that test's
+        teardown, re-enters ``ConfigManager()`` and resolves the data dir
+        with nothing patched. Measured for real — a nested pytest session
+        runs one test from this file with ``FIESTABOARD_DATA_DIR`` scrubbed
+        from its environment, and a ``-p`` plugin records the surviving value
+        from ``pytest_sessionfinish``, after every function fixture is
+        finalized.
+        """
+        probe = tmp_path / "floor_probe.py"
+        out = tmp_path / "floor.txt"
+        probe.write_text(
+            "import os\n"
+            "\n"
+            "\n"
+            "def pytest_sessionfinish(session, exitstatus):\n"
+            "    out = os.environ['FLOOR_PROBE_OUT']\n"
+            "    with open(out, 'w') as fh:\n"
+            "        fh.write(os.environ.get('FIESTABOARD_DATA_DIR', ''))\n"
+        )
+        env = dict(os.environ)
+        env.pop("FIESTABOARD_DATA_DIR", None)
+        env.pop("PYTEST_XDIST_WORKER", None)
+        env["FLOOR_PROBE_OUT"] = str(out)
+        env["PYTHONPATH"] = os.pathsep.join([str(tmp_path), env.get("PYTHONPATH", "")]).rstrip(os.pathsep)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                f"{__file__}::TestSessionDataDirFloor::test_get_data_dir_never_resolves_inside_the_repository",
+                "-q",
+                "-p",
+                "floor_probe",
+                "-p",
+                "no:cacheprovider",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"nested session failed:\n{result.stdout}\n{result.stderr}"
+        floor = out.read_text().strip()
+        assert floor, "FIESTABOARD_DATA_DIR was left *unset* once the function fixtures were torn down"
+        assert not Path(floor).resolve().is_relative_to(REPO_ROOT), (
+            f"the surviving data dir points into the checkout: {floor}"
+        )
+
+    def test_data_dir_is_unique_per_xdist_worker(self):
+        worker = os.environ.get("PYTEST_XDIST_WORKER")
+        if not worker:
+            pytest.skip("not running under xdist")
+        assert worker in str(ENV_AT_IMPORT_TIME), (
+            f"session data dir {ENV_AT_IMPORT_TIME!r} is not keyed by worker {worker!r} — "
+            "parallel workers would share one directory"
+        )
+
+    def test_get_data_dir_never_resolves_inside_the_repository(self):
+        from src.paths import get_data_dir
+
+        assert not get_data_dir().resolve().is_relative_to(REPO_ROOT)

--- a/tests/test_external_board_change_detection.py
+++ b/tests/test_external_board_change_detection.py
@@ -1,0 +1,109 @@
+"""Tests for external-board-change detection in the state poll (issue #1946).
+
+The board-state poll already reads the primary board every cycle. When a
+fresh read differs from what FiestaBoard itself last wrote, someone else
+wrote the board (Vestaboard app, direct API call), so the board is no
+longer showing the configured page. The poll must mark the runtime
+out-of-band so MQTT/Home Assistant stops reporting the stale page —
+mirroring what the web UI already shows from the same cache.
+
+Clearing the flag stays with the engine's own page sends: a read that
+matches ``_last_characters`` only proves the board shows whatever we
+last wrote (which may itself be an out-of-band manual message), so the
+poll never clears the flag.
+"""
+
+from unittest.mock import Mock
+
+from src.main import DisplayService
+
+SENT = [[1, 2, 3]]
+EXTERNAL = [[7, 7, 7]]
+
+
+def _make_service(last_chars):
+    svc = DisplayService()
+    client = Mock()
+    client._last_characters = last_chars
+    svc.vb_client = client
+    return svc, client
+
+
+class TestExternalChangeDetection:
+    def test_differing_read_marks_out_of_band(self):
+        """A fresh read that differs from what we last sent = external write."""
+        svc, client = _make_service(SENT)
+        client.read_current_message.return_value = EXTERNAL
+
+        svc._poll_board_state_once()
+
+        assert svc.is_showing_out_of_band() is True
+
+    def test_matching_read_does_not_mark_out_of_band(self):
+        """Board showing exactly what we sent — nothing external happened."""
+        svc, client = _make_service(SENT)
+        client.read_current_message.return_value = SENT
+
+        svc._poll_board_state_once()
+
+        assert svc.is_showing_out_of_band() is False
+
+    def test_poll_still_caches_board_state(self):
+        """The poll's original job — caching the read — must be preserved."""
+        svc, client = _make_service(SENT)
+        client.read_current_message.return_value = EXTERNAL
+
+        svc._poll_board_state_once()
+
+        assert svc._polled_characters == EXTERNAL
+        assert svc._polled_at is not None
+
+    def test_never_sent_anything_is_not_out_of_band(self):
+        """No baseline to compare against (fresh start) — stay quiet."""
+        svc, client = _make_service(None)
+        client.read_current_message.return_value = EXTERNAL
+
+        svc._poll_board_state_once()
+
+        assert svc.is_showing_out_of_band() is False
+
+    def test_failed_read_changes_nothing(self):
+        """A failed read must not touch cache or flag."""
+        svc, client = _make_service(SENT)
+        client.read_current_message.return_value = None
+
+        svc._poll_board_state_once()
+
+        assert svc._polled_characters is None
+        assert svc.is_showing_out_of_band() is False
+
+    def test_send_racing_the_read_skips_detection(self):
+        """If a send lands while the read is in flight, the read is stale
+        against the new baseline — skip detection for this cycle rather
+        than raise a false alarm."""
+        svc, client = _make_service(SENT)
+        new_sent = [[4, 4, 4]]
+
+        def read_and_race():
+            # A concurrent send replaces the baseline mid-read.
+            client._last_characters = new_sent
+            return SENT  # the read reflects the pre-send board
+
+        client.read_current_message.side_effect = read_and_race
+
+        svc._poll_board_state_once()
+
+        assert svc.is_showing_out_of_band() is False
+        # The stale read is still cached (matches historical behavior).
+        assert svc._polled_characters == SENT
+
+    def test_poll_never_clears_an_existing_flag(self):
+        """A matching read only proves the board shows our last write —
+        which may itself be a manual out-of-band message (issue #1831)."""
+        svc, client = _make_service(SENT)
+        svc.mark_showing_out_of_band()
+        client.read_current_message.return_value = SENT
+
+        svc._poll_board_state_once()
+
+        assert svc.is_showing_out_of_band() is True

--- a/tests/test_external_board_change_detection.py
+++ b/tests/test_external_board_change_detection.py
@@ -30,13 +30,54 @@ def _make_service(last_chars):
 
 
 class TestExternalChangeDetection:
-    def test_differing_read_marks_out_of_band(self):
-        """A fresh read that differs from what we last sent = external write."""
+    def test_two_consecutive_differing_reads_mark_out_of_band(self):
+        """Reads that differ from what we last sent, twice in a row against
+        the same baseline, prove an external write."""
+        svc, client = _make_service(SENT)
+        client.read_current_message.return_value = EXTERNAL
+
+        svc._poll_board_state_once()
+        svc._poll_board_state_once()
+
+        assert svc.is_showing_out_of_band() is True
+
+    def test_single_differing_read_is_only_a_suspect(self):
+        """One mismatch may be the cloud read API lagging our own send
+        (the lag request_board_refresh absorbs) — never flag on one read."""
         svc, client = _make_service(SENT)
         client.read_current_message.return_value = EXTERNAL
 
         svc._poll_board_state_once()
 
+        assert svc.is_showing_out_of_band() is False
+
+    def test_lag_that_resolves_by_the_next_poll_never_flags(self):
+        """Post-send read lag: first poll still sees the old frame, second
+        poll sees what we sent. No external write happened."""
+        svc, client = _make_service(SENT)
+        client.read_current_message.side_effect = [EXTERNAL, SENT, EXTERNAL]
+
+        svc._poll_board_state_once()
+        svc._poll_board_state_once()
+        # A later lone mismatch starts a fresh suspect cycle, not a flag.
+        svc._poll_board_state_once()
+
+        assert svc.is_showing_out_of_band() is False
+
+    def test_send_between_the_two_mismatches_resets_the_suspect(self):
+        """A send replaces the baseline: the second mismatch is judged
+        against fresh lag, so the suspect cycle restarts."""
+        svc, client = _make_service(SENT)
+        new_sent = [[4, 4, 4]]
+        client.read_current_message.return_value = EXTERNAL
+
+        svc._poll_board_state_once()
+        client._last_characters = new_sent  # engine sent between polls
+        svc._poll_board_state_once()
+
+        assert svc.is_showing_out_of_band() is False
+        # ...but persistence against the *new* baseline still flags.
+        svc._poll_board_state_once()
         assert svc.is_showing_out_of_band() is True
 
     def test_matching_read_does_not_mark_out_of_band(self):
@@ -44,6 +85,7 @@ class TestExternalChangeDetection:
         svc, client = _make_service(SENT)
         client.read_current_message.return_value = SENT
 
+        svc._poll_board_state_once()
         svc._poll_board_state_once()
 
         assert svc.is_showing_out_of_band() is False

--- a/tests/test_mqtt_discovery.py
+++ b/tests/test_mqtt_discovery.py
@@ -124,7 +124,7 @@ class TestEntityDefinitions:
         texts = [e for e in ENTITY_DEFINITIONS if e.entity_type == "text"]
         assert len(texts) == 1
         assert texts[0].object_id == "send_message"
-        assert texts[0].max_length == 132  # 22 chars × 6 rows
+        assert texts[0].max_length == 255  # HA text ceiling, not tile count (issue #1957)
 
     def test_number_entities(self):
         """Should have number entity for refresh interval."""
@@ -546,15 +546,14 @@ class TestBuildAllDiscoveryMessages:
                 return payload
         raise AssertionError("no send_message discovery message")
 
-    def test_send_message_max_length_defaults_to_flagship_capacity(self, mqtt_config):
-        """Without a resolved board, keep the historical 6x22 = 132 default."""
+    def test_send_message_max_is_ha_text_ceiling_not_tile_count(self, mqtt_config):
+        """Markup spends payload characters without spending tiles — {red} is
+        five characters for one flap — so a tile-count limit strands real
+        messages (issue #1957). Advertise HA's own text-entity ceiling (255)
+        instead; the server already wraps/clips whatever arrives to the board.
+        """
         messages = build_all_discovery_messages(mqtt_config)
-        assert self._send_message_payload(messages)["max"] == 132
-
-    def test_send_message_max_length_follows_the_board(self, mqtt_config):
-        """A Note holds 3x15 = 45 characters, not 132 (issue #1793 review)."""
-        messages = build_all_discovery_messages(mqtt_config, max_message_length=45)
-        assert self._send_message_payload(messages)["max"] == 45
+        assert self._send_message_payload(messages)["max"] == 255
 
     def test_custom_instance_id(self):
         """Custom instance ID should be reflected in all payloads."""

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -760,6 +760,51 @@ def test_fetch_breaker_closes_after_cooldown_and_success(registry, monkeypatch):
     assert registry._fetch_timeout_counts.get("flaky", 0) == 0
 
 
+def test_fetch_breaker_spares_healthy_plugin_that_started_late(registry, monkeypatch):
+    """A fetch that only got a pool worker late in the window is mid-flight at
+    the deadline, not wedged — `running()` alone cannot tell them apart, so
+    the breaker must only strike fetches that held a worker for (nearly) the
+    whole window. Otherwise the starved-but-healthy plugin the breaker exists
+    to protect gets banned itself.
+    """
+    import src.plugins.registry as registry_module
+
+    monkeypatch.setattr(registry_module, "CONTEXT_BUILD_TIMEOUT_SECONDS", 0.6)
+
+    release = threading.Event()
+    try:
+        # 7 wedged fetches hold 7 of the 8 workers all window.
+        for i in range(7):
+            _install(registry, _wedged_plugin(f"wedged_{i}", release))
+
+        # One brief fetch takes the 8th worker, then frees it mid-window...
+        brief = MagicMock(spec=PluginBase)
+        brief.plugin_id = "brief"
+
+        def _brief(board=None):
+            time.sleep(0.3)
+            return PluginResult(available=True, data={"ok": True})
+
+        brief.get_data.side_effect = _brief
+        _install(registry, brief)
+
+        # ...so this healthy-but-slow fetch starts ~halfway through the
+        # window and is still running (not wedged) when the deadline hits.
+        late = _wedged_plugin("late", release)
+        _install(registry, late)
+
+        ticks = PLUGIN_FETCH_BREAKER_THRESHOLD + 1
+        for _ in range(ticks):
+            registry.build_template_context()
+    finally:
+        release.set()
+
+    assert late.get_data.call_count == ticks, (
+        "late-starting fetch was struck as wedged and banned: it was "
+        f"submitted on only {late.get_data.call_count} of {ticks} ticks"
+    )
+
+
 # --- get_plugin_registry / reset_plugin_registry ---
 
 

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -11,6 +11,7 @@ from src.plugins.base import PluginBase, PluginResult
 from src.plugins.manifest import PluginManifest, load_manifest
 from src.plugins.previews import BoardPreview
 from src.plugins.registry import (
+    PLUGIN_FETCH_BREAKER_THRESHOLD,
     PluginRegistry,
     get_plugin_registry,
     reset_plugin_registry,
@@ -647,6 +648,116 @@ def test_build_template_context_skips_unavailable(registry, mock_loader, mock_pl
 
     context = registry.build_template_context()
     assert "test_plugin" not in context
+
+
+# --- build_template_context: fetch-pool starvation (#1884) ---
+
+
+def _wedged_plugin(pid: str, release: threading.Event) -> MagicMock:
+    """A plugin whose fetch blocks until *release* is set (a wedged network call)."""
+    plugin = MagicMock(spec=PluginBase)
+    plugin.plugin_id = pid
+
+    def _hang(board=None):
+        release.wait()
+        return PluginResult(available=False, error="wedged")
+
+    plugin.get_data.side_effect = _hang
+    return plugin
+
+
+def _healthy_plugin(pid: str) -> MagicMock:
+    plugin = MagicMock(spec=PluginBase)
+    plugin.plugin_id = pid
+    plugin.get_data.return_value = PluginResult(available=True, data={"ok": True})
+    return plugin
+
+
+def _install(registry, plugin):
+    registry._plugins[plugin.plugin_id] = plugin
+    registry._enabled[plugin.plugin_id] = True
+
+
+def test_wedged_plugins_do_not_starve_healthy_plugin(registry, monkeypatch):
+    """Regression test for #1884: >= pool-size permanently wedged fetches must
+    not block a healthy plugin's data forever.
+
+    Eight wedged plugins (one per pool worker) are submitted ahead of one
+    healthy plugin. Without a circuit breaker the wedged fetches occupy every
+    worker on every tick and the healthy plugin's fetch never runs, so its
+    data never reaches the context.
+    """
+    import src.plugins.registry as registry_module
+
+    monkeypatch.setattr(registry_module, "CONTEXT_BUILD_TIMEOUT_SECONDS", 0.2)
+
+    release = threading.Event()
+    try:
+        for i in range(8):
+            _install(registry, _wedged_plugin(f"wedged_{i}", release))
+        healthy = _healthy_plugin("healthy")
+        _install(registry, healthy)
+
+        # One tick per breaker strike, plus one tick to observe recovery.
+        contexts = [registry.build_template_context() for _ in range(PLUGIN_FETCH_BREAKER_THRESHOLD + 1)]
+    finally:
+        release.set()
+
+    assert "healthy" in contexts[-1], (
+        "healthy plugin starved: wedged fetches occupied every pool worker "
+        f"on all {len(contexts)} ticks and its fetch never ran"
+    )
+    assert contexts[-1]["healthy"] == {"ok": True}
+
+
+def test_fetch_breaker_opens_after_consecutive_timeouts(registry, monkeypatch):
+    """After threshold consecutive fetch timeouts a plugin is skipped for the
+    cooldown instead of being resubmitted every tick."""
+    import src.plugins.registry as registry_module
+
+    monkeypatch.setattr(registry_module, "CONTEXT_BUILD_TIMEOUT_SECONDS", 0.2)
+
+    release = threading.Event()
+    try:
+        wedged = _wedged_plugin("wedged", release)
+        _install(registry, wedged)
+        _install(registry, _healthy_plugin("healthy"))
+
+        # threshold strikes + 1 tick inside the cooldown
+        for _ in range(PLUGIN_FETCH_BREAKER_THRESHOLD + 1):
+            context = registry.build_template_context()
+            assert "healthy" in context  # pool has a free worker throughout
+    finally:
+        release.set()
+
+    # The strikes opened the breaker; the last tick must not have submitted the fetch.
+    assert wedged.get_data.call_count == PLUGIN_FETCH_BREAKER_THRESHOLD
+
+
+def test_fetch_breaker_closes_after_cooldown_and_success(registry, monkeypatch):
+    """Once the cooldown lapses the plugin is probed again, and a successful
+    fetch resets the breaker so it is not skipped afterwards."""
+    import src.plugins.registry as registry_module
+
+    monkeypatch.setattr(registry_module, "CONTEXT_BUILD_TIMEOUT_SECONDS", 0.2)
+
+    release = threading.Event()
+    try:
+        wedged = _wedged_plugin("flaky", release)
+        _install(registry, wedged)
+        for _ in range(PLUGIN_FETCH_BREAKER_THRESHOLD):  # open the breaker
+            registry.build_template_context()
+    finally:
+        release.set()
+
+    # Simulate the cooldown lapsing and the upstream recovering.
+    registry._fetch_breaker_open_until["flaky"] = 0.0
+    wedged.get_data.side_effect = None
+    wedged.get_data.return_value = PluginResult(available=True, data={"back": True})
+
+    context = registry.build_template_context()
+    assert context["flaky"] == {"back": True}
+    assert registry._fetch_timeout_counts.get("flaky", 0) == 0
 
 
 # --- get_plugin_registry / reset_plugin_registry ---

--- a/tests/test_schedule_board_validation.py
+++ b/tests/test_schedule_board_validation.py
@@ -1,0 +1,156 @@
+"""Regression tests for issue #1888: schedule write endpoints must 404 on an
+unknown board_id instead of persisting phantom entries (or silently dropping
+the write) while reporting success.
+
+Covers the four live write paths from the issue:
+  - POST /schedules
+  - PUT /schedules/{schedule_id}
+  - PUT /schedules/default-page
+  - PUT /schedules/enabled
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api_server import app
+from src.pages.models import PageCreate
+from src.pages.service import PageService
+from src.pages.storage import PageStorage
+from src.schedules.service import ScheduleService
+from src.schedules.storage import ScheduleStorage
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def env(monkeypatch, tmp_path):
+    """Real page/schedule services on temp storage, mocked settings with one board."""
+    page_service = PageService(storage=PageStorage(storage_file=str(tmp_path / "pages.json")))
+    schedule_service = ScheduleService(storage=ScheduleStorage(storage_file=str(tmp_path / "schedules.json")))
+
+    boards = [{"id": "board-flagship", "name": "Big Board", "device_type": "flagship"}]
+    settings = MagicMock()
+    settings.get_board_settings.return_value.boards = boards
+    settings.get_primary_board_id.return_value = "board-flagship"
+    settings.should_send_to_board.return_value = False
+
+    monkeypatch.setattr("src.pages.service.get_page_service", lambda: page_service)
+    monkeypatch.setattr("src.pages.service.get_settings_service", lambda: settings)
+    monkeypatch.setattr("src.api_server.get_page_service", lambda: page_service)
+    monkeypatch.setattr("src.api_server.get_settings_service", lambda: settings)
+    monkeypatch.setattr("src.api_server.get_schedule_service", lambda: schedule_service)
+    monkeypatch.setattr("src.api_server.get_service", lambda: None)
+    monkeypatch.setattr("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False)
+
+    page = page_service.create_page(PageCreate(name="Flag Page", type="template", template=["a"]))
+
+    return {
+        "settings": settings,
+        "schedule_service": schedule_service,
+        "page": page,
+    }
+
+
+def _payload(page_id, board_id):
+    return {"page_id": page_id, "board_id": board_id, "start_time": "09:00", "end_time": "10:00"}
+
+
+class TestCreateScheduleBoardValidation:
+    """POST /schedules must reject an unknown board_id."""
+
+    def test_create_with_unknown_board_404s(self, client, env):
+        response = client.post("/schedules", json=_payload(env["page"].id, "board-ghost"))
+        assert response.status_code == 404
+        assert "board-ghost" in response.json()["detail"]
+
+    def test_create_with_unknown_board_persists_nothing(self, client, env):
+        client.post("/schedules", json=_payload(env["page"].id, "board-ghost"))
+        assert env["schedule_service"].list_schedules(board_id="*") == []
+
+    def test_create_with_known_board_accepted(self, client, env):
+        response = client.post("/schedules", json=_payload(env["page"].id, "board-flagship"))
+        assert response.status_code == 200
+
+    def test_create_with_default_board_sentinel_accepted(self, client, env):
+        """board_id="" is the legacy default-board sentinel and stays valid."""
+        response = client.post("/schedules", json=_payload(env["page"].id, ""))
+        assert response.status_code == 200
+
+
+class TestUpdateScheduleBoardValidation:
+    """PUT /schedules/{id} must not re-parent a schedule onto an unknown board."""
+
+    def test_update_to_unknown_board_404s(self, client, env):
+        created = client.post("/schedules", json=_payload(env["page"].id, "board-flagship")).json()
+        response = client.put(f"/schedules/{created['id']}", json={"board_id": "board-ghost"})
+        assert response.status_code == 404
+        assert "board-ghost" in response.json()["detail"]
+
+    def test_update_to_unknown_board_leaves_schedule_unchanged(self, client, env):
+        created = client.post("/schedules", json=_payload(env["page"].id, "board-flagship")).json()
+        client.put(f"/schedules/{created['id']}", json={"board_id": "board-ghost"})
+        stored = env["schedule_service"].get_schedule(created["id"])
+        assert stored.board_id == "board-flagship"
+
+    def test_update_without_board_id_accepted(self, client, env):
+        created = client.post("/schedules", json=_payload(env["page"].id, "board-flagship")).json()
+        response = client.put(f"/schedules/{created['id']}", json={"start_time": "11:00"})
+        assert response.status_code == 200
+
+
+class TestDefaultPageBoardValidation:
+    """PUT /schedules/default-page must reject an unknown board_id."""
+
+    def test_set_default_page_with_unknown_board_404s(self, client, env):
+        response = client.put(
+            "/schedules/default-page",
+            json={"page_id": env["page"].id, "board_id": "board-ghost"},
+        )
+        assert response.status_code == 404
+        assert "board-ghost" in response.json()["detail"]
+
+    def test_set_default_page_with_unknown_board_writes_nothing(self, client, env):
+        client.put(
+            "/schedules/default-page",
+            json={"page_id": env["page"].id, "board_id": "board-ghost"},
+        )
+        assert env["schedule_service"].get_default_page(board_id="board-ghost") is None
+
+    def test_set_default_page_with_known_board_accepted(self, client, env):
+        response = client.put(
+            "/schedules/default-page",
+            json={"page_id": env["page"].id, "board_id": "board-flagship"},
+        )
+        assert response.status_code == 200
+
+    def test_set_default_page_without_board_accepted(self, client, env):
+        response = client.put("/schedules/default-page", json={"page_id": env["page"].id})
+        assert response.status_code == 200
+
+
+class TestScheduleEnabledBoardValidation:
+    """PUT /schedules/enabled must reject an unknown board_id instead of
+    reporting success for a write that never happened."""
+
+    def test_set_enabled_with_unknown_board_404s(self, client, env):
+        response = client.put("/schedules/enabled", json={"enabled": True, "board_id": "board-ghost"})
+        assert response.status_code == 404
+        assert "board-ghost" in response.json()["detail"]
+
+    def test_set_enabled_with_unknown_board_writes_nothing(self, client, env):
+        client.put("/schedules/enabled", json={"enabled": True, "board_id": "board-ghost"})
+        env["settings"].set_schedule_enabled.assert_not_called()
+
+    def test_set_enabled_with_known_board_accepted(self, client, env):
+        response = client.put("/schedules/enabled", json={"enabled": True, "board_id": "board-flagship"})
+        assert response.status_code == 200
+        env["settings"].set_schedule_enabled.assert_called_once_with(True, board_id="board-flagship")
+
+    def test_set_enabled_without_board_accepted(self, client, env):
+        response = client.put("/schedules/enabled", json={"enabled": False})
+        assert response.status_code == 200

--- a/tests/test_secrets_encryption.py
+++ b/tests/test_secrets_encryption.py
@@ -11,10 +11,8 @@ from src.security import secrets as secrets_mod
 
 @pytest.fixture(autouse=True)
 def _isolated_key(tmp_path, monkeypatch):
-    """Point the module at a temp data dir and clear any cached cipher."""
-    # Use env var path: deterministic across tests.
-    monkeypatch.setattr(secrets_mod, "_DATA_DIR", tmp_path)
-    monkeypatch.setattr(secrets_mod, "_KEY_PATH", tmp_path / ".secret_key")
+    """Point the data-dir seam at a temp dir and clear any cached cipher."""
+    monkeypatch.setenv("FIESTABOARD_DATA_DIR", str(tmp_path))
     monkeypatch.delenv("FIESTABOARD_SECRET_KEY", raising=False)
     secrets_mod._reset_for_tests()
     yield
@@ -53,7 +51,7 @@ def test_is_encrypted():
 
 def test_key_file_perms(tmp_path):
     secrets_mod.encrypt_secret("anything")
-    key_path = secrets_mod._KEY_PATH
+    key_path = secrets_mod._key_path()
     assert key_path.exists()
     mode = stat.S_IMODE(key_path.stat().st_mode)
     # 0600


### PR DESCRIPTION
Rollup of six independently developed, TDD'd fixes from the 2026-09-12 issue triage, combined onto one branch so CI/e2e runs once. Each commit is one fix and stands alone; every fix had a failing regression test before the code change.

## MQTT (reported by @mountainsandcode)

- **Closes #1957** — `fix(mqtt)`: the HA *Send Message* text entity advertised the board's tile count (132) as its character limit, but HA counts payload characters and markup like `{red}` spends 5 characters per flap. Now advertises HA's own 255-char ceiling; overflow keeps being word-wrapped/clipped server-side. Also fixes discovery breaking entirely for note arrays >255 tiles (HA rejects `max` > 255).
- **Closes #1946** — `fix(mqtt)`: the *Current Page* sensor / *Active Page* select kept reporting the stored page after the board was written from outside FiestaBoard. The board-state poll now compares each fresh read against what this process last wrote and marks the runtime out-of-band on mismatch (race-safe against concurrent sends; the poll never clears the flag). Detection latency = existing poll cadence (30 s local / 3 min cloud), same as the web UI.

## Backend validation

- **Closes #1888** — `fix(schedules)`: all four schedule write endpoints accepted a nonexistent `board_id` and persisted phantom entries with a 200. New `_require_board()` guard returns 404; legacy `""`/`None` sentinels unchanged.
- **Closes #1887** — `fix(api)`: two board-setup endpoints caught the SSRF host validator's `HTTPException(400)` and re-served it as HTTP 200 with `success: false`. The 400 now propagates; the guard itself was already effective (no outbound request was made) — only the status was wrong. UI error paths verified to still surface the message.

## Test infrastructure

- **Closes #1894** — `fix(tests)`: main had no data-dir seam at all, so any pytest run (and any xdist worker, at any phase incl. collection) could write the developer's real `data/`. Ports the `src/paths.py` `get_data_dir()` seam from next-rebuild's #1762 commit byte-identically (11 hardcoded `data/` resolutions rerouted) and adds a `pytest_configure` env floor keyed by xdist worker, set before collection. When next-rebuild merges, these regions should resolve identically.

## Engine resilience

- **Closes #1884** — `fix(plugins)`: ≥8 wedged plugin fetches monopolized the bounded per-render fetch pool so healthy plugins never fetched. Adds a per-plugin circuit breaker (3 strikes on *running* timed-out fetches → 60 s cooldown → re-probe); queued starvation victims deliberately don't accrue strikes; any success resets.

## Not included

- #1886 (nginx proxy timeouts) stays on standalone branch `fix-issue-1886-send-wait-timeout` — the identical fix already exists on `next` (`6fc97e7fc`); merging both paths would conflict trivially at rework-merge time. Take it separately only if #1886 must land on main first.
- #1750 needs no code: fixed on main by #1809, remainder tracked on `fix/1826-event-loop-blocking`.

## Verification

- Combined sweep in the isolated `fb-test` container across all touched areas: **856 passed** under `pytest -n 4` (xdist exercised on purpose — it's what #1894 fixes).
- `ruff check` + `ruff format --check` clean on all 25 changed files.
- Pre-fix failing-test outputs for each fix are recorded in the individual commit messages / triage report (e.g. `assert 132 == 255`, `assert 200 == 400`, `assert 200 == 404`, `healthy plugin starved ... assert 'healthy' in {}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V79Gu2BSDb1CbFye4ffFx4