### PR TITLE
feat(release): publish a 9.0.0-beta image from next on every merge

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -65,27 +65,56 @@ jobs:
 
       - name: Compute the beta version
         id: version
+        env:
+          # The stable release `next` is heading for. Declared, not derived.
+          #
+          # 9.0.0 because `next` is a breaking-change branch: MCP tool errors
+          # became protocol `isError` (#1874), GET /plugins dropped previews to
+          # opt-in, and GET /logs `total` became a lower bound rather than an
+          # exact count. Those are real contract breaks for existing clients.
+          #
+          # It is declared rather than derived for two reasons:
+          #
+          #   1. Deriving it would get it WRONG. The repo infers bump type from
+          #      conventional-commit titles (pr-label.yml:54-57 looks for `!:`
+          #      or a BREAKING CHANGE footer). Not one PR merged into `next`
+          #      carries a major label, because the breaking changes landed
+          #      under plain `feat:`/`refactor:` titles. The history undercounts
+          #      what actually happened to the API.
+          #   2. Deriving from package.json drifts. `next` tracks `main`, so a
+          #      "bump the minor" rule would silently retarget the moment main
+          #      shipped — and any beta already published under the old number
+          #      would then sort BELOW the stable release that took it.
+          #
+          # Change this when `next` starts aiming at a different release.
+          BETA_TARGET_VERSION: "9.0.0"
         run: |
           set -euo pipefail
-          # The stable version currently on this trunk. `next` tracks `main`,
-          # so this is the release a beta is running *ahead of*.
-          STABLE=$(node -p "require('./package.json').version")
-          if ! printf '%s' "$STABLE" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::package.json version '$STABLE' is not X.Y.Z — refusing to derive a beta from it"
+          if ! printf '%s' "$BETA_TARGET_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::BETA_TARGET_VERSION '$BETA_TARGET_VERSION' is not X.Y.Z"
             exit 1
           fi
