### PR TITLE
fix(storage): refuse a store file written by a newer build

### DIFF
--- a/src/settings/service.py
+++ b/src/settings/service.py
@@ -17,7 +17,7 @@ from typing import Literal, Optional, TypeVar, get_args
 
 from pydantic import BaseModel
 
-from src.storage.json_store import JsonStore
+from src.storage.json_store import JsonStore, SchemaTooNewError
 
 _Section = TypeVar("_Section")
 
@@ -1035,6 +1035,20 @@ class SettingsService:
         current_version = data.get("schema_version", 0)
         if not isinstance(current_version, int):
             current_version = 0
+
+        if current_version > CURRENT_SETTINGS_SCHEMA_VERSION:
+            # Written by a newer build. Migrations are forward-only, so
+            # there is nothing to run and no way to read this correctly.
+            # Falling through would read v(N+1) content as vN and the next
+            # save would stamp vN back onto it. This file is the one store
+            # whose schema has actually diverged across a release boundary,
+            # so it is what a downgrading user hits first.
+            raise SchemaTooNewError(
+                label="settings",
+                path=self.settings_file,
+                found=current_version,
+                supported=CURRENT_SETTINGS_SCHEMA_VERSION,
+            )
 
         if current_version >= CURRENT_SETTINGS_SCHEMA_VERSION:
             return

--- a/src/storage/json_store.py
+++ b/src/storage/json_store.py
@@ -61,6 +61,30 @@ logger = logging.getLogger(__name__)
 Migration = tuple[int, Callable[[Any], int]]
 
 
+class SchemaTooNewError(RuntimeError):
+    """A store file was written by a build newer than the one reading it.
+
+    Migrations are forward-only, so there is nothing to run and no way to
+    interpret the file correctly. Raised rather than tolerated because the
+    tolerant behaviour is worse than a crash: the file would be read as if
+    it were this version's format, and the next ``save()`` would stamp this
+    version's number back onto it — destroying the only evidence that the
+    data came from somewhere newer.
+    """
+
+    def __init__(self, *, label: str, path: Path, found: int, supported: int):
+        self.label = label
+        self.path = path
+        self.found = found
+        self.supported = supported
+        super().__init__(
+            f"{label}: {path} is schema_version {found}, but this build only understands "
+            f"up to {supported}. It was written by a newer version of FiestaBoard. "
+            f"Refusing to read it rather than risk misinterpreting the data. "
+            f"Restore a backup taken before the upgrade, or reinstall the newer version."
+        )
+
+
 class JsonStore:
     """Atomic, locked, schema-versioned persistence for one JSON file."""
 
@@ -99,6 +123,10 @@ class JsonStore:
         #: True when the most recent ``load()`` applied migrations; the caller
         #: should persist (``mutate()`` does so automatically).
         self.migrated = False
+        #: Set when a load refused a file from a newer build. Latches so a
+        #: caller that swallowed the load error cannot then overwrite the
+        #: file it failed to understand.
+        self._refused_future_schema = False
 
     @property
     def path(self) -> Path:
@@ -134,6 +162,7 @@ class JsonStore:
             # builtins.open to inject I/O errors.
             with open(self._path) as f:  # noqa: PTH123
                 data = json.load(f)
+            self._reject_future_schema(data)
             if self._migrations_pending(data):
                 self._backup_before_migration(data)
                 self._run_migrations(data)
