### PR TITLE
fix(nginx): outwait long board sends on the /api proxy (#1886)

### DIFF
--- a/nginx-dev.conf
+++ b/nginx-dev.conf
@@ -87,8 +87,17 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_connect_timeout 10s;
-            proxy_send_timeout 30s;
-            proxy_read_timeout 60s;
+            # Must OUTWAIT the backend's worst-case in-request board send: a
+            # wait-mode send may drive a transition to its 120s
+            # max_runtime_seconds cap, with cloud note-array boards pacing
+            # frames 15s apart, so minute-plus sends are routine. At the stock
+            # 60s nginx returned 504 to the browser while the backend went on
+            # working (issue #1886). 300s leaves headroom (and already covers
+            # the rework's 240s SEND_WAIT_TIMEOUT); raise both numbers
+            # together — tests/test_nginx_api_timeouts.py fails the build if
+            # they drift apart again.
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
         }
 
         location /api/ {
@@ -101,8 +110,11 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_connect_timeout 10s;
-            proxy_send_timeout 30s;
-            proxy_read_timeout 60s;
+            # Must OUTWAIT the backend's worst-case in-request board send —
+            # see the /api/mcp block above and issue #1886.
+            # tests/test_nginx_api_timeouts.py pins the relationship.
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
         }
 
         location @api_starting {

--- a/nginx.conf
+++ b/nginx.conf
@@ -106,8 +106,17 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_connect_timeout 10s;
-            proxy_send_timeout 30s;
-            proxy_read_timeout 60s;
+            # Must OUTWAIT the backend's worst-case in-request board send: a
+            # wait-mode send may drive a transition to its 120s
+            # max_runtime_seconds cap, with cloud note-array boards pacing
+            # frames 15s apart, so minute-plus sends are routine. At the stock
+            # 60s nginx returned 504 to the browser while the backend went on
+            # working (issue #1886). 300s leaves headroom (and already covers
+            # the rework's 240s SEND_WAIT_TIMEOUT); raise both numbers
+            # together — tests/test_nginx_api_timeouts.py fails the build if
+            # they drift apart again.
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
         }
 
         # All API traffic under /api/* → FastAPI backend (path stripped: /api/pages → /pages)