-          MAJOR=${STABLE%%.*}
-          MINOR=$(printf '%s' "$STABLE" | cut -d. -f2)
-          # A beta is the next MINOR: the smallest bump that is unambiguously
-          # ahead of every patch `main` can still ship while the beta is out.
-          # 8.35.5 -> 8.36.0-beta.N.
-          NEXT_MINOR=$((MINOR + 1))
-          # run_number is monotonic per workflow, so betas order correctly —
-          # semver compares numeric prerelease identifiers numerically, so
-          # beta.9 < beta.10 (a string sort would get that backwards).
-          VERSION="${MAJOR}.${NEXT_MINOR}.0-beta.${{ github.run_number }}"
+
+          STABLE=$(node -p "require('./package.json').version")
+
+          # Guard the drift case explicitly rather than trusting the target to
+          # stay ahead: if `main` ever ships at or past the target, every beta
+          # from here would sort at or below a real release, and the update
+          # checker would happily offer a "newer" beta that is actually older.
+          # Fail loudly at build time instead of publishing that.
+          NEWEST=$(printf '%s\n%s\n' "$STABLE" "$BETA_TARGET_VERSION" | sort -V | tail -1)
+          if [ "$NEWEST" != "$BETA_TARGET_VERSION" ] || [ "$STABLE" = "$BETA_TARGET_VERSION" ]; then
+            echo "::error::stable is $STABLE but betas target $BETA_TARGET_VERSION — main has caught up. Raise BETA_TARGET_VERSION in .github/workflows/release-beta.yml."
+            exit 1
+          fi
+
+          # run_number is monotonic per workflow, and semver compares numeric
+          # prerelease identifiers numerically, so beta.9 < beta.10 (a plain
+          # string sort would get that backwards).
+          VERSION="${BETA_TARGET_VERSION}-beta.${{ github.run_number }}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Stable on this trunk: $STABLE"
+          echo "Betas target:         $BETA_TARGET_VERSION"
           echo "Publishing beta:      $VERSION"
 
   build:

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -1,0 +1,264 @@
+name: "Release: Publish Beta Image"
+
+# Publishes a beta image from `next` on every merge.
+#
+# Deliberately a SEPARATE workflow from release.yml rather than a branch
+# condition inside it. Three reasons, each load-bearing:
+#
+#   1. release.yml's `revert-on-failure` job force-pushes `main`
+#      (release.yml:673-767). A shared workflow that ever ran with
+#      `github.ref` pointing at `next` is one expression away from
+#      force-pushing the wrong branch. Separation makes that impossible
+#      rather than unlikely.
+#   2. release.yml commits a version bump back to the branch. Betas must
+#      NOT do that: `scripts/version-sync.js:33` hard-matches
+#      /^(\d+)\.(\d+)\.(\d+)$/ and throws on a prerelease string, so a
+#      committed `-beta.N` would break the next *stable* release. The beta
+#      version is computed here and passed as a build-arg only.
+#   3. release.yml dispatches to the docs site (release.yml:639-652), which
+#      would snapshot fiestaboard.app to a beta tag.
+#
+# What this does NOT do, on purpose: no version commit, no docs dispatch, no
+# `latest` tag, no revert-on-failure, and no Pi image. `build-fiestapi.yml`
+# keys its `workflow_run` trigger on the literal name "Release: Publish
+# Image", so this workflow's different name means betas never kick off the
+# 60-minute Pi build; it also already filters prereleases out of its version
+# lookup (build-fiestapi.yml:118-120).
+
+on:
+  push:
+    branches: [next]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - ".github/**"
+      - ".devcontainer/**"
+      - ".cursor*"
+      - "images/**"
+      - "LICENSE"
+      - "fiesta-icon.png"
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why you are cutting this beta by hand"
+        required: false
+        default: "manual"
+
+# Betas are disposable but their pushes are not: cancelling mid-`imagetools
+# create` can leave a half-written manifest list. Queue instead of cancel,
+# matching release.yml.
+concurrency:
+  group: release-beta-publish
+  cancel-in-progress: false
+
+jobs:
+  version:
+    name: Compute beta version
+    # Never publish from a fork.
+    if: github.repository == 'Fiestaboard/FiestaBoard'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Compute the beta version
+        id: version
+        run: |
+          set -euo pipefail
+          # The stable version currently on this trunk. `next` tracks `main`,
+          # so this is the release a beta is running *ahead of*.
+          STABLE=$(node -p "require('./package.json').version")
+          if ! printf '%s' "$STABLE" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::package.json version '$STABLE' is not X.Y.Z — refusing to derive a beta from it"
+            exit 1
+          fi
+          MAJOR=${STABLE%%.*}
+          MINOR=$(printf '%s' "$STABLE" | cut -d. -f2)
+          # A beta is the next MINOR: the smallest bump that is unambiguously
+          # ahead of every patch `main` can still ship while the beta is out.
+          # 8.35.5 -> 8.36.0-beta.N.
+          NEXT_MINOR=$((MINOR + 1))
+          # run_number is monotonic per workflow, so betas order correctly —
+          # semver compares numeric prerelease identifiers numerically, so
+          # beta.9 < beta.10 (a string sort would get that backwards).
+          VERSION="${MAJOR}.${NEXT_MINOR}.0-beta.${{ github.run_number }}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Stable on this trunk: $STABLE"
+          echo "Publishing beta:      $VERSION"
+
+  build:
+    name: Build (${{ matrix.platform }})
+    needs: [version]
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Native runners per arch, same as release.yml. QEMU would be the
+      # simpler YAML, but this image builds the web UI, and emulated arm64
+      # turns a ~5-minute build into the better part of an hour — unworkable
+      # for something that runs on every merge to `next`.
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          # Pin the production stage — a target-less build takes whatever
+          # stage is last in the Dockerfile, which once shipped the dev
+          # supervisor config to users (#1377).
+          target: runtime
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            VERSION=${{ needs.version.outputs.version }}
+          cache-from: type=gha,scope=beta-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=beta-${{ matrix.platform }}
+          outputs: type=image,name=fiestaboard/fiestaboard,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${digest#sha256:}"
+        env:
+          digest: ${{ steps.build.outputs.digest }}
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: beta-digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Tag and publish beta
+    needs: [version, build]
+    runs-on: ubuntu-latest
+    # Explicit rather than inherited: this job creates a tag and a release.
+    # If the repo's default GITHUB_TOKEN permissions are ever tightened to
+    # read-only, an inherited scope would fail here at publish time — after
+    # the image is already on Docker Hub, leaving a tagless beta.
+    permissions:
+      contents: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v8
+        with:
+          path: /tmp/digests
+          pattern: beta-digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Two tags and deliberately NOT `latest`: `:beta` is the moving tag a
+      # tester follows, `:X.Y.Z-beta.N` is the immutable one a bug report can
+      # name.
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            -t fiestaboard/fiestaboard:beta \
+            -t fiestaboard/fiestaboard:${{ needs.version.outputs.version }} \
+            $(printf 'fiestaboard/fiestaboard@sha256:%s ' *)
+
+      - name: Verify the published manifest carries both architectures
+        run: |
+          set -euo pipefail
+          RAW=$(docker buildx imagetools inspect \
+            "fiestaboard/fiestaboard:${{ needs.version.outputs.version }}" --raw)
+          for arch in amd64 arm64; do
+            echo "$RAW" | jq -e --arg a "$arch" \
+              '.manifests[] | select(.platform.architecture == $a and .platform.os == "linux")' >/dev/null \
+              || { echo "::error::published beta is missing linux/$arch"; exit 1; }
+          done
+          echo "beta manifest carries linux/amd64 and linux/arm64"
+
+      - name: Create the prerelease
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const version = '${{ steps.version.outputs.version }}';
+            const tag = `v${version}`;
+            const sha = context.sha;
+
+            // The tag is what the update checker's GitHub source resolves a
+            // beta by, so it has to exist before the release references it.
+            try {
+              await github.rest.git.createRef({
+                ...context.repo, ref: `refs/tags/${tag}`, sha,
+              });
+            } catch (e) {
+              if (e.status !== 422) throw e;   // 422 = already exists
+              core.info(`tag ${tag} already exists, reusing it`);
+            }
+
+            const body = [
+              '> **This is a beta build from `next`.** It is not a stable release.',
+              '> Expect breaking changes, and read the notes below before installing.',
+              '',
+              '## Install',
+              '',
+              '```bash',
+              '# point your compose file at the beta tag',
+              'docker compose -f docker-compose.hub.yml pull && docker compose -f docker-compose.hub.yml up -d',
+              '```',
+              '',
+              `Pinned: \`docker pull fiestaboard/fiestaboard:${version}\``,
+              `Moving: \`docker pull fiestaboard/fiestaboard:beta\``,
+              '',
+              '## Going back to stable',
+              '',
+              'Set the tag back to `:latest` and pull again. Note that `next` may',
+              'have migrated your data to a schema stable does not understand — the',
+              'app refuses to read such a file rather than misinterpreting it, so',
+              'restore a backup taken before you joined the beta.',
+              '',
+              `Built from \`${sha.substring(0, 9)}\`.`,
+            ].join('\n');
+
+            await github.rest.repos.createRelease({
+              ...context.repo,
+              tag_name: tag,
+              name: `Beta ${version}`,
+              body,
+              draft: false,
+              // Both matter. `prerelease` is what keeps this out of
+              // /releases/latest, which is the endpoint stable installs poll —
+              // so a stable user can never be offered a beta. `make_latest`
+              // false keeps release.yml's pinned "latest" pointing at the
+              // newest STABLE release (release.yml:624-627).
+              prerelease: true,
+              make_latest: 'false',
+            });
+
+            core.notice(`Published beta ${version} (${tag})`);

--- a/tests/test_beta_release_workflow.py
+++ b/tests/test_beta_release_workflow.py
@@ -1,0 +1,134 @@
+"""The beta channel must not be able to masquerade as stable (#1955 follow-on).
+
+`release-beta.yml` publishes from `next` on every merge. Four of its
+properties are what keep a beta from reaching someone who never asked for
+one, and every single one is a one-line edit away from silently inverting:
+
+* it must never push `:latest` — that tag *is* the stable channel, and the
+  Pi image and `docker-compose.hub.yml` both follow it unconditionally;
+* its GitHub release must be a **prerelease**, because `/releases/latest`
+  (what stable installs poll, `update_service.py:143-159`) is defined as
+  excluding prereleases. That exclusion is the entire reason a stable user
+  cannot be offered a beta;
+* its workflow `name:` must differ from the stable one, because
+  `build-fiestapi.yml` keys a `workflow_run` trigger on the literal string
+  "Release: Publish Image" — matching it would fire a 60-minute Pi build on
+  every beta;
+* it must never commit a version bump, because `scripts/version-sync.js`
+  rejects any non-`X.Y.Z` string, so a committed `-beta.N` would break the
+  next *stable* release.
+
+These are asserted against the workflow files rather than a live run,
+because a live run publishes to Docker Hub — there is no safe way to find
+out empirically that the guard broke.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOWS = Path(__file__).resolve().parent.parent / ".github" / "workflows"
+BETA = WORKFLOWS / "release-beta.yml"
+STABLE = WORKFLOWS / "release.yml"
+PI = WORKFLOWS / "build-fiestapi.yml"
+
+
+def _load(path: Path) -> dict:
+    # PyYAML parses the `on:` key as the boolean True (YAML 1.1 truthiness).
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _triggers(doc: dict) -> dict:
+    return doc.get(True, doc.get("on", {}))
+
+
+@pytest.fixture(scope="module")
+def beta_text() -> str:
+    return BETA.read_text(encoding="utf-8")
+
+
+def test_the_beta_workflow_never_pushes_the_latest_tag(beta_text):
+    """`:latest` is the stable channel. The Pi image follows it unconditionally."""
+    offenders = [
+        line.strip()
+        for line in beta_text.splitlines()
+        if "fiestaboard/fiestaboard:latest" in line and not line.strip().startswith("#")
+    ]
+    assert not offenders, (
+        "release-beta.yml references the stable `:latest` tag outside a comment: "
+        f"{offenders}. Every Pi and every default docker-compose install follows "
+        "that tag, so publishing a beta to it ships the beta to everyone."
+    )
+
+
+def test_the_beta_release_is_marked_prerelease(beta_text):
+    """`/releases/latest` excludes prereleases — that is what protects stable users."""
+    assert "prerelease: true" in beta_text, (
+        "release-beta.yml must create its GitHub release with prerelease: true. "
+        "Without it the beta becomes /releases/latest, which is the endpoint "
+        "every stable install polls for updates."
+    )
+    assert "make_latest: 'false'" in beta_text or 'make_latest: "false"' in beta_text, (
+        "release-beta.yml must set make_latest false so the stable release keeps "
+        "the 'latest' pointer release.yml deliberately pins."
+    )
+
+
+def test_the_beta_workflow_name_cannot_trigger_the_pi_build():
+    """`build-fiestapi.yml` keys a workflow_run trigger on the stable name."""
+    beta_name = _load(BETA)["name"]
+    stable_name = _load(STABLE)["name"]
+    assert beta_name != stable_name, "beta and stable workflows share a name"
+
+    pi_triggers = _triggers(_load(PI))
+    watched = pi_triggers.get("workflow_run", {}).get("workflows", [])
+    assert stable_name in watched, (
+        "build-fiestapi.yml no longer watches the stable release workflow by name; "
+        "this test's premise needs rechecking."
+    )
+    assert beta_name not in watched, (
+        f"build-fiestapi.yml watches {beta_name!r}, so every beta would kick off the 60-minute Pi image build."
+    )
+
+
+def test_the_beta_workflow_only_publishes_from_next():
+    triggers = _triggers(_load(BETA))
+    assert triggers["push"]["branches"] == ["next"], (
+        "release-beta.yml must publish only from `next`; it builds and pushes to Docker Hub with no review gate."
+    )
+
+
+def test_the_beta_workflow_never_commits_a_version_bump(beta_text):
+    """`version-sync.js` throws on a non-X.Y.Z version, breaking stable releases."""
+    # Comments are excluded: this file's own header *explains* why it must not
+    # run version-sync.js, and a substring match would flag that prose.
+    executable = [line for line in beta_text.splitlines() if not line.strip().startswith("#")]
+    for forbidden in ("version-sync.js", "git commit", "git push"):
+        offenders = [line.strip() for line in executable if forbidden in line]
+        assert not offenders, (
+            f"release-beta.yml runs {forbidden!r}: {offenders}. The beta version is "
+            "a build-arg only — committing it would put a `-beta.N` string in "
+            "package.json, which scripts/version-sync.js rejects on the next "
+            "stable release."
+        )
+
+
+def test_the_beta_workflow_does_not_dispatch_to_the_docs_site(beta_text):
+    """release.yml's dispatch snapshots fiestaboard.app to the released tag."""
+    assert "fiestaboard.github.io" not in beta_text, (
+        "release-beta.yml dispatches to the docs site, which would snapshot fiestaboard.app to a beta tag."
+    )
+
+
+def test_the_stable_workflow_does_not_publish_a_beta_tag():
+    """The guard in the other direction: stable must not touch `:beta`."""
+    stable_text = STABLE.read_text(encoding="utf-8")
+    offenders = [
+        line.strip()
+        for line in stable_text.splitlines()
+        if "fiestaboard/fiestaboard:beta" in line and not line.strip().startswith("#")
+    ]
+    assert not offenders, f"release.yml publishes to the beta tag: {offenders}"

--- a/tests/test_beta_release_workflow.py
+++ b/tests/test_beta_release_workflow.py
@@ -132,3 +132,36 @@ def test_the_stable_workflow_does_not_publish_a_beta_tag():
         if "fiestaboard/fiestaboard:beta" in line and not line.strip().startswith("#")
     ]
     assert not offenders, f"release.yml publishes to the beta tag: {offenders}"