@@ -151,6 +180,15 @@ class JsonStore:
         store's own view never depends on whether the disk needed touching.
         """
         with self._lock:
+            if self._refused_future_schema:
+                # The load refused this file; writing now would stamp our
+                # lower schema_version onto newer content.
+                raise SchemaTooNewError(
+                    label=self._label,
+                    path=self._path,
+                    found=self._file_version(self._peek_disk_version()),
+                    supported=self._version,
+                )
             if self._version and isinstance(data, dict):
                 data["schema_version"] = self._version
             write_json_atomic(self._path, data, if_changed=True)
@@ -182,6 +220,30 @@ class JsonStore:
             return result
 
     # ── schema migrations ──────────────────────────────────────────────
+
+    def _reject_future_schema(self, data: Any) -> None:
+        """Refuse a file stamped newer than this build understands."""
+        if self._version <= 0 or not isinstance(data, dict):
+            return
+        found = self._file_version(data)
+        if found <= self._version:
+            return
+        self._refused_future_schema = True
+        raise SchemaTooNewError(
+            label=self._label,
+            path=self._path,
+            found=found,
+            supported=self._version,
+        )
+
+    def _peek_disk_version(self) -> dict:
+        """Re-read just the version stamp, for the refusal message."""
+        try:
+            with open(self._path) as f:  # noqa: PTH123
+                data = json.load(f)
+            return data if isinstance(data, dict) else {}
+        except Exception:
+            return {}
 
     def _migrations_pending(self, data: Any) -> bool:
         return self._version > 0 and isinstance(data, dict) and self._file_version(data) < self._version

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -1004,3 +1004,72 @@ class TestLocalArrayTileMasking:
         tiles = {(t["row"], t["col"]): t for t in settings_service._board.boards[0]["tiles"]}
         assert tiles[(0, 0)]["host"] == "10.0.0.77"
         assert tiles[(0, 0)]["local_api_key"] == "secret-a"
+
+
+class TestSettingsRefusesAFutureSchema:
+    """settings.json written by a NEWER build must not be read as ours.
+
+    ``SettingsService`` does not load through ``JsonStore.load()`` — it
+    pre-reads the file itself in ``_migrate_if_needed`` (an artifact of the
+    migration machinery predating the storage kernel), so the kernel's
+    :class:`SchemaTooNewError` guard does not cover it. That matters more
+    here than anywhere else: ``settings.json`` is the one store whose schema
+    has actually diverged across a release boundary (v2 on the stable line,
+    v3 on ``next``), so it is the file a downgrading user is guaranteed to
+    hit.
+
+    Without this the old build reads v3 content as v2 and the next save
+    stamps ``schema_version: 2`` back onto it.
+    """
+
+    def _seed(self, tmp_path, version_offset):
+        import json
+
+        from src.settings.service import CURRENT_SETTINGS_SCHEMA_VERSION
+
+        path = tmp_path / "settings.json"
+        payload = {
+            "schema_version": CURRENT_SETTINGS_SCHEMA_VERSION + version_offset,
+            "general": {"instance_name": "From the future"},
+        }
+        path.write_text(json.dumps(payload))
+        return path, json.dumps(payload)
+
+    def test_a_newer_settings_file_is_refused(self, tmp_path, monkeypatch):
+        import pytest
+
+        from src.storage.json_store import SchemaTooNewError
+
+        path, _ = self._seed(tmp_path, +1)
+        monkeypatch.setenv("FIESTABOARD_DATA_DIR", str(tmp_path))
+
+        from src.settings.service import SettingsService
+
+        with pytest.raises(SchemaTooNewError) as excinfo:
+            SettingsService(settings_file=path)
+
+        assert "settings" in str(excinfo.value).lower()
+
+    def test_the_refused_settings_file_is_not_rewritten(self, tmp_path, monkeypatch):
+        import contextlib
+
+        from src.storage.json_store import SchemaTooNewError
+
+        path, original = self._seed(tmp_path, +1)
+        monkeypatch.setenv("FIESTABOARD_DATA_DIR", str(tmp_path))
+
+        from src.settings.service import SettingsService
+
+        with contextlib.suppress(SchemaTooNewError):
+            SettingsService(settings_file=path)
+
+        assert path.read_text() == original
+
+    def test_a_current_settings_file_still_loads(self, tmp_path, monkeypatch):
+        """The guard fires on strictly-newer only."""
+        path, _ = self._seed(tmp_path, 0)
+        monkeypatch.setenv("FIESTABOARD_DATA_DIR", str(tmp_path))
+
+        from src.settings.service import SettingsService
+
+        SettingsService(settings_file=path)  # must not raise

--- a/tests/test_storage_kernel.py
+++ b/tests/test_storage_kernel.py
@@ -208,6 +208,86 @@ class TestJsonStoreMigrations:
         assert path.read_text() == original
 
 
+class TestJsonStoreRefusesAFutureSchema:
+    """A file written by a NEWER build must not be read as if it were ours.
+
+    Downgrading is now a supported path (the beta release channel), and a
+    downgrade lands an older binary on a data directory a newer one already
+    migrated. Before this guard every store took the same shape:
+
+        if file_version >= CURRENT_SCHEMA_VERSION: skip migrations
+
+    so a v3 file loaded into a v2 build fell straight through and was read
+    as v2 — and the first ``save()`` then stamped ``schema_version: 2`` back
+    onto v3-shaped content, destroying the evidence. Silent misreading, then
+    silent corruption.
+
+    Loud refusal is the contract: ``load()`` already documents that read
+    errors propagate and the domain store decides whether a broken file is
+    fatal.
+    """
+
+    def _store(self, path, version=2):
+        from src.storage.json_store import JsonStore
+
+        return JsonStore(path, current_schema_version=version, label="widgets")
+
+    def test_load_refuses_a_file_from_a_newer_build(self, tmp_path):
+        from src.storage.json_store import SchemaTooNewError
+
+        path = tmp_path / "x.json"
+        path.write_text(json.dumps({"schema_version": 3, "items": ["from the future"]}))
+
+        with pytest.raises(SchemaTooNewError) as excinfo:
+            self._store(path, version=2).load()
+
+        message = str(excinfo.value)
+        assert "widgets" in message, "the error must name which store refused"
+        assert "3" in message and "2" in message, "the error must name both versions"
+
+    def test_the_refused_file_is_left_exactly_as_it_was(self, tmp_path):
+        """The newer file is the user's only copy of that data."""
+        from src.storage.json_store import SchemaTooNewError
+
+        path = tmp_path / "x.json"
+        original = json.dumps({"schema_version": 3, "items": ["from the future"]})
+        path.write_text(original)
+
+        with contextlib.suppress(SchemaTooNewError):
+            self._store(path, version=2).load()
+
+        assert path.read_text() == original
+        assert not list(tmp_path.glob("*_backup")), "a refused load must not take a migration backup"
+
+    def test_a_refused_store_will_not_overwrite_the_newer_file(self, tmp_path):
+        """The dangerous move is the SAVE after the failed load, not the load."""
+        from src.storage.json_store import SchemaTooNewError
+
+        path = tmp_path / "x.json"
+        original = json.dumps({"schema_version": 3, "items": ["from the future"]})
+        path.write_text(original)
+        store = self._store(path, version=2)
+
+        with contextlib.suppress(SchemaTooNewError):
+            store.load()
+        with pytest.raises(SchemaTooNewError):
+            store.save({"items": []})
+
+        assert path.read_text() == original
+
+    def test_an_equal_version_still_loads(self, tmp_path):
+        """The guard must fire on strictly-newer only, never on equal."""
+        path = tmp_path / "x.json"
+        path.write_text(json.dumps({"schema_version": 2, "items": ["ours"]}))
+        assert self._store(path, version=2).load()["items"] == ["ours"]
+
+    def test_an_unversioned_store_reads_anything(self, tmp_path):
+        """current_schema_version=0 disables versioning entirely."""
+        path = tmp_path / "x.json"
+        path.write_text(json.dumps({"schema_version": 99, "items": ["ok"]}))
+        assert self._store(path, version=0).load()["items"] == ["ok"]
+
+
 class TestJsonStoreMutate:
     def test_mutate_is_a_locked_read_modify_write(self, tmp_path):
         from src.storage.json_store import JsonStore