@@ -122,8 +131,11 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_connect_timeout 10s;
-            proxy_send_timeout 30s;
-            proxy_read_timeout 60s;
+            # Must OUTWAIT the backend's worst-case in-request board send —
+            # see the /api/mcp block above and issue #1886.
+            # tests/test_nginx_api_timeouts.py pins the relationship.
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
         }
 
         location @api_starting {

--- a/nginx.https.conf
+++ b/nginx.https.conf
@@ -95,8 +95,17 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_connect_timeout 10s;
-            proxy_send_timeout 30s;
-            proxy_read_timeout 60s;
+            # Must OUTWAIT the backend's worst-case in-request board send: a
+            # wait-mode send may drive a transition to its 120s
+            # max_runtime_seconds cap, with cloud note-array boards pacing
+            # frames 15s apart, so minute-plus sends are routine. At the stock
+            # 60s nginx returned 504 to the browser while the backend went on
+            # working (issue #1886). 300s leaves headroom (and already covers
+            # the rework's 240s SEND_WAIT_TIMEOUT); raise both numbers
+            # together — tests/test_nginx_api_timeouts.py fails the build if
+            # they drift apart again.
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
         }
 
         location /api/ {
@@ -109,8 +118,11 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_connect_timeout 10s;
-            proxy_send_timeout 30s;
-            proxy_read_timeout 60s;
+            # Must OUTWAIT the backend's worst-case in-request board send —
+            # see the /api/mcp block above and issue #1886.
+            # tests/test_nginx_api_timeouts.py pins the relationship.
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
         }
 
         location @api_starting {

--- a/tests/test_nginx_api_timeouts.py
+++ b/tests/test_nginx_api_timeouts.py
@@ -1,0 +1,92 @@
+"""nginx must outwait the backend on the API proxy (issue #1886).
+
+A ``wait``-mode send (``/refresh``, ``/force-refresh``, ``/pages/{id}/send``,
+``PUT /settings/active-page``) runs the board send synchronously inside the
+HTTP request, and that send may drive a transition animation: the runner in
+``src/transitions/runner.py`` honors the manifest cap ``max_runtime_seconds``
+(default 120s), and cloud note-array boards additionally pace every frame —
+including the final snap-to-target — ``NOTE_ARRAY_MIN_SEND_INTERVAL`` (15s)
+apart. Minute-plus sends are therefore routine, not pathological.
+
+nginx's API proxy was on the stock ``proxy_read_timeout 60s`` /
+``proxy_send_timeout 30s``, so any send that legitimately ran longer than a
+minute returned 504 to the browser while the backend went on working for
+up to twice as long: the UI reported failure for a send that succeeded, and
+because /api 502/504s fall through to ``@api_starting``, the real JSON was
+replaced by "Service is starting up".
+
+That drift is the bug, so this test pins the RELATIONSHIP rather than the
+numbers: raising the backend's send budget without raising nginx fails here.
+(On the ``next`` rework branch the budget is ``src.main.SEND_WAIT_TIMEOUT`` =
+240s; the 300s the configs carry already outwaits that too.)
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from src.board_client import NOTE_ARRAY_MIN_SEND_INTERVAL
+from src.plugins.manifest import MANIFEST_SCHEMA
+
+# Worst-case wall clock for one in-request board send: a transition running to
+# its default manifest cap, plus the paced final snap-to-target on a cloud
+# note-array board. Derived from the real constants, not restated, so the
+# assertion moves when the backend budget moves.
+_TRANSITION_RUNTIME_CAP = float(
+    MANIFEST_SCHEMA["properties"]["transition_settings"]["properties"]["max_runtime_seconds"]["default"]
+)
+BACKEND_SEND_BUDGET = _TRANSITION_RUNTIME_CAP + NOTE_ARRAY_MIN_SEND_INTERVAL
+
+CONFIGS = ("nginx.conf", "nginx.https.conf", "nginx-dev.conf")
+API_LOCATIONS = ("/api/mcp", "/api/")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_DURATION = re.compile(r"^(\d+(?:\.\d+)?)(ms|s|m|h)?$")
+_UNIT_SECONDS = {None: 1.0, "ms": 0.001, "s": 1.0, "m": 60.0, "h": 3600.0}
+
+
+def _seconds(value: str) -> float:
+    """Parse an nginx time literal ("300s", "5m", "250ms") into seconds."""
+    match = _DURATION.match(value)
+    assert match, f"unparseable nginx duration: {value!r}"
+    return float(match.group(1)) * _UNIT_SECONDS[match.group(2)]
+
+
+def _location_body(text: str, location: str) -> str:
+    """The brace-matched body of ``location <location> { ... }``."""
+    opener = f"location {location} {{"
+    start = text.index(opener) + len(opener)
+    depth = 1
+    for index in range(start, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:index]
+    raise AssertionError(f"unbalanced braces in `location {location}`")
+
+
+def _directive(body: str, name: str) -> float:
+    match = re.search(rf"^\s*{name}\s+(\S+?);", body, re.MULTILINE)
+    assert match, f"`{name}` is not declared in this location block"
+    return _seconds(match.group(1))
+
+
+@pytest.mark.parametrize("config_name", CONFIGS)
+@pytest.mark.parametrize("location", API_LOCATIONS)
+@pytest.mark.parametrize("directive", ("proxy_read_timeout", "proxy_send_timeout"))
+def test_api_proxy_outwaits_the_backend_send_budget(config_name: str, location: str, directive: str) -> None:
+    body = _location_body((REPO_ROOT / config_name).read_text(encoding="utf-8"), location)
+    value = _directive(body, directive)
+
+    assert value > BACKEND_SEND_BUDGET, (
+        f"{config_name} `location {location}` has {directive} {value:g}s but a wait-mode "
+        f"board send can legitimately run {BACKEND_SEND_BUDGET:g}s (transition "
+        f"max_runtime_seconds default {_TRANSITION_RUNTIME_CAP:g}s + {NOTE_ARRAY_MIN_SEND_INTERVAL:g}s "
+        f"cloud frame pacing for the final snap): the browser gets 504 while the backend is "
+        "still working (issue #1886). Raise the nginx timeout whenever the backend send "
+        "budget rises."
+    )


### PR DESCRIPTION
Closes #1886

`proxy_read_timeout 60s` / `proxy_send_timeout 30s` on the `/api` (and `/api/mcp`) location blocks sit below the backend's legitimate in-request send budget: a paced transition send can run ~135 s today (`max_runtime_seconds` default 120 s + the 15 s note-array frame floor), so the client got a 504 (rewritten to the `@api_starting` JSON) while the backend kept working — and a retry could double-send.

**Repro/verification (TDD):** new `tests/test_nginx_api_timeouts.py` derives the backend budget from the real constants and parses each config's location blocks — 12 failures before the fix (`proxy_read_timeout 60s but a wait-mode board send can legitimately run 135s`), 12 passes after. `nginx -t` clean on `nginx.conf` and `nginx-dev.conf` (`nginx.https.conf` needs the runtime-generated TLS cert, pre-existing).

**Fix:** raise both directives to **300 s** on the `/api` blocks in `nginx.conf`, `nginx.https.conf`, `nginx-dev.conf`.

**Note for merge sequencing:** `next` already carries the same fix (`6fc97e7fc`, same 300 s values, test anchored on its `SEND_WAIT_TIMEOUT = 240`). 300 s was chosen here to match, so the nginx hunks merge value-identically; at rework-merge time take `next`'s test + comments, which supersede these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V79Gu2BSDb1CbFye4ffFx4