+
+
+def test_the_declared_beta_target_is_ahead_of_the_stable_version():
+    """Betas must sort above the release they follow and below the one they precede.
+
+    The target is declared in the workflow rather than derived, because
+    deriving it gets it wrong in both available ways: the repo infers bump
+    type from conventional-commit titles and no PR merged into `next` carries
+    a major label (the breaking changes landed under plain `feat:`/`refactor:`
+    titles), and deriving from package.json drifts the moment `main` ships —
+    retroactively putting already-published betas *below* a real release.
+
+    Declaring it moves the risk to one place, and this test plus the
+    workflow's own runtime guard watch that place.
+    """
+    import json
+    import re
+
+    beta_text = BETA.read_text(encoding="utf-8")
+    match = re.search(r'BETA_TARGET_VERSION:\s*"([^"]+)"', beta_text)
+    assert match, "release-beta.yml no longer declares BETA_TARGET_VERSION"
+    target = match.group(1)
+    assert re.fullmatch(r"\d+\.\d+\.\d+", target), f"BETA_TARGET_VERSION {target!r} is not X.Y.Z"
+
+    stable = json.loads((BETA.parent.parent.parent / "package.json").read_text())["version"]
+    as_tuple = lambda v: tuple(int(p) for p in v.split("."))  # noqa: E731
+
+    assert as_tuple(target) > as_tuple(stable), (
+        f"betas target {target} but stable is already {stable}. Every beta published "
+        f"from here would sort at or below a real release, and the update checker "
+        f"would offer a 'newer' beta that is actually older. Raise "
+        f"BETA_TARGET_VERSION in .github/workflows/release-beta.yml."
+    )