### PR DESCRIPTION
Layer 5 of the beta-channel plan, landed first because it is small, independently correct, and it converts the worst downgrade failure mode from silent corruption into a clear error *before* any user can downgrade.

## The bug

Every store took the same shape:

```python
if file_version >= CURRENT_SCHEMA_VERSION:   # skip migrations
```

Migrations are forward-only, so a file stamped **newer** than the running build fell straight through that check and was read as if it were this version's format. The next `save()` then stamped this version's number back onto it, destroying the only evidence the data came from somewhere newer.

Silent misreading, then silent corruption, with no error anywhere.

Nothing exercised it while updates only moved forward. The beta release channel makes downgrading a supported path — and `settings.json` has **already** diverged across a release boundary (v2 on the stable line, v3 on `next`), so it is precisely what a downgrading user hits first.

## The fix

`JsonStore.load()` raises `SchemaTooNewError`, naming the store, both versions, and what to do:

```
settings: /data/settings.json is schema_version 4, but this build only
understands up to 3. It was written by a newer version of FiestaBoard.
Refusing to read it rather than risk misinterpreting the data. Restore a
backup taken before the upgrade, or reinstall the newer version.
```

`save()` refuses too, latched on the failed load — **the dangerous move is the write after a caller swallowed the read error**, not the read.

### Why `SettingsService` needed it separately

`SettingsService` does not load through `JsonStore.load()`. It pre-reads the file itself in `_migrate_if_needed` (`src/settings/service.py:1024-1039`), an artifact of the migration machinery predating the storage kernel. The kernel guard alone would have left the one genuinely-diverged store unprotected — a false sense of safety, which is worse than none.

Coverage after this change:

| store | path | guarded |
|---|---|---|
| pages, panels, schedules | `JsonStore.load()` | kernel guard |
| collections | `JsonStore.load()` | kernel guard |
| collections (legacy `carousels.json`) | own read | n/a — a legacy import cannot be from the future |
| **settings** | **own pre-read** | **its own guard, added here** |

## Loud, but not fatal

Verified end to end against a seeded v(N+1) data dir: the error is logged in full **and the API still serves** (`GET /health` → 200). A downgraded user reaches the UI to fix it rather than facing a container restart loop. The refused file is left byte-identical on disk.

## Proof

**Fail-first, settings half, against the unmodified tree:**

```
Failed: DID NOT RAISE SchemaTooNewError
```

**Mutation-verified, kernel half.** The first kernel failures were `ImportError`, which proves nothing about behaviour — so I re-ran with the class importable and only the enforcement removed:

| mutation | result |
|---|---|
| drop `_reject_future_schema()` call, keep class | `test_load_refuses_a_file_from_a_newer_build` and `test_a_refused_store_will_not_overwrite_the_newer_file` fail |

Two of the eight tests pass on the unmodified tree by design — `test_an_equal_version_still_loads` and `test_an_unversioned_store_reads_anything` are regression guards ensuring the check fires on *strictly* newer only.

**Suite:** `6992 passed, 1 skipped, 0 failed` against a pristine `git archive` export (6984 baseline + 8 new). `ruff==0.16.5` clean, 413 files already formatted.

## Scope

No route, response shape, schema, or storage format changes. This only adds a refusal where there was previously a silent misread. Follow-up layers (beta image publishing, channel-aware discovery, tag-targeted install, in-app join/leave) are tracked in the plan and land separately.