### PR DESCRIPTION
Layer 1 of the beta channel. `next` gets its own publishing lane so the rework can reach real users before it reaches `main`.

## What lands on Docker Hub

| tag | meaning |
|---|---|
| `fiestaboard/fiestaboard:beta` | moving — what a tester follows |
| `fiestaboard/fiestaboard:9.0.0-beta.N` | immutable — what a bug report can name |

Never `:latest`. Every Pi and every default docker-compose install follows that tag unconditionally, so publishing a beta there would ship it to everyone.

## Why a separate workflow, not a branch condition in release.yml

Three reasons, each load-bearing:

1. release.yml's `revert-on-failure` job **force-pushes `main`**. A shared workflow that ever ran with `github.ref` on `next` is one expression away from force-pushing the wrong branch. Separation makes that impossible rather than unlikely.
2. release.yml **commits a version bump**. Betas must not: `scripts/version-sync.js:33` hard-matches `/^(\d+)\.(\d+)\.(\d+)$/` and throws on a prerelease string, so a committed `-beta.N` would break the next *stable* release. The beta version is a build-arg only; `package.json` is never touched.
3. release.yml **dispatches to the docs site**, which would snapshot fiestaboard.app to a beta tag.

## How stable users stay protected

`prerelease: true` is the entire mechanism. `/releases/latest` is defined as excluding prereleases, and that is the endpoint stable installs poll (`update_service.py:143-159`). `make_latest: false` keeps release.yml's deliberately-pinned "latest" on the newest stable.

Betas also never trigger the Pi build: `build-fiestapi.yml` keys its `workflow_run` on the literal name "Release: Publish Image", and this workflow's name differs.

## Notes

- Version is `9.0.0-beta.<run_number>`. **Declared, not derived** — `next` is a breaking-change branch (MCP `isError`, `/plugins` previews opt-in, `/logs` `total` now a lower bound), so it targets a major. Deriving would have said *minor* in both available ways: no PR merged into `next` carries a `major` label (the breaks landed under plain `feat:`/`refactor:` titles), and deriving from `package.json` drifts the moment `main` ships — retroactively sorting published betas *below* the real release that took their number. A build-time guard fails the run if `main` ever reaches the target. `run_number` is monotonic and semver compares numeric prerelease identifiers *numerically*, so `beta.9` sorts before `beta.10` (a string sort would get that backwards).
- Native arm64 runners, not QEMU. This image builds the web UI; emulated arm64 turns a ~5-minute build into the better part of an hour, which is unworkable on every merge.
- `permissions: contents: write` is explicit on the publish job so a tightened default token can't fail *after* the image is already pushed, leaving a tagless beta.

## Proof

`tests/test_beta_release_workflow.py` pins the properties that keep a beta away from someone who never asked for one. All mutation-verified:

| mutation | caught by |
|---|---|
| `:beta` → `:latest` | `test_..._never_pushes_the_latest_tag` |
| `prerelease: true` → `false` | `test_..._is_marked_prerelease` |
| `branches: [next]` → `+main` | `test_..._only_publishes_from_next` |

`act -l` stages `version → build → publish` correctly. **7020 passed, 1 skipped** against a pristine export; `ruff==0.16.5` clean.

## ⚠️ Merging this publishes the first beta immediately

The push that merges this PR touches `tests/` (not in `paths-ignore`), so the workflow fires on merge and `fiestaboard/fiestaboard:beta` + `:9.0.0-beta.1` appear on Docker Hub. That first beta contains the **entire rework**, including three breaking changes (MCP `isError`, `/plugins` previews opt-in, `/logs` `total` now a lower bound). #1885's client-migration note should land before this is announced anywhere.
